### PR TITLE
feat(readiness): add M1 P0 gate helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ node_modules/
 .codex/
 
 # Runtime workspace
-workspace/
+/workspace/
 
 # Large data
 *.dat

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ node_modules/
 .agents/
 .codex/
 
+# Runtime workspace
+workspace/
+
 # Large data
 *.dat
 *.nc

--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -56,3 +56,67 @@
 
 - [GRILL-1..3] 已全部定案（2026-07-03 M1 grill，记录见 [ADR-0002 开放项处置节](../../../docs/adr/0002-mvp-reality-anchoring.md)）：不 fork + submodule 引用；工具面照准草案；`GLM_API_KEY`（Config_Secrets §4 已补行，账本例外批次 4）。
 - zero 包引用技术形态（workspace 纳入 vs `file:` 依赖 vs 运行时入口加载）：**唯一存留开放项**，spike 条 1 实现时实测确认并回写 Decision 3。
+
+## Subagent Workflow Fixture — Issue #12
+
+Fixture level: expanded; repair intensity: high. Project profile: SHUD-Harness.
+
+Expanded-trigger rationale:
+- Core triggers: deterministic script entry, schema/field/format contract (`readiness_gate` YAML), file output/path/overwrite under `workspace/readiness/`, legacy/submodule compatibility, and persisted/shared-state gating for all downstream M1 coding issues.
+- Profile triggers: `readiness`, `workspace`, `idempotency`, `lock`, `SHUD`, `rSHUD`, `AutoSHUD`, `Zero`.
+
+Change surface:
+- Optional deterministic readiness helper under `scripts/readiness/`.
+- Runtime-only output `workspace/readiness/readiness_gate_v0_8_1.yaml` (must not be committed).
+- Contract reads across `.gitmodules`, submodule checkouts, `docs/00_INDEX/CANONICAL_CONTRACTS.md`, `docs/03_SPEC/*`, and `docs/04_IMPLEMENTATION/*`.
+
+Must preserve:
+- No edits to frozen docs, implementation packages, or submodule source.
+- `workspace/` remains runtime state outside tracked source.
+- A blocking readiness conflict must stop downstream coding instead of being hidden as pass.
+
+Must add/change:
+- A reproducible way to execute and record the P0 nine-gate readiness result.
+- Evidence that every gate has an independent result matching `MVP_Implementation_Readiness_Checklist.md`.
+
+Risk packs considered:
+- Public API / CLI / script entry: selected - helper script is a user-invoked deterministic entrypoint.
+- Config / project setup: selected - `.gitmodules`, submodule state, package/workspace readiness, and local environment are gate inputs.
+- File IO / path safety / overwrite: selected - helper writes runtime YAML and must not write outside `workspace/readiness/`.
+- Schema / columns / units / field names: selected - YAML keys and decision values are part of the readiness contract.
+- Auth / permissions / secrets: not selected - no credential handling; secret checks are later GLM/observability work.
+- Concurrency / shared state / ordering: selected - #12 unlocks or blocks all downstream M1 coding issues.
+- Resource limits / large input / discovery: not selected - reads are bounded known files and submodule metadata.
+- Legacy compatibility / examples: selected - four submodules must remain readable and unchanged.
+- Error handling / rollback / partial outputs: selected - failed gates must produce stable `block` or `pass_with_notes` without partial misleading signoff.
+- Release / packaging / dependency compatibility: not selected - packageManager/lockfile are #14.
+- Documentation / migration notes: selected - issue/PR summary must record gate evidence and decision.
+Domain packs:
+- Scientific governance / PI gate / evidence lineage: selected - readiness signoff is governance evidence for M1 entry.
+- Hydrology runtime / SHUD-rSHUD-AutoSHUD compatibility: selected - submodule checkout gates cover three scientific repos.
+- Zero adapter / tool registry / agent role governance: selected - zero checkout and frozen no-source-edit boundary are M1 prerequisites.
+
+Invariant Matrix:
+- Governing invariant: The #12 readiness decision must be derived only from the nine canonical P0 gate checks and must bind to the exact local repo/submodule state inspected.
+- Source-of-truth identity/contract: `MVP_Implementation_Readiness_Checklist.md` P0 Gate table plus the generated YAML `readiness_gate.version`, `checked_at`, `decision`, and per-gate keys.
+- Producers: readiness helper or manual gate runner; issue/PR evidence summary.
+- Validators/preflight: YAML decision enum validation; per-gate pass/block/pass_with_notes mapping.
+- Storage/cache/query: `workspace/readiness/readiness_gate_v0_8_1.yaml` runtime file only.
+- Public routes/entrypoints: none - #12 has no backend/API surface.
+- Frontend/downstream consumers: M1 downstream issues consume the decision semantics, not the runtime file directly.
+- Failure paths/rollback/stale state: gate failure yields `decision: block`; workspace output is overwrite-safe and regenerated for current HEAD.
+- Evidence/audit/readiness: issue comment or PR description records gate summary, commands, and whether downstream coding is unlocked.
+- Regression rows:
+  - Current HEAD with all nine P0 checks passing -> YAML contains exactly `gitmodules_parse`, `submodules_checkout`, `canonical_index`, `core_schema`, `support_schema`, `api_registry`, `error_idempotency`, `artifact_registry`, `lock_recovery` under `p0`, each `pass`, and aggregate `decision: pass`.
+  - Missing required contract file or unreadable submodule in an isolated temp fixture -> affected gate is non-pass and aggregate decision is `block`.
+  - `workspace/readiness/` absent or preexisting -> helper creates/overwrites only `workspace/readiness/readiness_gate_v0_8_1.yaml`; `git status --short -- workspace` remains empty because runtime assets are ignored/untracked.
+  - PR or issue evidence summary records per-gate inputs/results and the downstream action: `block` freezes #16+ coding, while `pass|pass_with_notes` unlocks it.
+
+Non-goals:
+- Link checking / CI (#13), lockfile and DependencyLock (#14), SHUD make and rSHUD version verification (#15).
+- Canonical frozen doc edits; any discovered conflict becomes a block or a separately governed bug-fix/ADR exception.
+
+Review focus:
+- Gate list exactly matches the P0 table.
+- Runtime output cannot accidentally satisfy source-controlled evidence or enter git.
+- `decision` aggregation is conservative and cannot classify contract conflicts as pass.

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -7,6 +7,11 @@
 ## 1. 就绪收口（readiness-gates）
 
 - [ ] 1.1 P0 九 Gate 逐项验证 + 签核 YAML 落 `workspace/readiness/readiness_gate_v0_8_1.yaml`（校验类合并一个 issue；decision=block 时后续编码任务全部冻结）
+  - Evidence floor (#12):
+    - Current HEAD + nine P0 checks -> `workspace/readiness/readiness_gate_v0_8_1.yaml` contains `checked_at`, `checked_by`, legal `decision`, and exactly these `p0` keys: `gitmodules_parse`, `submodules_checkout`, `canonical_index`, `core_schema`, `support_schema`, `api_registry`, `error_idempotency`, `artifact_registry`, `lock_recovery`.
+    - All nine gates pass -> aggregate `decision: pass`; a schema/API/path/lock conflict in an isolated failure fixture (for example missing required contract file) -> affected gate non-pass and aggregate `decision: block`.
+    - Absent or preexisting `workspace/readiness/` -> helper creates/overwrites only `workspace/readiness/readiness_gate_v0_8_1.yaml`; `git status --short -- workspace` remains empty.
+    - PR description or issue comment -> records per-gate input/result, command evidence, and downstream action: `block` freezes #16+ coding; `pass|pass_with_notes` unlocks downstream M1 coding.
 - [ ] 1.2 link check 脚本入库 `scripts/` + CI 工作流骨架（PR 触发：link check + 单测占位；schema drift 检查由 4.2 接入，PERF-API-001 冒烟由 6.5 接入）
 - [ ] 1.3 根 `package.json` 固定 packageManager + lockfile 入库 + 初始 DependencyLock（四 submodule commit + 运行时依赖版本）
 - [ ] 1.4 SHUD `make` 复验（一次本机编译 + 环境快照记入 readiness notes）+ rSHUD ≥2.5.0 在位确认

--- a/openspec/project-profile.md
+++ b/openspec/project-profile.md
@@ -1,0 +1,34 @@
+Project profile: SHUD-Harness
+
+Living artifact maintained by `subagent-workflow` Phase 0.0/0.5.
+
+Entry surfaces:
+- `packages/core|backend|frontend` TypeScript packages and `scripts/` deterministic tooling.
+- `openspec/changes/*`, `docs/04_IMPLEMENTATION/*`, `docs/03_SPEC/*` contract sources.
+- Runtime workspace layout under `workspace/` / `shud-workspace/`, with task snapshots, readiness notes, artifacts, and audit trails.
+- Read-only submodules: `SHUD/`, `rSHUD/`, `AutoSHUD/`, `zero/`.
+
+Contracts:
+- OpenSpec change fixtures, issue acceptance criteria, ADR-0001/0002, and Phased_Plan milestone gates.
+- Zod schemas, API envelope/idempotency contracts, workspace path conventions, artifact registry, and readiness YAML shape.
+- Zero reuse boundary: root submodule pinned to 13e25c1 with `zero/` source diff kept at 0 unless an ADR revisits it.
+
+Risk axes:
+- Path/workspace containment, symlink escape, generated runtime assets accidentally entering git.
+- Schema/API/error/idempotency drift across frozen docs, generated artifacts, implementation, and issue projections.
+- Evidence chain correctness: readiness, audit, review, CI, PR, and issue closure must bind to the exact checked state.
+- Scientific governance boundaries: agent cannot make scientific claims; high-risk model/parameter/output changes require PI gate.
+
+Typical evidence:
+- `openspec validate <change> --strict --no-interactive`; targeted docs/spec contract reads; `git diff --check`.
+- Focused unit/integration tests for touched package/script; shell dry-runs for deterministic scripts.
+- Git/submodule status, generated YAML/JSON schema validation, PR CI, and issue/PR evidence links.
+
+Domain risk packs:
+- Scientific governance / PI gate / evidence lineage.
+- Hydrology runtime / SHUD-rSHUD-AutoSHUD compatibility.
+- Zero adapter / tool registry / agent role governance.
+
+Domain expanded-triggers:
+- `readiness`, `workspace`, `artifact`, `snapshot`, `idempotency`, `lock`, `remediation`, `guard_class`.
+- `SHUD`, `rSHUD`, `AutoSHUD`, `Zero`, `ToolBase`, `beforeExecute`, `provider`, `GLM`.

--- a/scripts/readiness/check_readiness.py
+++ b/scripts/readiness/check_readiness.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Run the M1 P0 readiness gates and write the readiness signoff YAML."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+VERSION = "v0.8.1"
+OUTPUT_RELATIVE = Path("workspace/readiness/readiness_gate_v0_8_1.yaml")
+EXPECTED_SUBMODULES = ("SHUD", "rSHUD", "AutoSHUD", "zero")
+P0_KEYS = (
+    "gitmodules_parse",
+    "submodules_checkout",
+    "canonical_index",
+    "core_schema",
+    "support_schema",
+    "api_registry",
+    "error_idempotency",
+    "artifact_registry",
+    "lock_recovery",
+)
+
+
+@dataclass(frozen=True)
+class GateResult:
+    status: str
+    summary: str
+
+
+def pass_gate(summary: str) -> GateResult:
+    return GateResult("pass", summary)
+
+
+def block_gate(summary: str) -> GateResult:
+    return GateResult("block", summary)
+
+
+def run_command(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=str(cwd) if cwd else None,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def read_contract(repo_root: Path, relative_path: str) -> tuple[str | None, GateResult | None]:
+    path = repo_root / relative_path
+    if not path.is_file():
+        return None, block_gate(f"Missing required contract file: {relative_path}.")
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except OSError as exc:
+        return None, block_gate(f"Cannot read required contract file {relative_path}: {exc}.")
+
+
+def missing_tokens(text: str, tokens: list[str], *, case_sensitive: bool = True) -> list[str]:
+    haystack = text if case_sensitive else text.lower()
+    misses: list[str] = []
+    for token in tokens:
+        needle = token if case_sensitive else token.lower()
+        if needle not in haystack:
+            misses.append(token)
+    return misses
+
+
+def gate_gitmodules_parse(repo_root: Path) -> GateResult:
+    gitmodules = repo_root / ".gitmodules"
+    if not gitmodules.is_file():
+        return block_gate("Missing .gitmodules.")
+
+    result = run_command(
+        [
+            "git",
+            "config",
+            "--file",
+            str(gitmodules),
+            "--get-regexp",
+            r"^submodule\..*\.(path|url)$",
+        ]
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        return block_gate(f".gitmodules could not be parsed by git config: {detail}.")
+
+    parsed: dict[str, dict[str, str]] = {}
+    key_re = re.compile(r"^submodule\.([^.]+)\.(path|url)$")
+    for line in result.stdout.splitlines():
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        match = key_re.match(parts[0])
+        if not match:
+            continue
+        parsed.setdefault(match.group(1), {})[match.group(2)] = parts[1].strip()
+
+    missing: list[str] = []
+    for name in EXPECTED_SUBMODULES:
+        entry = parsed.get(name, {})
+        if entry.get("path") != name:
+            missing.append(f"{name}.path")
+        if not entry.get("url"):
+            missing.append(f"{name}.url")
+
+    if missing:
+        return block_gate(f".gitmodules is missing expected entries: {', '.join(missing)}.")
+    return pass_gate(".gitmodules defines path and url for SHUD, rSHUD, AutoSHUD, and zero.")
+
+
+def gate_submodules_checkout(repo_root: Path) -> GateResult:
+    commits: list[str] = []
+    missing: list[str] = []
+    for name in EXPECTED_SUBMODULES:
+        submodule_path = repo_root / name
+        if not submodule_path.is_dir():
+            missing.append(f"{name}: missing directory")
+            continue
+        result = run_command(["git", "-C", str(submodule_path), "rev-parse", "--verify", "HEAD"])
+        if result.returncode != 0:
+            missing.append(f"{name}: no checked-out commit")
+            continue
+        commit = result.stdout.strip()
+        if not re.fullmatch(r"[0-9a-fA-F]{40}", commit):
+            missing.append(f"{name}: invalid commit {commit!r}")
+            continue
+        commits.append(f"{name}@{commit[:12]}")
+
+    if missing:
+        return block_gate(f"Submodule checkout incomplete: {', '.join(missing)}.")
+    return pass_gate("Submodule directories exist with commits: " + ", ".join(commits) + ".")
+
+
+def gate_canonical_index(repo_root: Path) -> GateResult:
+    text, error = read_contract(repo_root, "docs/00_INDEX/CANONICAL_CONTRACTS.md")
+    if error:
+        return error
+    assert text is not None
+    required = [
+        "canonical_for: [canonical-source-index]",
+        "docs/03_SPEC/Minimal_Schemas.md",
+        "docs/03_SPEC/Support_Schema_Contracts.md",
+        "docs/04_IMPLEMENTATION/Schemas_APIs_CLIs.md",
+        "docs/04_IMPLEMENTATION/API_Error_And_Idempotency_Contracts.md",
+        "docs/03_SPEC/WebSocket_Protocol.md",
+        "docs/03_SPEC/Artifact_Registry_Spec.md",
+        "docs/03_SPEC/Workspace_Conventions.md",
+        "docs/03_SPEC/Idempotency_Concurrency_Locking_Spec.md",
+        "docs/03_SPEC/Workspace_Snapshot_And_Recovery_Spec.md",
+        "## 4. API registry",
+        "## 5. WebSocket event registry",
+        "## 6. Artifact registry",
+        "## 9. Schema drift policy",
+    ]
+    misses = missing_tokens(text, required)
+    if misses:
+        return block_gate("Canonical index is missing required source-of-truth entries: " + ", ".join(misses) + ".")
+    return pass_gate("Canonical index identifies unique sources for schema, API, events, paths, artifacts, locks, and recovery.")
+
+
+def markdown_section(text: str, name: str) -> str | None:
+    heading_re = re.compile(rf"^(?P<marks>##+)\s+.*\b{re.escape(name)}\b.*$", re.MULTILINE)
+    match = heading_re.search(text)
+    if not match:
+        return None
+    start = match.end()
+    level = len(match.group("marks"))
+    next_re = re.compile(rf"^#{{2,{level}}}\s+", re.MULTILINE)
+    next_match = next_re.search(text, start)
+    end = next_match.start() if next_match else len(text)
+    return text[start:end]
+
+
+def extract_enum(section: str, field: str) -> tuple[str, ...] | None:
+    match = re.search(rf"^\s*{re.escape(field)}:\s*([^\n#]+)", section, re.MULTILINE)
+    if not match:
+        return None
+    raw = match.group(1).strip()
+    raw = re.sub(r"\s+#.*$", "", raw).strip()
+    values = []
+    for value in raw.split("|"):
+        normalized = value.strip().strip("`'\"")
+        if normalized:
+            values.append(normalized)
+    return tuple(values)
+
+
+def gate_core_schema(repo_root: Path) -> GateResult:
+    minimal, minimal_error = read_contract(repo_root, "docs/03_SPEC/Minimal_Schemas.md")
+    if minimal_error:
+        return minimal_error
+    spec, spec_error = read_contract(repo_root, "docs/SPEC_v0.8_Final.md")
+    if spec_error:
+        return spec_error
+    assert minimal is not None and spec is not None
+
+    checks = [
+        ("TaskCard", "status"),
+        ("RunJob", "status"),
+        ("RunRecord", "status"),
+        ("EvidenceReport", "status"),
+        ("AnalysisPlan", "mode"),
+    ]
+    conflicts: list[str] = []
+    for object_name, field in checks:
+        minimal_section = markdown_section(minimal, object_name)
+        spec_section = markdown_section(spec, object_name)
+        if minimal_section is None:
+            conflicts.append(f"{object_name}: missing in Minimal_Schemas.md")
+            continue
+        if spec_section is None:
+            conflicts.append(f"{object_name}: missing in SPEC_v0.8_Final.md")
+            continue
+        minimal_enum = extract_enum(minimal_section, field)
+        spec_enum = extract_enum(spec_section, field)
+        if minimal_enum is None:
+            conflicts.append(f"{object_name}.{field}: missing in Minimal_Schemas.md")
+            continue
+        if spec_enum is None:
+            conflicts.append(f"{object_name}.{field}: missing in SPEC_v0.8_Final.md")
+            continue
+        if minimal_enum != spec_enum:
+            conflicts.append(
+                f"{object_name}.{field}: Minimal_Schemas={minimal_enum} SPEC_v0.8_Final={spec_enum}"
+            )
+
+    if conflicts:
+        return block_gate("Core schema conflicts detected: " + "; ".join(conflicts) + ".")
+    return pass_gate("TaskCard, RunJob, RunRecord, EvidenceReport status enums and AnalysisPlan mode align.")
+
+
+def gate_support_schema(repo_root: Path) -> GateResult:
+    text, error = read_contract(repo_root, "docs/03_SPEC/Support_Schema_Contracts.md")
+    if error:
+        return error
+    assert text is not None
+    required = [
+        "interface Artifact",
+        "interface ErrorRecord",
+        "interface PiGate",
+        "interface NotificationRecord",
+        "interface ReportExport",
+        "AuditEvent",
+        "LockRecord",
+        "runner result",
+    ]
+    misses = missing_tokens(text, required, case_sensitive=False)
+    if misses:
+        return block_gate("Support schema contract is missing required definitions or references: " + ", ".join(misses) + ".")
+    return pass_gate("Support schema covers Artifact, ErrorRecord, PiGate, Notification, ReportExport, Audit, Lock, and runner result.")
+
+
+def gate_api_registry(repo_root: Path) -> GateResult:
+    text, error = read_contract(repo_root, "docs/04_IMPLEMENTATION/Schemas_APIs_CLIs.md")
+    if error:
+        return error
+    assert text is not None
+    required = [
+        "Canonical data API",
+        "Convenience API",
+        "canonical API",
+        "Visualization_Data_Spec.md",
+        "/api/artifacts/:artifactId/data",
+        "/api/runs/:runId/series",
+    ]
+    misses = missing_tokens(text, required)
+    if misses:
+        return block_gate("API registry does not clearly separate canonical and convenience APIs: " + ", ".join(misses) + ".")
+    return pass_gate("API registry explicitly separates canonical data APIs from convenience APIs.")
+
+
+def gate_error_idempotency(repo_root: Path) -> GateResult:
+    text, error = read_contract(repo_root, "docs/04_IMPLEMENTATION/API_Error_And_Idempotency_Contracts.md")
+    if error:
+        return error
+    assert text is not None
+    required = [
+        "interface ApiErrorResponse",
+        "Idempotency-Key",
+        "Retry policy",
+        "idempotency key mismatch",
+        "422",
+        "retryable",
+    ]
+    misses = missing_tokens(text, required)
+    if misses:
+        return block_gate("API error/idempotency contract is missing required rules: " + ", ".join(misses) + ".")
+    return pass_gate("Non-2xx envelope, Idempotency-Key, mismatch handling, and retry policy are defined.")
+
+
+def gate_artifact_registry(repo_root: Path) -> GateResult:
+    text, error = read_contract(repo_root, "docs/03_SPEC/Artifact_Registry_Spec.md")
+    if error:
+        return error
+    assert text is not None
+    required = [
+        "## 2. Artifact",
+        "retention_class",
+        "redaction_status",
+        "evidence_usable",
+        "Artifact manifest",
+        "Retention",
+    ]
+    misses = missing_tokens(text, required)
+    if misses:
+        return block_gate("Artifact registry is missing required artifact, retention, redaction, or evidence rules: " + ", ".join(misses) + ".")
+    return pass_gate("Artifact type, retention, redaction_status, evidence_usable, and manifest rules are defined.")
+
+
+def gate_lock_recovery(repo_root: Path) -> GateResult:
+    locking, locking_error = read_contract(repo_root, "docs/03_SPEC/Idempotency_Concurrency_Locking_Spec.md")
+    if locking_error:
+        return locking_error
+    recovery, recovery_error = read_contract(repo_root, "docs/03_SPEC/Workspace_Snapshot_And_Recovery_Spec.md")
+    if recovery_error:
+        return recovery_error
+    assert locking is not None and recovery is not None
+    locking_required = [
+        "POST /api/jobs/:id/collect",
+        "export",
+        "Notification send",
+        "PI gate decision",
+        "LockRecord",
+        "stolen_after_recovery",
+    ]
+    recovery_required = [
+        "Service startup recovery",
+        "lock expired",
+        "snapshot_required",
+        "parked_state.yaml",
+    ]
+    misses = missing_tokens(locking, locking_required) + missing_tokens(recovery, recovery_required)
+    if misses:
+        return block_gate("Lock/recovery contracts are missing required idempotency or recovery rules: " + ", ".join(misses) + ".")
+    return pass_gate("Collect/export/notification/PI decision idempotency and startup lock recovery rules are defined.")
+
+
+GATE_RUNNERS = {
+    "gitmodules_parse": gate_gitmodules_parse,
+    "submodules_checkout": gate_submodules_checkout,
+    "canonical_index": gate_canonical_index,
+    "core_schema": gate_core_schema,
+    "support_schema": gate_support_schema,
+    "api_registry": gate_api_registry,
+    "error_idempotency": gate_error_idempotency,
+    "artifact_registry": gate_artifact_registry,
+    "lock_recovery": gate_lock_recovery,
+}
+
+
+def is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def resolve_output_path(repo_root: Path) -> Path:
+    repo_real = repo_root.resolve()
+    output_path = repo_root / OUTPUT_RELATIVE
+    readiness_dir = output_path.parent
+
+    resolved_parent = readiness_dir.resolve(strict=False)
+    resolved_output = output_path.resolve(strict=False)
+    if not is_relative_to(resolved_parent, repo_real) or not is_relative_to(resolved_output, repo_real):
+        raise RuntimeError(f"Refusing to write outside repo root: {OUTPUT_RELATIVE}")
+    if readiness_dir.exists() and readiness_dir.is_symlink():
+        raise RuntimeError(f"Refusing to write through symlinked directory: {readiness_dir}")
+    if output_path.exists() and output_path.is_symlink():
+        raise RuntimeError(f"Refusing to overwrite symlinked output file: {output_path}")
+
+    readiness_dir.mkdir(parents=True, exist_ok=True)
+    if not readiness_dir.is_dir():
+        raise RuntimeError(f"Readiness output parent is not a directory: {readiness_dir}")
+    return output_path
+
+
+def yaml_quote(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def build_yaml(*, checked_at: str, checked_by: str, decision: str, results: dict[str, GateResult]) -> str:
+    lines = [
+        "readiness_gate:",
+        f"  version: {VERSION}",
+        f"  checked_at: {yaml_quote(checked_at)}",
+        f"  checked_by: {yaml_quote(checked_by)}",
+        f"  decision: {decision}",
+        "  p0:",
+    ]
+    for key in P0_KEYS:
+        lines.append(f"    {key}: {results[key].status}")
+    lines.append("  notes:")
+    for key in P0_KEYS:
+        result = results[key]
+        lines.append(f"    - {yaml_quote(f'[{key}] {result.status}: {result.summary}')}")
+    lines.append(
+        "    - "
+        + yaml_quote(
+            "Scope: #12 verifies the nine P0 readiness gates only; link check, DependencyLock, SHUD make, and rSHUD version checks are separate M1 issues."
+        )
+    )
+    return "\n".join(lines) + "\n"
+
+
+def run_readiness(repo_root: Path) -> dict[str, GateResult]:
+    results: dict[str, GateResult] = {}
+    for key in P0_KEYS:
+        try:
+            results[key] = GATE_RUNNERS[key](repo_root)
+        except Exception as exc:  # Defensive: a checker crash is a blocking readiness failure.
+            results[key] = block_gate(f"Gate checker failed: {exc}.")
+    return results
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", help="Repository root to inspect.")
+    parser.add_argument("--checked-by", default=os.environ.get("USER", "unknown"), help="Signer recorded in YAML.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo_root = Path(args.repo_root).expanduser().resolve()
+    if not repo_root.is_dir():
+        print(f"error: repo root is not a directory: {repo_root}", file=sys.stderr)
+        return 2
+
+    results = run_readiness(repo_root)
+    decision = "pass" if all(result.status == "pass" for result in results.values()) else "block"
+    checked_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    try:
+        output_path = resolve_output_path(repo_root)
+        output_path.write_text(
+            build_yaml(checked_at=checked_at, checked_by=args.checked_by, decision=decision, results=results),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        print(f"error: failed to write readiness YAML: {exc}", file=sys.stderr)
+        return 1
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"wrote: {output_path}")
+    print(f"decision: {decision}")
+    for key in P0_KEYS:
+        result = results[key]
+        print(f"{key}: {result.status} - {result.summary}")
+    return 0 if decision == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/readiness/check_readiness.py
+++ b/scripts/readiness/check_readiness.py
@@ -4,13 +4,14 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import os
 import re
+import secrets
 import stat
 import subprocess
 import sys
-import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -18,6 +19,8 @@ from pathlib import Path
 
 VERSION = "v0.8.1"
 OUTPUT_RELATIVE = Path("workspace/readiness/readiness_gate_v0_8_1.yaml")
+READINESS_TEST_HOOK_ENV = "_SHUD_READINESS_TEST_HOOK"
+READINESS_TEST_HOOK_STAGE_ENV = "_SHUD_READINESS_TEST_HOOK_STAGE"
 EXPECTED_SUBMODULES = ("SHUD", "rSHUD", "AutoSHUD", "zero")
 P0_KEYS = (
     "gitmodules_parse",
@@ -336,6 +339,9 @@ def gate_submodules_checkout(repo_root: Path) -> GateResult:
 
     if state.errors:
         blockers.extend(f"root: {error}" for error in state.errors)
+    if state.dirty:
+        detail = "; ".join(state.status_short[:5])
+        blockers.append(f"root: dirty checkout ({detail})")
 
     for submodule in state.submodules:
         if submodule.errors:
@@ -626,16 +632,17 @@ def lstat_or_none(path: Path) -> os.stat_result | None:
         return None
 
 
-def assert_existing_output_file_safe(output_path: Path) -> None:
-    output_stat = lstat_or_none(output_path)
-    if output_stat is None:
+def assert_existing_output_file_safe_fd(readiness_dir_fd: int, output_name: str, display_path: Path) -> None:
+    try:
+        output_stat = os.stat(output_name, dir_fd=readiness_dir_fd, follow_symlinks=False)
+    except FileNotFoundError:
         return
     if stat.S_ISLNK(output_stat.st_mode):
-        raise RuntimeError(f"Refusing to overwrite symlinked output file: {output_path}")
+        raise RuntimeError(f"Refusing to overwrite symlinked output file: {display_path}")
     if not stat.S_ISREG(output_stat.st_mode):
-        raise RuntimeError(f"Readiness output target is not a regular file: {output_path}")
+        raise RuntimeError(f"Readiness output target is not a regular file: {display_path}")
     if output_stat.st_nlink != 1:
-        raise RuntimeError(f"Refusing to overwrite hardlinked output file: {output_path}")
+        raise RuntimeError(f"Refusing to overwrite hardlinked output file: {display_path}")
 
 
 def ensure_output_ancestors(repo_root: Path, *, create: bool) -> Path:
@@ -662,14 +669,110 @@ def resolve_output_path(repo_root: Path) -> Path:
     output_path = repo_root / OUTPUT_RELATIVE
     if repo_root != repo_real:
         raise RuntimeError(f"Repository root must be the resolved git top-level: {repo_root}")
-    readiness_dir = ensure_output_ancestors(repo_root, create=True)
-    if readiness_dir != output_path.parent:
-        raise RuntimeError(f"Unexpected readiness output parent: {readiness_dir}")
-    assert_existing_output_file_safe(output_path)
-    resolved_parent = readiness_dir.resolve(strict=True)
-    if not is_relative_to(resolved_parent, repo_real):
-        raise RuntimeError(f"Refusing to write outside repo root: {OUTPUT_RELATIVE}")
     return output_path
+
+
+def dir_open_flags() -> int:
+    required_flags = ("O_DIRECTORY", "O_NOFOLLOW")
+    missing = [flag for flag in required_flags if not hasattr(os, flag)]
+    if missing:
+        raise RuntimeError("fd-relative readiness writes require POSIX directory flags: " + ", ".join(missing))
+    return os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+
+
+def create_file_flags() -> int:
+    return os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+
+
+def raise_output_ancestor_error(parent_fd: int, part: str, display_path: Path, exc: OSError) -> None:
+    try:
+        current_stat = os.stat(part, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        raise RuntimeError(f"Readiness output parent disappeared: {display_path}") from exc
+    except OSError:
+        raise RuntimeError(f"Cannot inspect readiness output ancestor {display_path}: {exc}") from exc
+    if stat.S_ISLNK(current_stat.st_mode):
+        raise RuntimeError(f"Refusing to write through symlinked output ancestor: {display_path}") from exc
+    if not stat.S_ISDIR(current_stat.st_mode):
+        raise RuntimeError(f"Readiness output ancestor is not a directory: {display_path}") from exc
+    raise RuntimeError(f"Cannot open readiness output ancestor {display_path}: {exc}") from exc
+
+
+def open_child_directory_fd(parent_fd: int, part: str, display_path: Path, *, create: bool) -> int:
+    try:
+        return os.open(part, dir_open_flags(), dir_fd=parent_fd)
+    except FileNotFoundError:
+        if not create:
+            raise RuntimeError(f"Readiness output parent disappeared: {display_path}")
+        os.mkdir(part, mode=0o755, dir_fd=parent_fd)
+        try:
+            return os.open(part, dir_open_flags(), dir_fd=parent_fd)
+        except OSError as exc:
+            raise_output_ancestor_error(parent_fd, part, display_path, exc)
+    except OSError as exc:
+        raise_output_ancestor_error(parent_fd, part, display_path, exc)
+    raise AssertionError("unreachable")
+
+
+def open_readiness_directory_fd(repo_root: Path, *, create: bool) -> int:
+    root_fd = os.open(str(repo_root), dir_open_flags())
+    current_fd = root_fd
+    current_path = repo_root
+    try:
+        for part in OUTPUT_RELATIVE.parts[:-1]:
+            current_path = current_path / part
+            child_fd = open_child_directory_fd(current_fd, part, current_path, create=create)
+            os.close(current_fd)
+            current_fd = child_fd
+        return current_fd
+    except Exception:
+        os.close(current_fd)
+        raise
+
+
+def verify_held_readiness_directory(repo_root: Path, readiness_dir_fd: int) -> None:
+    readiness_dir = ensure_output_ancestors(repo_root, create=False)
+    held_stat = os.fstat(readiness_dir_fd)
+    path_stat = os.stat(readiness_dir, follow_symlinks=False)
+    if not stat.S_ISDIR(held_stat.st_mode):
+        raise RuntimeError(f"Held readiness output parent is not a directory: {readiness_dir}")
+    if (held_stat.st_dev, held_stat.st_ino) != (path_stat.st_dev, path_stat.st_ino):
+        raise RuntimeError(f"Readiness output parent changed while writing: {readiness_dir}")
+    resolved_parent = readiness_dir.resolve(strict=True)
+    if not is_relative_to(resolved_parent, repo_root.resolve()):
+        raise RuntimeError(f"Refusing to write outside repo root: {OUTPUT_RELATIVE}")
+
+
+def create_temp_file_fd(readiness_dir_fd: int, output_name: str) -> tuple[int, str]:
+    for _ in range(100):
+        temp_name = f".{output_name}.{os.getpid()}.{secrets.token_hex(8)}.tmp"
+        try:
+            return os.open(temp_name, create_file_flags(), mode=0o600, dir_fd=readiness_dir_fd), temp_name
+        except FileExistsError:
+            continue
+        except OSError as exc:
+            if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+                raise RuntimeError(f"Refusing unsafe readiness temp file name: {temp_name}") from exc
+            raise
+    raise RuntimeError("Could not allocate a unique readiness temp file name.")
+
+
+def run_internal_test_hook(stage: str, repo_root: Path) -> None:
+    hook = os.environ.get(READINESS_TEST_HOOK_ENV)
+    if not hook:
+        return
+    target_stage = os.environ.get(READINESS_TEST_HOOK_STAGE_ENV)
+    if target_stage and target_stage != stage:
+        return
+    if hook != "swap_readiness_to_docs":
+        raise RuntimeError(f"Unsupported readiness test hook: {hook}")
+
+    readiness_dir = repo_root / OUTPUT_RELATIVE.parent
+    backup_dir = repo_root / "workspace" / f"readiness.held.{stage}.{os.getpid()}"
+    (repo_root / "docs").mkdir(exist_ok=True)
+    if readiness_dir.exists() or readiness_dir.is_symlink():
+        readiness_dir.rename(backup_dir)
+    os.symlink("../docs", readiness_dir)
 
 
 def yaml_quote(value: str) -> str:
@@ -728,33 +831,45 @@ def append_repo_state_yaml(lines: list[str], repo_state: RepoState) -> None:
 
 
 def write_text_atomic(output_path: Path, content: str, repo_root: Path) -> None:
-    temp_path: str | None = None
+    readiness_dir_fd: int | None = None
+    temp_name: str | None = None
     try:
-        ensure_output_ancestors(repo_root, create=False)
-        assert_existing_output_file_safe(output_path)
-        fd, temp_path = tempfile.mkstemp(
-            prefix=f".{output_path.name}.",
-            suffix=".tmp",
-            dir=str(output_path.parent),
-            text=True,
-        )
+        readiness_dir_fd = open_readiness_directory_fd(repo_root, create=True)
+        verify_held_readiness_directory(repo_root, readiness_dir_fd)
+        assert_existing_output_file_safe_fd(readiness_dir_fd, output_path.name, output_path)
+
+        run_internal_test_hook("before_temp_create", repo_root)
+        verify_held_readiness_directory(repo_root, readiness_dir_fd)
+        assert_existing_output_file_safe_fd(readiness_dir_fd, output_path.name, output_path)
+
+        fd, temp_name = create_temp_file_fd(readiness_dir_fd, output_path.name)
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(content)
             handle.flush()
             os.fsync(handle.fileno())
 
-        ensure_output_ancestors(repo_root, create=False)
-        assert_existing_output_file_safe(output_path)
-        os.replace(temp_path, output_path)
-        temp_path = None
-        ensure_output_ancestors(repo_root, create=False)
-        assert_existing_output_file_safe(output_path)
-        resolved_output = output_path.resolve(strict=True)
-        if not is_relative_to(resolved_output, repo_root.resolve()):
-            raise RuntimeError(f"Readiness output escaped repo root after replace: {output_path}")
+        run_internal_test_hook("before_replace", repo_root)
+        verify_held_readiness_directory(repo_root, readiness_dir_fd)
+        assert_existing_output_file_safe_fd(readiness_dir_fd, output_path.name, output_path)
+
+        os.replace(
+            temp_name,
+            output_path.name,
+            src_dir_fd=readiness_dir_fd,
+            dst_dir_fd=readiness_dir_fd,
+        )
+        temp_name = None
+        assert_existing_output_file_safe_fd(readiness_dir_fd, output_path.name, output_path)
+        os.fsync(readiness_dir_fd)
+        verify_held_readiness_directory(repo_root, readiness_dir_fd)
     finally:
-        if temp_path and os.path.exists(temp_path):
-            os.unlink(temp_path)
+        if readiness_dir_fd is not None:
+            if temp_name is not None:
+                try:
+                    os.unlink(temp_name, dir_fd=readiness_dir_fd)
+                except FileNotFoundError:
+                    pass
+            os.close(readiness_dir_fd)
 
 
 def build_yaml(

--- a/scripts/readiness/check_readiness.py
+++ b/scripts/readiness/check_readiness.py
@@ -7,8 +7,10 @@ import argparse
 import json
 import os
 import re
+import stat
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -36,8 +38,40 @@ class GateResult:
     summary: str
 
 
+@dataclass(frozen=True)
+class SubmoduleState:
+    name: str
+    path: str
+    gitlink: str | None
+    head: str | None
+    branch: str | None
+    branchish: str | None
+    dirty: bool | None
+    status_short: tuple[str, ...]
+    worktree_top_level: str | None
+    errors: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RepoState:
+    path: str
+    git_top_level: str | None
+    is_top_level: bool
+    head: str | None
+    branch: str | None
+    branchish: str | None
+    dirty: bool | None
+    status_short: tuple[str, ...]
+    errors: tuple[str, ...]
+    submodules: tuple[SubmoduleState, ...]
+
+
 def pass_gate(summary: str) -> GateResult:
     return GateResult("pass", summary)
+
+
+def pass_with_notes_gate(summary: str) -> GateResult:
+    return GateResult("pass_with_notes", summary)
 
 
 def block_gate(summary: str) -> GateResult:
@@ -65,6 +99,13 @@ def read_contract(repo_root: Path, relative_path: str) -> tuple[str | None, Gate
         return None, block_gate(f"Cannot read required contract file {relative_path}: {exc}.")
 
 
+def contract_has_crlf(repo_root: Path, relative_path: str) -> bool:
+    try:
+        return b"\r\n" in (repo_root / relative_path).read_bytes()
+    except OSError:
+        return False
+
+
 def missing_tokens(text: str, tokens: list[str], *, case_sensitive: bool = True) -> list[str]:
     haystack = text if case_sensitive else text.lower()
     misses: list[str] = []
@@ -73,6 +114,176 @@ def missing_tokens(text: str, tokens: list[str], *, case_sensitive: bool = True)
         if needle not in haystack:
             misses.append(token)
     return misses
+
+
+def code_blocks(text: str) -> tuple[str, ...]:
+    return tuple(
+        match.group("body")
+        for match in re.finditer(r"^```[^\n]*\n(?P<body>.*?)^```", text, re.MULTILINE | re.DOTALL)
+    )
+
+
+def has_interface_definition(text: str, interface_name: str) -> bool:
+    interface_re = re.compile(rf"^\s*(?:export\s+)?interface\s+{re.escape(interface_name)}\s*\{{", re.MULTILINE)
+    return any(interface_re.search(block) for block in code_blocks(text))
+
+
+def find_interface_definition(
+    repo_root: Path, interface_name: str, candidate_paths: tuple[str, ...]
+) -> tuple[str | None, str | None]:
+    read_errors: list[str] = []
+    for relative_path in candidate_paths:
+        text, error = read_contract(repo_root, relative_path)
+        if error:
+            read_errors.append(f"{relative_path}: {error.summary}")
+            continue
+        assert text is not None
+        if has_interface_definition(text, interface_name):
+            return relative_path, None
+    if read_errors and len(read_errors) == len(candidate_paths):
+        return None, "; ".join(read_errors)
+    return None, None
+
+
+def git_stdout(args: list[str], cwd: Path) -> tuple[str | None, str | None]:
+    result = run_command(["git", "-C", str(cwd), *args])
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        return None, detail or f"git {' '.join(args)} failed"
+    return result.stdout.strip(), None
+
+
+def git_head(cwd: Path) -> tuple[str | None, str | None]:
+    output, error = git_stdout(["rev-parse", "--verify", "HEAD"], cwd)
+    if error:
+        return None, error
+    if output and re.fullmatch(r"[0-9a-fA-F]{40}", output):
+        return output, None
+    return None, f"invalid HEAD {output!r}"
+
+
+def git_branch(cwd: Path) -> str | None:
+    output, error = git_stdout(["symbolic-ref", "--short", "-q", "HEAD"], cwd)
+    if error or not output:
+        return None
+    return output
+
+
+def git_branchish(cwd: Path, branch: str | None) -> str | None:
+    if branch:
+        return branch
+    output, error = git_stdout(["describe", "--tags", "--always", "--dirty"], cwd)
+    if error:
+        return None
+    return output
+
+
+def git_status_short(cwd: Path) -> tuple[str, ...]:
+    result = run_command(["git", "-C", str(cwd), "status", "--short", "--untracked-files=all"])
+    if result.returncode != 0:
+        return ()
+    return tuple(line for line in result.stdout.splitlines() if line)
+
+
+def git_top_level(cwd: Path) -> tuple[str | None, str | None]:
+    return git_stdout(["rev-parse", "--show-toplevel"], cwd)
+
+
+def superproject_gitlink(repo_root: Path, name: str) -> tuple[str | None, str | None]:
+    result = run_command(["git", "-C", str(repo_root), "ls-tree", "HEAD", "--", name])
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        return None, detail or f"cannot read gitlink for {name}"
+    line = result.stdout.strip()
+    if not line:
+        return None, "missing superproject gitlink"
+    match = re.fullmatch(r"160000\s+commit\s+([0-9a-fA-F]{40})\t(.+)", line)
+    if not match:
+        return None, f"expected 160000 commit gitlink, got {line!r}"
+    if match.group(2) != name:
+        return None, f"gitlink path mismatch: expected {name}, got {match.group(2)}"
+    return match.group(1), None
+
+
+def collect_repo_state(repo_root: Path) -> RepoState:
+    root_errors: list[str] = []
+    root_top_level, top_error = git_top_level(repo_root)
+    if top_error:
+        root_errors.append(top_error)
+    root_resolved = str(repo_root.resolve())
+    top_resolved = str(Path(root_top_level).resolve()) if root_top_level else None
+    is_top_level = top_resolved == root_resolved
+    if root_top_level and not is_top_level:
+        root_errors.append(f"repo_root is not git worktree top-level: top-level is {root_top_level}")
+
+    root_head, head_error = git_head(repo_root)
+    if head_error:
+        root_errors.append(head_error)
+    root_branch = git_branch(repo_root)
+    root_branchish = git_branchish(repo_root, root_branch)
+    root_status = git_status_short(repo_root)
+
+    submodules: list[SubmoduleState] = []
+    for name in EXPECTED_SUBMODULES:
+        submodule_path = repo_root / name
+        errors: list[str] = []
+        gitlink, gitlink_error = superproject_gitlink(repo_root, name)
+        if gitlink_error:
+            errors.append(gitlink_error)
+
+        head: str | None = None
+        branch: str | None = None
+        branchish: str | None = None
+        dirty: bool | None = None
+        status_short: tuple[str, ...] = ()
+        worktree_top_level: str | None = None
+
+        if not submodule_path.is_dir():
+            errors.append("missing directory")
+        else:
+            worktree_top_level, worktree_error = git_top_level(submodule_path)
+            if worktree_error:
+                errors.append(f"not a git worktree: {worktree_error}")
+            else:
+                expected_top = str(submodule_path.resolve())
+                actual_top = str(Path(worktree_top_level).resolve()) if worktree_top_level else None
+                if actual_top != expected_top:
+                    errors.append(f"submodule worktree top-level mismatch: {worktree_top_level}")
+            head, sub_head_error = git_head(submodule_path)
+            if sub_head_error:
+                errors.append(f"no checked-out commit: {sub_head_error}")
+            branch = git_branch(submodule_path)
+            branchish = git_branchish(submodule_path, branch)
+            status_short = git_status_short(submodule_path)
+            dirty = bool(status_short)
+
+        submodules.append(
+            SubmoduleState(
+                name=name,
+                path=str(submodule_path),
+                gitlink=gitlink,
+                head=head,
+                branch=branch,
+                branchish=branchish,
+                dirty=dirty,
+                status_short=status_short,
+                worktree_top_level=worktree_top_level,
+                errors=tuple(errors),
+            )
+        )
+
+    return RepoState(
+        path=str(repo_root),
+        git_top_level=root_top_level,
+        is_top_level=is_top_level,
+        head=root_head,
+        branch=root_branch,
+        branchish=root_branchish,
+        dirty=bool(root_status),
+        status_short=root_status,
+        errors=tuple(root_errors),
+        submodules=tuple(submodules),
+    )
 
 
 def gate_gitmodules_parse(repo_root: Path) -> GateResult:
@@ -119,26 +330,29 @@ def gate_gitmodules_parse(repo_root: Path) -> GateResult:
 
 
 def gate_submodules_checkout(repo_root: Path) -> GateResult:
+    state = collect_repo_state(repo_root)
+    blockers: list[str] = []
     commits: list[str] = []
-    missing: list[str] = []
-    for name in EXPECTED_SUBMODULES:
-        submodule_path = repo_root / name
-        if not submodule_path.is_dir():
-            missing.append(f"{name}: missing directory")
-            continue
-        result = run_command(["git", "-C", str(submodule_path), "rev-parse", "--verify", "HEAD"])
-        if result.returncode != 0:
-            missing.append(f"{name}: no checked-out commit")
-            continue
-        commit = result.stdout.strip()
-        if not re.fullmatch(r"[0-9a-fA-F]{40}", commit):
-            missing.append(f"{name}: invalid commit {commit!r}")
-            continue
-        commits.append(f"{name}@{commit[:12]}")
 
-    if missing:
-        return block_gate(f"Submodule checkout incomplete: {', '.join(missing)}.")
-    return pass_gate("Submodule directories exist with commits: " + ", ".join(commits) + ".")
+    if state.errors:
+        blockers.extend(f"root: {error}" for error in state.errors)
+
+    for submodule in state.submodules:
+        if submodule.errors:
+            blockers.extend(f"{submodule.name}: {error}" for error in submodule.errors)
+        if submodule.gitlink and submodule.head and submodule.gitlink != submodule.head:
+            blockers.append(
+                f"{submodule.name}: gitlink {submodule.gitlink[:12]} != checkout HEAD {submodule.head[:12]}"
+            )
+        if submodule.dirty:
+            detail = "; ".join(submodule.status_short[:5])
+            blockers.append(f"{submodule.name}: dirty checkout ({detail})")
+        if submodule.gitlink and submodule.head and submodule.gitlink == submodule.head:
+            commits.append(f"{submodule.name}@{submodule.head[:12]}")
+
+    if blockers:
+        return block_gate("Submodule state is not bound to superproject gitlinks: " + "; ".join(blockers) + ".")
+    return pass_gate("Submodule gitlinks match checkout HEAD and checkouts are clean: " + ", ".join(commits) + ".")
 
 
 def gate_canonical_index(repo_root: Path) -> GateResult:
@@ -165,6 +379,10 @@ def gate_canonical_index(repo_root: Path) -> GateResult:
     misses = missing_tokens(text, required)
     if misses:
         return block_gate("Canonical index is missing required source-of-truth entries: " + ", ".join(misses) + ".")
+    if contract_has_crlf(repo_root, "docs/00_INDEX/CANONICAL_CONTRACTS.md"):
+        return pass_with_notes_gate(
+            "Canonical index content is complete; document format note: CRLF line endings should be normalized in M1 CI."
+        )
     return pass_gate("Canonical index identifies unique sources for schema, API, events, paths, artifacts, locks, and recovery.")
 
 
@@ -244,20 +462,55 @@ def gate_support_schema(repo_root: Path) -> GateResult:
     if error:
         return error
     assert text is not None
-    required = [
-        "interface Artifact",
-        "interface ErrorRecord",
-        "interface PiGate",
-        "interface NotificationRecord",
-        "interface ReportExport",
-        "AuditEvent",
-        "LockRecord",
-        "runner result",
-    ]
-    misses = missing_tokens(text, required, case_sensitive=False)
+    checks: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+        ("Artifact", "Artifact", ("docs/03_SPEC/Support_Schema_Contracts.md",)),
+        ("ErrorRecord", "ErrorRecord", ("docs/03_SPEC/Support_Schema_Contracts.md",)),
+        ("PiGate", "PiGate", ("docs/03_SPEC/Support_Schema_Contracts.md",)),
+        ("NotificationRecord", "NotificationRecord", ("docs/03_SPEC/Support_Schema_Contracts.md",)),
+        ("ReportExport", "ReportExport", ("docs/03_SPEC/Support_Schema_Contracts.md",)),
+        (
+            "AuditEvent",
+            "AuditEvent",
+            (
+                "docs/03_SPEC/Support_Schema_Contracts.md",
+                "docs/03_SPEC/User_Session_And_Audit_Schema.md",
+            ),
+        ),
+        (
+            "LockRecord",
+            "LockRecord",
+            (
+                "docs/03_SPEC/Support_Schema_Contracts.md",
+                "docs/03_SPEC/Idempotency_Concurrency_Locking_Spec.md",
+            ),
+        ),
+        (
+            "RunnerResult",
+            "RunnerResult",
+            (
+                "docs/03_SPEC/Support_Schema_Contracts.md",
+                "docs/03_SPEC/Runner_Adapter_Contracts.md",
+            ),
+        ),
+    )
+    misses: list[str] = []
+    evidence: list[str] = []
+    read_errors: list[str] = []
+    for label, interface_name, candidate_paths in checks:
+        found_path, read_error = find_interface_definition(repo_root, interface_name, candidate_paths)
+        if found_path:
+            evidence.append(f"{label}={interface_name}@{found_path}")
+            continue
+        misses.append(label)
+        if read_error:
+            read_errors.append(f"{label}: {read_error}")
+
     if misses:
-        return block_gate("Support schema contract is missing required definitions or references: " + ", ".join(misses) + ".")
-    return pass_gate("Support schema covers Artifact, ErrorRecord, PiGate, Notification, ReportExport, Audit, Lock, and runner result.")
+        detail = "missing definition-level evidence for " + ", ".join(misses)
+        if read_errors:
+            detail += "; read errors: " + "; ".join(read_errors)
+        return block_gate(detail + ".")
+    return pass_gate("Support schema definition evidence: " + "; ".join(evidence) + ".")
 
 
 def gate_api_registry(repo_root: Path) -> GateResult:
@@ -366,23 +619,56 @@ def is_relative_to(path: Path, parent: Path) -> bool:
         return False
 
 
+def lstat_or_none(path: Path) -> os.stat_result | None:
+    try:
+        return os.lstat(path)
+    except FileNotFoundError:
+        return None
+
+
+def assert_existing_output_file_safe(output_path: Path) -> None:
+    output_stat = lstat_or_none(output_path)
+    if output_stat is None:
+        return
+    if stat.S_ISLNK(output_stat.st_mode):
+        raise RuntimeError(f"Refusing to overwrite symlinked output file: {output_path}")
+    if not stat.S_ISREG(output_stat.st_mode):
+        raise RuntimeError(f"Readiness output target is not a regular file: {output_path}")
+    if output_stat.st_nlink != 1:
+        raise RuntimeError(f"Refusing to overwrite hardlinked output file: {output_path}")
+
+
+def ensure_output_ancestors(repo_root: Path, *, create: bool) -> Path:
+    current = repo_root
+    for part in OUTPUT_RELATIVE.parts[:-1]:
+        current = current / part
+        current_stat = lstat_or_none(current)
+        if current_stat is None:
+            if not create:
+                raise RuntimeError(f"Readiness output parent disappeared: {current}")
+            current.mkdir()
+            current_stat = lstat_or_none(current)
+            if current_stat is None:
+                raise RuntimeError(f"Readiness output parent could not be created: {current}")
+        if stat.S_ISLNK(current_stat.st_mode):
+            raise RuntimeError(f"Refusing to write through symlinked output ancestor: {current}")
+        if not stat.S_ISDIR(current_stat.st_mode):
+            raise RuntimeError(f"Readiness output ancestor is not a directory: {current}")
+    return current
+
+
 def resolve_output_path(repo_root: Path) -> Path:
     repo_real = repo_root.resolve()
     output_path = repo_root / OUTPUT_RELATIVE
-    readiness_dir = output_path.parent
-
-    resolved_parent = readiness_dir.resolve(strict=False)
-    resolved_output = output_path.resolve(strict=False)
-    if not is_relative_to(resolved_parent, repo_real) or not is_relative_to(resolved_output, repo_real):
+    if repo_root != repo_real:
+        raise RuntimeError(f"Repository root must be the resolved git top-level: {repo_root}")
+    readiness_dir = ensure_output_ancestors(repo_root, create=True)
+    if readiness_dir != output_path.parent:
+        raise RuntimeError(f"Unexpected readiness output parent: {readiness_dir}")
+    assert_existing_output_file_safe(output_path)
+    resolved_parent = readiness_dir.resolve(strict=True)
+    if not is_relative_to(resolved_parent, repo_real):
         raise RuntimeError(f"Refusing to write outside repo root: {OUTPUT_RELATIVE}")
-    if readiness_dir.exists() and readiness_dir.is_symlink():
-        raise RuntimeError(f"Refusing to write through symlinked directory: {readiness_dir}")
-    if output_path.exists() and output_path.is_symlink():
-        raise RuntimeError(f"Refusing to overwrite symlinked output file: {output_path}")
-
-    readiness_dir.mkdir(parents=True, exist_ok=True)
-    if not readiness_dir.is_dir():
-        raise RuntimeError(f"Readiness output parent is not a directory: {readiness_dir}")
     return output_path
 
 
@@ -390,7 +676,90 @@ def yaml_quote(value: str) -> str:
     return json.dumps(value, ensure_ascii=False)
 
 
-def build_yaml(*, checked_at: str, checked_by: str, decision: str, results: dict[str, GateResult]) -> str:
+def yaml_scalar(value: object) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return yaml_quote(str(value))
+
+
+def append_yaml_list(lines: list[str], indent: str, key: str, values: tuple[str, ...]) -> None:
+    if not values:
+        lines.append(f"{indent}{key}: []")
+        return
+    lines.append(f"{indent}{key}:")
+    for value in values:
+        lines.append(f"{indent}  - {yaml_quote(value)}")
+
+
+def append_repo_state_yaml(lines: list[str], repo_state: RepoState) -> None:
+    lines.extend(
+        [
+            "  repo_state:",
+            "    root:",
+            f"      path: {yaml_scalar(repo_state.path)}",
+            f"      git_top_level: {yaml_scalar(repo_state.git_top_level)}",
+            f"      is_top_level: {yaml_scalar(repo_state.is_top_level)}",
+            f"      head: {yaml_scalar(repo_state.head)}",
+            f"      branch: {yaml_scalar(repo_state.branch)}",
+            f"      branchish: {yaml_scalar(repo_state.branchish)}",
+            f"      dirty: {yaml_scalar(repo_state.dirty)}",
+        ]
+    )
+    append_yaml_list(lines, "      ", "status_short", repo_state.status_short)
+    append_yaml_list(lines, "      ", "errors", repo_state.errors)
+    lines.append("    submodules:")
+    for submodule in repo_state.submodules:
+        lines.extend(
+            [
+                f"      {submodule.name}:",
+                f"        path: {yaml_scalar(submodule.path)}",
+                f"        gitlink: {yaml_scalar(submodule.gitlink)}",
+                f"        head: {yaml_scalar(submodule.head)}",
+                f"        branch: {yaml_scalar(submodule.branch)}",
+                f"        branchish: {yaml_scalar(submodule.branchish)}",
+                f"        dirty: {yaml_scalar(submodule.dirty)}",
+                f"        worktree_top_level: {yaml_scalar(submodule.worktree_top_level)}",
+            ]
+        )
+        append_yaml_list(lines, "        ", "status_short", submodule.status_short)
+        append_yaml_list(lines, "        ", "errors", submodule.errors)
+
+
+def write_text_atomic(output_path: Path, content: str, repo_root: Path) -> None:
+    temp_path: str | None = None
+    try:
+        ensure_output_ancestors(repo_root, create=False)
+        assert_existing_output_file_safe(output_path)
+        fd, temp_path = tempfile.mkstemp(
+            prefix=f".{output_path.name}.",
+            suffix=".tmp",
+            dir=str(output_path.parent),
+            text=True,
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        ensure_output_ancestors(repo_root, create=False)
+        assert_existing_output_file_safe(output_path)
+        os.replace(temp_path, output_path)
+        temp_path = None
+        ensure_output_ancestors(repo_root, create=False)
+        assert_existing_output_file_safe(output_path)
+        resolved_output = output_path.resolve(strict=True)
+        if not is_relative_to(resolved_output, repo_root.resolve()):
+            raise RuntimeError(f"Readiness output escaped repo root after replace: {output_path}")
+    finally:
+        if temp_path and os.path.exists(temp_path):
+            os.unlink(temp_path)
+
+
+def build_yaml(
+    *, checked_at: str, checked_by: str, decision: str, results: dict[str, GateResult], repo_state: RepoState
+) -> str:
     lines = [
         "readiness_gate:",
         f"  version: {VERSION}",
@@ -411,17 +780,19 @@ def build_yaml(*, checked_at: str, checked_by: str, decision: str, results: dict
             "Scope: #12 verifies the nine P0 readiness gates only; link check, DependencyLock, SHUD make, and rSHUD version checks are separate M1 issues."
         )
     )
+    append_repo_state_yaml(lines, repo_state)
     return "\n".join(lines) + "\n"
 
 
-def run_readiness(repo_root: Path) -> dict[str, GateResult]:
+def run_readiness(repo_root: Path) -> tuple[dict[str, GateResult], RepoState]:
+    repo_state = collect_repo_state(repo_root)
     results: dict[str, GateResult] = {}
     for key in P0_KEYS:
         try:
             results[key] = GATE_RUNNERS[key](repo_root)
         except Exception as exc:  # Defensive: a checker crash is a blocking readiness failure.
             results[key] = block_gate(f"Gate checker failed: {exc}.")
-    return results
+    return results, repo_state
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -431,21 +802,77 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def normalize_repo_root(repo_root_arg: str) -> Path:
+    candidate = Path(repo_root_arg).expanduser().resolve()
+    if not candidate.is_dir():
+        raise RuntimeError(f"repo root is not a directory: {candidate}")
+    top_level, error = git_top_level(candidate)
+    if error or top_level is None:
+        raise RuntimeError(f"repo root is not a git worktree: {candidate}: {error}")
+    top_path = Path(top_level).resolve()
+    if top_path != candidate:
+        raise RuntimeError(f"repo root must be the git worktree top-level: got {candidate}, top-level is {top_path}")
+    return top_path
+
+
+def aggregate_decision(results: dict[str, GateResult]) -> str:
+    statuses = [result.status for result in results.values()]
+    if any(status == "block" for status in statuses):
+        return "block"
+    if any(status == "pass_with_notes" for status in statuses):
+        return "pass_with_notes"
+    return "pass"
+
+
+def short_ref(value: str | None) -> str:
+    if value is None:
+        return "null"
+    if re.fullmatch(r"[0-9a-fA-F]{40}", value):
+        return value[:12]
+    return value
+
+
+def print_repo_state(repo_state: RepoState) -> None:
+    print(
+        "repo_state: "
+        f"head={short_ref(repo_state.head)} "
+        f"branch={repo_state.branch or 'detached'} "
+        f"dirty={repo_state.dirty}"
+    )
+    for submodule in repo_state.submodules:
+        print(
+            "submodule_state: "
+            f"{submodule.name} "
+            f"gitlink={short_ref(submodule.gitlink)} "
+            f"head={short_ref(submodule.head)} "
+            f"branch={submodule.branch or 'detached'} "
+            f"dirty={submodule.dirty}"
+        )
+
+
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
-    repo_root = Path(args.repo_root).expanduser().resolve()
-    if not repo_root.is_dir():
-        print(f"error: repo root is not a directory: {repo_root}", file=sys.stderr)
+    try:
+        repo_root = normalize_repo_root(args.repo_root)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
         return 2
 
-    results = run_readiness(repo_root)
-    decision = "pass" if all(result.status == "pass" for result in results.values()) else "block"
+    results, repo_state = run_readiness(repo_root)
+    decision = aggregate_decision(results)
     checked_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     try:
         output_path = resolve_output_path(repo_root)
-        output_path.write_text(
-            build_yaml(checked_at=checked_at, checked_by=args.checked_by, decision=decision, results=results),
-            encoding="utf-8",
+        write_text_atomic(
+            output_path,
+            build_yaml(
+                checked_at=checked_at,
+                checked_by=args.checked_by,
+                decision=decision,
+                results=results,
+                repo_state=repo_state,
+            ),
+            repo_root,
         )
     except OSError as exc:
         print(f"error: failed to write readiness YAML: {exc}", file=sys.stderr)
@@ -459,7 +886,8 @@ def main(argv: list[str]) -> int:
     for key in P0_KEYS:
         result = results[key]
         print(f"{key}: {result.status} - {result.summary}")
-    return 0 if decision == "pass" else 1
+    print_repo_state(repo_state)
+    return 0 if decision != "block" else 1
 
 
 if __name__ == "__main__":

--- a/scripts/readiness/check_readiness.sh
+++ b/scripts/readiness/check_readiness.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec python3 "$SCRIPT_DIR/check_readiness.py" "$@"

--- a/scripts/readiness/self_test.sh
+++ b/scripts/readiness/self_test.sh
@@ -31,6 +31,13 @@ if [ -n "$workspace_status_before" ]; then
   fail "live workspace was not clean before self-test"
 fi
 
+if ! git -C "$REPO_ROOT" check-ignore --no-index -v workspace/readiness/readiness_gate_v0_8_1.yaml >/dev/null; then
+  fail "root runtime workspace readiness output is not ignored"
+fi
+if git -C "$REPO_ROOT" check-ignore --no-index -v packages/core/src/workspace/index.ts >/dev/null; then
+  fail "nested package workspace path is over-ignored"
+fi
+
 assert_live_unchanged() {
   workspace_status_after=$(git -C "$REPO_ROOT" status --short -- workspace)
   if [ -n "$workspace_status_after" ]; then
@@ -153,6 +160,7 @@ docs/03_SPEC/Artifact_Registry_Spec.md'
     cp "$REPO_ROOT/$file_path" "$fixture_root/$file_path"
   done
   cp "$REPO_ROOT/.gitmodules" "$fixture_root/.gitmodules"
+  cp "$REPO_ROOT/.gitignore" "$fixture_root/.gitignore"
 }
 
 append_runner_result_definition() {
@@ -178,6 +186,7 @@ init_git_repo() {
   git -C "$fixture_root" init -q
   git -C "$fixture_root" config user.email "readiness-test@example.invalid"
   git -C "$fixture_root" config user.name "readiness-test"
+  git -C "$fixture_root" config core.autocrlf false
   git -C "$fixture_root" config advice.addEmbeddedRepo false
 }
 
@@ -196,7 +205,7 @@ create_fake_submodules() {
 
 commit_superproject_with_gitlinks() {
   fixture_root=$1
-  git -C "$fixture_root" add .gitmodules docs
+  git -C "$fixture_root" add .gitignore .gitmodules docs
   for name in SHUD rSHUD AutoSHUD zero; do
     git -C "$fixture_root" add "$name" 2>/dev/null
   done
@@ -222,7 +231,7 @@ make_fake_standalone_fixture() {
   init_git_repo "$fixture_root"
   copy_contracts "$fixture_root"
   append_runner_result_definition "$fixture_root"
-  git -C "$fixture_root" add .gitmodules docs
+  git -C "$fixture_root" add .gitignore .gitmodules docs
   git -C "$fixture_root" commit -q -m "fixture superproject without gitlinks"
   create_fake_submodules "$fixture_root"
 }
@@ -263,6 +272,8 @@ path = Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
 path.write_bytes(text.replace("\n", "\r\n").encode("utf-8"))
 PY
+git -C "$notes_fixture" add docs/00_INDEX/CANONICAL_CONTRACTS.md
+git -C "$notes_fixture" commit -q -m "fixture committed crlf note"
 "$HELPER" --repo-root "$notes_fixture" --checked-by readiness-self-test >/dev/null || fail "pass_with_notes fixture returned non-zero"
 validate_yaml "$notes_fixture/$OUTPUT_REL" pass_with_notes canonical_index pass_with_notes
 
@@ -297,6 +308,14 @@ if "$HELPER" --repo-root "$dirty_fixture" --checked-by readiness-self-test >/dev
   fail "dirty submodule fixture unexpectedly returned zero"
 fi
 validate_yaml "$dirty_fixture/$OUTPUT_REL" block submodules_checkout block
+
+root_dirty_fixture="$TMP_ROOT/fixture-dirty-root"
+make_fixture "$root_dirty_fixture"
+printf '\nroot dirty fixture\n' >> "$root_dirty_fixture/docs/04_IMPLEMENTATION/Schemas_APIs_CLIs.md"
+if "$HELPER" --repo-root "$root_dirty_fixture" --checked-by readiness-self-test >/dev/null; then
+  fail "dirty root fixture unexpectedly returned zero"
+fi
+validate_yaml "$root_dirty_fixture/$OUTPUT_REL" block submodules_checkout block
 
 workspace_symlink_fixture="$TMP_ROOT/fixture-workspace-symlink"
 make_fixture "$workspace_symlink_fixture"
@@ -340,6 +359,24 @@ if "$HELPER" --repo-root "$hardlink_fixture" --checked-by readiness-self-test >/
 fi
 if ! grep -q stale "$hardlink_fixture/$OUTPUT_REL"; then
   fail "helper overwrote hardlinked output"
+fi
+
+before_temp_swap_fixture="$TMP_ROOT/fixture-swap-before-temp"
+make_fixture "$before_temp_swap_fixture"
+if _SHUD_READINESS_TEST_HOOK=swap_readiness_to_docs _SHUD_READINESS_TEST_HOOK_STAGE=before_temp_create "$HELPER" --repo-root "$before_temp_swap_fixture" --checked-by readiness-self-test >/dev/null 2>/dev/null; then
+  fail "before-temp readiness dir swap fixture unexpectedly returned zero"
+fi
+if [ -e "$before_temp_swap_fixture/docs/readiness_gate_v0_8_1.yaml" ]; then
+  fail "before-temp readiness dir swap wrote through symlink target"
+fi
+
+before_replace_swap_fixture="$TMP_ROOT/fixture-swap-before-replace"
+make_fixture "$before_replace_swap_fixture"
+if _SHUD_READINESS_TEST_HOOK=swap_readiness_to_docs _SHUD_READINESS_TEST_HOOK_STAGE=before_replace "$HELPER" --repo-root "$before_replace_swap_fixture" --checked-by readiness-self-test >/dev/null 2>/dev/null; then
+  fail "before-replace readiness dir swap fixture unexpectedly returned zero"
+fi
+if [ -e "$before_replace_swap_fixture/docs/readiness_gate_v0_8_1.yaml" ]; then
+  fail "before-replace readiness dir swap wrote through symlink target"
 fi
 
 assert_live_unchanged

--- a/scripts/readiness/self_test.sh
+++ b/scripts/readiness/self_test.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+HELPER="$SCRIPT_DIR/check_readiness.sh"
+OUTPUT_REL="workspace/readiness/readiness_gate_v0_8_1.yaml"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/shud-readiness-test.XXXXXX")
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+
+fail() {
+  printf 'self-test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+validate_yaml() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+expected_decision = sys.argv[2]
+expected_gate = sys.argv[3]
+expected_keys = [
+    "gitmodules_parse",
+    "submodules_checkout",
+    "canonical_index",
+    "core_schema",
+    "support_schema",
+    "api_registry",
+    "error_idempotency",
+    "artifact_registry",
+    "lock_recovery",
+]
+
+text = path.read_text(encoding="utf-8")
+if "\t" in text:
+    raise SystemExit("YAML contains a tab")
+if not text.startswith("readiness_gate:\n"):
+    raise SystemExit("missing readiness_gate root")
+fields = {}
+p0 = {}
+in_p0 = False
+in_notes = False
+note_count = 0
+for line in text.splitlines():
+    if line == "  p0:":
+        in_p0 = True
+        in_notes = False
+        continue
+    if line == "  notes:":
+        in_p0 = False
+        in_notes = True
+        continue
+    if in_p0 and line.startswith("    "):
+        key, sep, value = line.strip().partition(": ")
+        if sep != ": ":
+            raise SystemExit(f"invalid p0 line: {line}")
+        p0[key] = value
+        continue
+    if in_notes and line.startswith("    - "):
+        note_count += 1
+        continue
+    match = re.match(r"^  ([a-z_]+): (.+)$", line)
+    if match:
+        fields[match.group(1)] = match.group(2).strip('"')
+
+if fields.get("version") != "v0.8.1":
+    raise SystemExit("wrong version")
+if not re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$", fields.get("checked_at", "")):
+    raise SystemExit("checked_at is not ISO8601 UTC")
+if "checked_by" not in fields:
+    raise SystemExit("missing checked_by")
+if fields.get("decision") != expected_decision:
+    raise SystemExit(f"expected decision {expected_decision}, got {fields.get('decision')}")
+if list(p0.keys()) != expected_keys:
+    raise SystemExit(f"unexpected p0 keys: {list(p0.keys())}")
+if expected_gate != "-" and p0.get(expected_gate) == "pass":
+    raise SystemExit(f"expected non-pass gate {expected_gate}")
+if expected_gate == "-" and any(value != "pass" for value in p0.values()):
+    raise SystemExit(f"expected all p0 gates to pass, got {p0}")
+if note_count < len(expected_keys):
+    raise SystemExit("missing per-gate notes")
+PY
+}
+
+copy_contracts() {
+  fixture_root=$1
+  contract_files='docs/00_INDEX/CANONICAL_CONTRACTS.md
+docs/SPEC_v0.8_Final.md
+docs/03_SPEC/Minimal_Schemas.md
+docs/03_SPEC/Support_Schema_Contracts.md
+docs/04_IMPLEMENTATION/Schemas_APIs_CLIs.md
+docs/04_IMPLEMENTATION/API_Error_And_Idempotency_Contracts.md
+docs/03_SPEC/Artifact_Registry_Spec.md
+docs/03_SPEC/Idempotency_Concurrency_Locking_Spec.md
+docs/03_SPEC/Workspace_Snapshot_And_Recovery_Spec.md'
+  printf '%s\n' "$contract_files" | while IFS= read -r file_path; do
+    mkdir -p "$fixture_root/$(dirname "$file_path")"
+    cp "$REPO_ROOT/$file_path" "$fixture_root/$file_path"
+  done
+  cp "$REPO_ROOT/.gitmodules" "$fixture_root/.gitmodules"
+}
+
+create_fake_submodules() {
+  fixture_root=$1
+  for name in SHUD rSHUD AutoSHUD zero; do
+    mkdir -p "$fixture_root/$name"
+    git -C "$fixture_root/$name" init -q
+    git -C "$fixture_root/$name" config user.email "readiness-test@example.invalid"
+    git -C "$fixture_root/$name" config user.name "readiness-test"
+    printf '%s\n' "$name fixture" > "$fixture_root/$name/.fixture"
+    git -C "$fixture_root/$name" add .fixture
+    git -C "$fixture_root/$name" commit -q -m "fixture"
+  done
+}
+
+make_fixture() {
+  fixture_root=$1
+  mkdir -p "$fixture_root"
+  copy_contracts "$fixture_root"
+  create_fake_submodules "$fixture_root"
+}
+
+"$HELPER" --repo-root "$REPO_ROOT" --checked-by readiness-self-test >/dev/null || fail "current HEAD readiness helper returned non-zero"
+validate_yaml "$REPO_ROOT/$OUTPUT_REL" pass -
+
+workspace_status=$(git -C "$REPO_ROOT" status --short -- workspace)
+if [ -n "$workspace_status" ]; then
+  printf '%s\n' "$workspace_status" >&2
+  fail "workspace has tracked or untracked status after helper run"
+fi
+
+fixture="$TMP_ROOT/fixture-pass"
+make_fixture "$fixture"
+"$HELPER" --repo-root "$fixture" --checked-by readiness-self-test >/dev/null || fail "fixture pass run returned non-zero"
+validate_yaml "$fixture/$OUTPUT_REL" pass -
+
+workspace_files=$(find "$fixture/workspace" -type f -print | sed "s#^$fixture/##" | sort)
+if [ "$workspace_files" != "$OUTPUT_REL" ]; then
+  printf '%s\n' "$workspace_files" >&2
+  fail "helper wrote unexpected files for absent workspace"
+fi
+
+printf '%s\n' stale > "$fixture/$OUTPUT_REL"
+"$HELPER" --repo-root "$fixture" --checked-by readiness-self-test >/dev/null || fail "fixture overwrite run returned non-zero"
+if grep -q stale "$fixture/$OUTPUT_REL"; then
+  fail "helper did not overwrite expected readiness YAML"
+fi
+workspace_files=$(find "$fixture/workspace" -type f -print | sed "s#^$fixture/##" | sort)
+if [ "$workspace_files" != "$OUTPUT_REL" ]; then
+  printf '%s\n' "$workspace_files" >&2
+  fail "helper wrote unexpected files for preexisting workspace"
+fi
+
+failure_fixture="$TMP_ROOT/fixture-failure"
+make_fixture "$failure_fixture"
+rm "$failure_fixture/docs/04_IMPLEMENTATION/API_Error_And_Idempotency_Contracts.md"
+if "$HELPER" --repo-root "$failure_fixture" --checked-by readiness-self-test >/dev/null; then
+  fail "failure fixture unexpectedly returned zero"
+fi
+validate_yaml "$failure_fixture/$OUTPUT_REL" block error_idempotency
+
+printf '%s\n' "self-test passed"

--- a/scripts/readiness/self_test.sh
+++ b/scripts/readiness/self_test.sh
@@ -6,6 +6,9 @@ REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
 HELPER="$SCRIPT_DIR/check_readiness.sh"
 OUTPUT_REL="workspace/readiness/readiness_gate_v0_8_1.yaml"
 TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/shud-readiness-test.XXXXXX")
+LIVE_OUTPUT="$REPO_ROOT/$OUTPUT_REL"
+LIVE_COPY="$TMP_ROOT/live-readiness.before"
+LIVE_EXISTED=0
 
 cleanup() {
   rm -rf "$TMP_ROOT"
@@ -17,8 +20,34 @@ fail() {
   exit 1
 }
 
+if [ -e "$LIVE_OUTPUT" ] || [ -L "$LIVE_OUTPUT" ]; then
+  LIVE_EXISTED=1
+  cp -p "$LIVE_OUTPUT" "$LIVE_COPY"
+fi
+
+workspace_status_before=$(git -C "$REPO_ROOT" status --short -- workspace)
+if [ -n "$workspace_status_before" ]; then
+  printf '%s\n' "$workspace_status_before" >&2
+  fail "live workspace was not clean before self-test"
+fi
+
+assert_live_unchanged() {
+  workspace_status_after=$(git -C "$REPO_ROOT" status --short -- workspace)
+  if [ -n "$workspace_status_after" ]; then
+    printf '%s\n' "$workspace_status_after" >&2
+    fail "live workspace has tracked or untracked status after self-test"
+  fi
+  if [ "$LIVE_EXISTED" -eq 1 ]; then
+    if ! cmp -s "$LIVE_COPY" "$LIVE_OUTPUT"; then
+      fail "self-test modified live readiness evidence"
+    fi
+  elif [ -e "$LIVE_OUTPUT" ] || [ -L "$LIVE_OUTPUT" ]; then
+    fail "self-test created live readiness evidence"
+  fi
+}
+
 validate_yaml() {
-  python3 - "$1" "$2" "$3" <<'PY'
+  python3 - "$1" "$2" "$3" "$4" <<'PY'
 import re
 import sys
 from pathlib import Path
@@ -26,6 +55,7 @@ from pathlib import Path
 path = Path(sys.argv[1])
 expected_decision = sys.argv[2]
 expected_gate = sys.argv[3]
+expected_gate_status = sys.argv[4]
 expected_keys = [
     "gitmodules_parse",
     "submodules_checkout",
@@ -37,12 +67,19 @@ expected_keys = [
     "artifact_registry",
     "lock_recovery",
 ]
+valid_statuses = {"pass", "pass_with_notes", "block"}
 
+if not path.is_file():
+    raise SystemExit(f"missing YAML: {path}")
 text = path.read_text(encoding="utf-8")
 if "\t" in text:
     raise SystemExit("YAML contains a tab")
 if not text.startswith("readiness_gate:\n"):
     raise SystemExit("missing readiness_gate root")
+for token in ("  repo_state:\n", "      head: ", "      dirty: ", "        gitlink: ", "        branchish: "):
+    if token not in text:
+        raise SystemExit(f"missing repo/submodule state token: {token.strip()}")
+
 fields = {}
 p0 = {}
 in_p0 = False
@@ -80,10 +117,19 @@ if fields.get("decision") != expected_decision:
     raise SystemExit(f"expected decision {expected_decision}, got {fields.get('decision')}")
 if list(p0.keys()) != expected_keys:
     raise SystemExit(f"unexpected p0 keys: {list(p0.keys())}")
-if expected_gate != "-" and p0.get(expected_gate) == "pass":
-    raise SystemExit(f"expected non-pass gate {expected_gate}")
-if expected_gate == "-" and any(value != "pass" for value in p0.values()):
+if any(value not in valid_statuses for value in p0.values()):
+    raise SystemExit(f"unexpected p0 statuses: {p0}")
+if expected_decision == "pass" and any(value != "pass" for value in p0.values()):
     raise SystemExit(f"expected all p0 gates to pass, got {p0}")
+if expected_decision == "pass_with_notes":
+    if any(value == "block" for value in p0.values()):
+        raise SystemExit(f"pass_with_notes decision cannot contain block: {p0}")
+    if not any(value == "pass_with_notes" for value in p0.values()):
+        raise SystemExit(f"pass_with_notes decision requires at least one noted gate: {p0}")
+if expected_decision == "block" and not any(value == "block" for value in p0.values()):
+    raise SystemExit(f"block decision requires at least one block gate: {p0}")
+if expected_gate != "-" and p0.get(expected_gate) != expected_gate_status:
+    raise SystemExit(f"expected {expected_gate}={expected_gate_status}, got {p0.get(expected_gate)}")
 if note_count < len(expected_keys):
     raise SystemExit("missing per-gate notes")
 PY
@@ -95,16 +141,44 @@ copy_contracts() {
 docs/SPEC_v0.8_Final.md
 docs/03_SPEC/Minimal_Schemas.md
 docs/03_SPEC/Support_Schema_Contracts.md
+docs/03_SPEC/User_Session_And_Audit_Schema.md
+docs/03_SPEC/Idempotency_Concurrency_Locking_Spec.md
+docs/03_SPEC/Runner_Adapter_Contracts.md
+docs/03_SPEC/Workspace_Snapshot_And_Recovery_Spec.md
 docs/04_IMPLEMENTATION/Schemas_APIs_CLIs.md
 docs/04_IMPLEMENTATION/API_Error_And_Idempotency_Contracts.md
-docs/03_SPEC/Artifact_Registry_Spec.md
-docs/03_SPEC/Idempotency_Concurrency_Locking_Spec.md
-docs/03_SPEC/Workspace_Snapshot_And_Recovery_Spec.md'
+docs/03_SPEC/Artifact_Registry_Spec.md'
   printf '%s\n' "$contract_files" | while IFS= read -r file_path; do
     mkdir -p "$fixture_root/$(dirname "$file_path")"
     cp "$REPO_ROOT/$file_path" "$fixture_root/$file_path"
   done
   cp "$REPO_ROOT/.gitmodules" "$fixture_root/.gitmodules"
+}
+
+append_runner_result_definition() {
+  fixture_root=$1
+  cat >> "$fixture_root/docs/03_SPEC/Support_Schema_Contracts.md" <<'EOF'
+
+## Self-test RunnerResult fixture
+
+```ts
+interface RunnerResult {
+  result_id: string;
+  job_id: string;
+  status: "succeeded" | "failed" | "timed_out" | "cancelled";
+  output_paths: string[];
+  created_at: string;
+}
+```
+EOF
+}
+
+init_git_repo() {
+  fixture_root=$1
+  git -C "$fixture_root" init -q
+  git -C "$fixture_root" config user.email "readiness-test@example.invalid"
+  git -C "$fixture_root" config user.name "readiness-test"
+  git -C "$fixture_root" config advice.addEmbeddedRepo false
 }
 
 create_fake_submodules() {
@@ -120,26 +194,43 @@ create_fake_submodules() {
   done
 }
 
-make_fixture() {
+commit_superproject_with_gitlinks() {
   fixture_root=$1
-  mkdir -p "$fixture_root"
-  copy_contracts "$fixture_root"
-  create_fake_submodules "$fixture_root"
+  git -C "$fixture_root" add .gitmodules docs
+  for name in SHUD rSHUD AutoSHUD zero; do
+    git -C "$fixture_root" add "$name" 2>/dev/null
+  done
+  git -C "$fixture_root" commit -q -m "fixture superproject"
 }
 
-"$HELPER" --repo-root "$REPO_ROOT" --checked-by readiness-self-test >/dev/null || fail "current HEAD readiness helper returned non-zero"
-validate_yaml "$REPO_ROOT/$OUTPUT_REL" pass -
+make_fixture() {
+  fixture_root=$1
+  runner_schema=${2:-with-runner}
+  mkdir -p "$fixture_root"
+  init_git_repo "$fixture_root"
+  copy_contracts "$fixture_root"
+  if [ "$runner_schema" = "with-runner" ]; then
+    append_runner_result_definition "$fixture_root"
+  fi
+  create_fake_submodules "$fixture_root"
+  commit_superproject_with_gitlinks "$fixture_root"
+}
 
-workspace_status=$(git -C "$REPO_ROOT" status --short -- workspace)
-if [ -n "$workspace_status" ]; then
-  printf '%s\n' "$workspace_status" >&2
-  fail "workspace has tracked or untracked status after helper run"
-fi
+make_fake_standalone_fixture() {
+  fixture_root=$1
+  mkdir -p "$fixture_root"
+  init_git_repo "$fixture_root"
+  copy_contracts "$fixture_root"
+  append_runner_result_definition "$fixture_root"
+  git -C "$fixture_root" add .gitmodules docs
+  git -C "$fixture_root" commit -q -m "fixture superproject without gitlinks"
+  create_fake_submodules "$fixture_root"
+}
 
 fixture="$TMP_ROOT/fixture-pass"
 make_fixture "$fixture"
 "$HELPER" --repo-root "$fixture" --checked-by readiness-self-test >/dev/null || fail "fixture pass run returned non-zero"
-validate_yaml "$fixture/$OUTPUT_REL" pass -
+validate_yaml "$fixture/$OUTPUT_REL" pass - pass
 
 workspace_files=$(find "$fixture/workspace" -type f -print | sed "s#^$fixture/##" | sort)
 if [ "$workspace_files" != "$OUTPUT_REL" ]; then
@@ -152,11 +243,7 @@ printf '%s\n' stale > "$fixture/$OUTPUT_REL"
 if grep -q stale "$fixture/$OUTPUT_REL"; then
   fail "helper did not overwrite expected readiness YAML"
 fi
-workspace_files=$(find "$fixture/workspace" -type f -print | sed "s#^$fixture/##" | sort)
-if [ "$workspace_files" != "$OUTPUT_REL" ]; then
-  printf '%s\n' "$workspace_files" >&2
-  fail "helper wrote unexpected files for preexisting workspace"
-fi
+validate_yaml "$fixture/$OUTPUT_REL" pass - pass
 
 failure_fixture="$TMP_ROOT/fixture-failure"
 make_fixture "$failure_fixture"
@@ -164,6 +251,97 @@ rm "$failure_fixture/docs/04_IMPLEMENTATION/API_Error_And_Idempotency_Contracts.
 if "$HELPER" --repo-root "$failure_fixture" --checked-by readiness-self-test >/dev/null; then
   fail "failure fixture unexpectedly returned zero"
 fi
-validate_yaml "$failure_fixture/$OUTPUT_REL" block error_idempotency
+validate_yaml "$failure_fixture/$OUTPUT_REL" block error_idempotency block
+
+notes_fixture="$TMP_ROOT/fixture-pass-with-notes"
+make_fixture "$notes_fixture"
+python3 - "$notes_fixture/docs/00_INDEX/CANONICAL_CONTRACTS.md" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+path.write_bytes(text.replace("\n", "\r\n").encode("utf-8"))
+PY
+"$HELPER" --repo-root "$notes_fixture" --checked-by readiness-self-test >/dev/null || fail "pass_with_notes fixture returned non-zero"
+validate_yaml "$notes_fixture/$OUTPUT_REL" pass_with_notes canonical_index pass_with_notes
+
+support_false_fixture="$TMP_ROOT/fixture-support-false-pass"
+make_fixture "$support_false_fixture" without-runner
+if "$HELPER" --repo-root "$support_false_fixture" --checked-by readiness-self-test >/dev/null; then
+  fail "support schema prose-only RunnerResult fixture unexpectedly returned zero"
+fi
+validate_yaml "$support_false_fixture/$OUTPUT_REL" block support_schema block
+
+fake_fixture="$TMP_ROOT/fixture-fake-standalone-submodules"
+make_fake_standalone_fixture "$fake_fixture"
+if "$HELPER" --repo-root "$fake_fixture" --checked-by readiness-self-test >/dev/null; then
+  fail "fake standalone submodule fixture unexpectedly returned zero"
+fi
+validate_yaml "$fake_fixture/$OUTPUT_REL" block submodules_checkout block
+
+mismatch_fixture="$TMP_ROOT/fixture-mismatched-submodule"
+make_fixture "$mismatch_fixture"
+printf '%s\n' "new commit" > "$mismatch_fixture/SHUD/.mismatch"
+git -C "$mismatch_fixture/SHUD" add .mismatch
+git -C "$mismatch_fixture/SHUD" commit -q -m "mismatch"
+if "$HELPER" --repo-root "$mismatch_fixture" --checked-by readiness-self-test >/dev/null; then
+  fail "mismatched submodule fixture unexpectedly returned zero"
+fi
+validate_yaml "$mismatch_fixture/$OUTPUT_REL" block submodules_checkout block
+
+dirty_fixture="$TMP_ROOT/fixture-dirty-submodule"
+make_fixture "$dirty_fixture"
+printf '%s\n' dirty >> "$dirty_fixture/SHUD/.fixture"
+if "$HELPER" --repo-root "$dirty_fixture" --checked-by readiness-self-test >/dev/null; then
+  fail "dirty submodule fixture unexpectedly returned zero"
+fi
+validate_yaml "$dirty_fixture/$OUTPUT_REL" block submodules_checkout block
+
+workspace_symlink_fixture="$TMP_ROOT/fixture-workspace-symlink"
+make_fixture "$workspace_symlink_fixture"
+ln -s docs "$workspace_symlink_fixture/workspace"
+if "$HELPER" --repo-root "$workspace_symlink_fixture" --checked-by readiness-self-test >/dev/null 2>/dev/null; then
+  fail "workspace symlink ancestor fixture unexpectedly returned zero"
+fi
+if [ -e "$workspace_symlink_fixture/docs/readiness/readiness_gate_v0_8_1.yaml" ]; then
+  fail "helper wrote through workspace symlink ancestor"
+fi
+
+readiness_symlink_fixture="$TMP_ROOT/fixture-readiness-symlink"
+make_fixture "$readiness_symlink_fixture"
+mkdir -p "$readiness_symlink_fixture/workspace"
+ln -s ../docs "$readiness_symlink_fixture/workspace/readiness"
+if "$HELPER" --repo-root "$readiness_symlink_fixture" --checked-by readiness-self-test >/dev/null 2>/dev/null; then
+  fail "readiness symlink directory fixture unexpectedly returned zero"
+fi
+if [ -e "$readiness_symlink_fixture/docs/readiness_gate_v0_8_1.yaml" ]; then
+  fail "helper wrote through readiness symlink directory"
+fi
+
+output_symlink_fixture="$TMP_ROOT/fixture-output-symlink"
+make_fixture "$output_symlink_fixture"
+mkdir -p "$output_symlink_fixture/workspace/readiness"
+ln -s ../../docs/00_INDEX/CANONICAL_CONTRACTS.md "$output_symlink_fixture/$OUTPUT_REL"
+if "$HELPER" --repo-root "$output_symlink_fixture" --checked-by readiness-self-test >/dev/null 2>/dev/null; then
+  fail "output symlink fixture unexpectedly returned zero"
+fi
+if [ ! -L "$output_symlink_fixture/$OUTPUT_REL" ]; then
+  fail "helper replaced symlinked output"
+fi
+
+hardlink_fixture="$TMP_ROOT/fixture-hardlink-output"
+make_fixture "$hardlink_fixture"
+mkdir -p "$hardlink_fixture/workspace/readiness"
+printf '%s\n' stale > "$hardlink_fixture/$OUTPUT_REL"
+ln "$hardlink_fixture/$OUTPUT_REL" "$hardlink_fixture/hardlink-peer"
+if "$HELPER" --repo-root "$hardlink_fixture" --checked-by readiness-self-test >/dev/null 2>/dev/null; then
+  fail "hardlinked output fixture unexpectedly returned zero"
+fi
+if ! grep -q stale "$hardlink_fixture/$OUTPUT_REL"; then
+  fail "helper overwrote hardlinked output"
+fi
+
+assert_live_unchanged
 
 printf '%s\n' "self-test passed"


### PR DESCRIPTION
## Summary

Closes #12.

Adds the deterministic M1 P0 readiness helper and records the project-local subagent workflow fixture/profile needed to execute readiness-gated M1 work.

Current readiness result on reviewed head `4d0d87467a8da08c757050a7d3f71a9e98188893`: `decision: block`.

This PR does not unlock #16+. The only blocking P0 gate is `support_schema`, because frozen support schema docs lack definition-level evidence for `RunnerResult`. Follow-up: #40.

## What changed

- Added `scripts/readiness/check_readiness.py` and `check_readiness.sh` to execute the nine P0 gates and write `workspace/readiness/readiness_gate_v0_8_1.yaml`.
- Added `scripts/readiness/self_test.sh` covering pass, block, pass_with_notes, support-schema false-pass, fake/mismatched/dirty submodules, dirty root, static symlink/hardlink boundaries, fd-relative TOCTOU swap cases, root-only workspace ignore behavior, and live-evidence preservation.
- Added `/workspace/` to `.gitignore` so only the repo-root runtime workspace is ignored.
- Added `openspec/project-profile.md` and #12 fixture details in `m1-foundation` for risk/evidence gating.

## Readiness Evidence

Reviewed head SHA: `4d0d87467a8da08c757050a7d3f71a9e98188893`

Command evidence:

- `bash scripts/readiness/check_readiness.sh --repo-root . --checked-by codex-phase6b-postcommit` -> expected nonzero; wrote runtime YAML with `decision: block`
- `bash scripts/readiness/self_test.sh` -> pass
- `python3 -m py_compile scripts/readiness/check_readiness.py` -> pass
- `openspec validate m1-foundation --strict --no-interactive` -> pass
- `git diff --check -- .gitignore scripts/readiness/check_readiness.py scripts/readiness/self_test.sh scripts/readiness/check_readiness.sh` -> pass
- `git check-ignore --no-index -v workspace/readiness/readiness_gate_v0_8_1.yaml` -> matches `.gitignore:31:/workspace/`
- `git check-ignore --no-index -v packages/core/src/workspace/index.ts` -> no match
- `git status --short -- workspace` -> empty

Per-gate result:

| Gate | Result | Input / evidence |
| --- | --- | --- |
| `gitmodules_parse` | pass | `.gitmodules` defines path and url for SHUD, rSHUD, AutoSHUD, zero |
| `submodules_checkout` | pass | gitlink equals checkout HEAD and clean for all four submodules |
| `canonical_index` | pass | canonical index identifies unique sources for schema/API/events/paths/artifacts/locks/recovery |
| `core_schema` | pass | core object status enums and `AnalysisPlan.mode` align |
| `support_schema` | block | missing definition-level evidence for `RunnerResult` |
| `api_registry` | pass | canonical/convenience API layering is explicit |
| `error_idempotency` | pass | non-2xx envelope, `Idempotency-Key`, mismatch handling, retry policy defined |
| `artifact_registry` | pass | artifact type, retention, redaction, `evidence_usable`, manifest rules defined |
| `lock_recovery` | pass | collect/export/notification/PI decision idempotency and startup lock recovery rules defined |

Repo/submodule state:

- root: `4d0d87467a8da08c757050a7d3f71a9e98188893`, branch `feat/issue-12-m1-foundation`, clean
- SHUD: gitlink/head `3aec65755926c478e13ca7d4fea80715e4e90345`, clean
- rSHUD: gitlink/head `2b7742e32ea323a57fd0a947dc2cea67bfd0afd1`, clean
- AutoSHUD: gitlink/head `f421445340f70b8cb160ce58cefb066751628593`, clean
- zero: gitlink/head `13e25c116c62411e6ee8a0ad67a6c53dc7c376c6`, clean

Downstream action: #16+ remains frozen until #40 lands a governed `RunnerResult` support schema fix and the readiness helper is rerun with `decision: pass` or `pass_with_notes`.

## Agent Review

- Reviewer agents used: 6-reviewer full cross-review after each repair round.
- Reviewed head SHA: `4d0d87467a8da08c757050a7d3f71a9e98188893`
- Review result: code/config findings closed; remaining evidence-lineage blocker resolved by this PR body and #12 issue comment.
- Findings closed: support-schema false pass, repo/submodule state identity, workspace path safety/static symlink/hardlink handling, live self-test evidence overwrite, `pass_with_notes` aggregation, PR/issue evidence mismatch, fd-relative TOCTOU write safety, root dirty non-unlocking state, and over-broad `workspace/` ignore rule.
- OpenSpec change: `m1-foundation`; fixture level: expanded; selected risk packs: public script entry, config/project setup, file IO/path safety/overwrite, schema/field names, shared-state gating, legacy/submodule compatibility, error handling/partial outputs, documentation/evidence, scientific governance/evidence lineage, SHUD/rSHUD/AutoSHUD compatibility, Zero boundary.

