### PR TITLE
docs(readiness): define RunnerResult support schema

### DIFF
--- a/docs/03_SPEC/Support_Schema_Contracts.md
+++ b/docs/03_SPEC/Support_Schema_Contracts.md
@@ -165,6 +165,33 @@ interface FailureRecord {
 }
 ```
 
+## 4.1 RunnerResult
+
+RunnerResult 是 support schema 中持久化的 runner evidence projection，用于把 `RunnerCollectResult` 的 collect 语义落盘并关联 TaskCard、RunJob、artifact 和错误记录。`RunnerCollectResult` 仍是 runner adapter 的返回契约；RunnerResult 不替代该接口，只固定可持久化、可审计、可被报告引用的证据结构。
+
+```ts
+interface RunnerResult {
+  result_id: string;
+  task_id: string;
+  job_id: string;
+  run_id?: string;
+  analysis_plan_id?: string;
+  runner_kind: "local_direct" | "local_job" | "docker_job" | "slurm";
+  status: "succeeded" | "failed" | "cancelled" | "timed_out" | "collected";
+  exit_code?: number;
+  started_at?: string;
+  finished_at?: string;
+  wall_seconds?: number;
+  peak_memory_mb?: number;
+  stdout_path: string;
+  stderr_path: string;
+  output_paths: string[];
+  artifact_refs: string[];
+  error_id?: string;
+  created_at: string;
+}
+```
+
 ## 5. PiGate
 
 ```ts

--- a/scripts/readiness/self_test.sh
+++ b/scripts/readiness/self_test.sh
@@ -181,6 +181,25 @@ interface RunnerResult {
 EOF
 }
 
+strip_runner_result_definition() {
+  fixture_root=$1
+  python3 - "$fixture_root/docs/03_SPEC/Support_Schema_Contracts.md" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = re.sub(
+    r"\n## (?:4\.1 RunnerResult|Self-test RunnerResult fixture)\n\n.*?(?=\n## [0-9]+(?:\.[0-9]+)?\.? |\Z)",
+    "\n",
+    text,
+    flags=re.DOTALL,
+)
+path.write_text(text, encoding="utf-8")
+PY
+}
+
 init_git_repo() {
   fixture_root=$1
   git -C "$fixture_root" init -q
@@ -219,7 +238,11 @@ make_fixture() {
   init_git_repo "$fixture_root"
   copy_contracts "$fixture_root"
   if [ "$runner_schema" = "with-runner" ]; then
-    append_runner_result_definition "$fixture_root"
+    if ! grep -q 'interface RunnerResult' "$fixture_root/docs/03_SPEC/Support_Schema_Contracts.md"; then
+      append_runner_result_definition "$fixture_root"
+    fi
+  else
+    strip_runner_result_definition "$fixture_root"
   fi
   create_fake_submodules "$fixture_root"
   commit_superproject_with_gitlinks "$fixture_root"


### PR DESCRIPTION
## Summary

Closes #40.

Adds definition-level support schema evidence for `RunnerResult`, the only blocker found by the #12 readiness gate.

Current readiness result on reviewed head `9490fa6e08dbb4122b8b64f2bac543b643182a67`: `decision: pass`.

## What changed

- Added `## 4.1 RunnerResult` to `docs/03_SPEC/Support_Schema_Contracts.md`.
- Defined `interface RunnerResult` as the persisted runner evidence projection aligned with, but not replacing, `RunnerCollectResult`.
- Updated `scripts/readiness/self_test.sh` so the support-schema false-pass fixture remains synthetic after the real docs now include `RunnerResult`.

## Readiness Evidence

Reviewed head SHA: `9490fa6e08dbb4122b8b64f2bac543b643182a67`

Command evidence:

- `rg -n "interface RunnerResult" docs/03_SPEC/Support_Schema_Contracts.md` -> `173:interface RunnerResult {`
- `bash scripts/readiness/check_readiness.sh --repo-root . --checked-by codex-issue40-postcommit-final` -> `decision: pass`
- `bash scripts/readiness/self_test.sh` -> pass
- `python3 -m py_compile scripts/readiness/check_readiness.py` -> pass
- `openspec validate m1-foundation --strict --no-interactive` -> pass
- `git diff --check HEAD~2..HEAD` -> pass

Per-gate result after #40:

| Gate | Result |
| --- | --- |
| `gitmodules_parse` | pass |
| `submodules_checkout` | pass |
| `canonical_index` | pass |
| `core_schema` | pass |
| `support_schema` | pass |
| `api_registry` | pass |
| `error_idempotency` | pass |
| `artifact_registry` | pass |
| `lock_recovery` | pass |

Downstream action: #16+ can unlock after this PR merges, because the #12 readiness helper now reports `decision: pass` on a clean committed root.

