### PR TITLE
M1-2.1 monorepo skeleton

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,1 @@
+# Bun workspace configuration for SHUD-Harness.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "shud-harness",
+  "private": true,
+  "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "check": "bun run typecheck"
+  },
+  "devDependencies": {
+    "typescript": "5.8.3"
+  }
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@shud-harness/backend",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@shud-harness/core": "workspace:*"
+  }
+}

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,0 +1,16 @@
+import {
+  SHUD_HARNESS_CORE_PACKAGE,
+  ZERO_PROVISIONAL_REFERENCE
+} from "@shud-harness/core";
+
+export * from "./middleware/index";
+export * from "./routes/index";
+export * from "./ws/index";
+
+export const SHUD_HARNESS_BACKEND_PACKAGE = "@shud-harness/backend" as const;
+
+export const backendSkeleton = {
+  packageName: SHUD_HARNESS_BACKEND_PACKAGE,
+  corePackage: SHUD_HARNESS_CORE_PACKAGE,
+  zeroReferenceStatus: ZERO_PROVISIONAL_REFERENCE.status
+} as const;

--- a/packages/backend/src/middleware/index.ts
+++ b/packages/backend/src/middleware/index.ts
@@ -1,0 +1,3 @@
+export const BACKEND_MIDDLEWARE_NAMESPACE = "backend/middleware" as const;
+
+export type BackendMiddlewareNamespace = typeof BACKEND_MIDDLEWARE_NAMESPACE;

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -1,0 +1,3 @@
+export const BACKEND_ROUTES_NAMESPACE = "backend/routes" as const;
+
+export type BackendRoutesNamespace = typeof BACKEND_ROUTES_NAMESPACE;

--- a/packages/backend/src/ws/index.ts
+++ b/packages/backend/src/ws/index.ts
@@ -1,0 +1,3 @@
+export const BACKEND_WS_NAMESPACE = "backend/ws" as const;
+
+export type BackendWsNamespace = typeof BACKEND_WS_NAMESPACE;

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@shud-harness/core",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  }
+}

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1,0 +1,10 @@
+export const CORE_AGENT_MODULES = [
+  "coordinator",
+  "explorer",
+  "worker",
+  "reviewer",
+  "park-resume",
+  "research-closure"
+] as const;
+
+export type CoreAgentModule = (typeof CORE_AGENT_MODULES)[number];

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -1,0 +1,2 @@
+export * from "./schemas/index";
+export * from "./services/index";

--- a/packages/core/src/domain/schemas/index.ts
+++ b/packages/core/src/domain/schemas/index.ts
@@ -1,0 +1,3 @@
+export const CORE_SCHEMA_NAMESPACE = "core/domain/schemas" as const;
+
+export type CoreSchemaNamespace = typeof CORE_SCHEMA_NAMESPACE;

--- a/packages/core/src/domain/services/index.ts
+++ b/packages/core/src/domain/services/index.ts
@@ -1,0 +1,3 @@
+export const CORE_SERVICE_NAMESPACE = "core/domain/services" as const;
+
+export type CoreServiceNamespace = typeof CORE_SERVICE_NAMESPACE;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./agent/index";
+export * from "./domain/index";
+export * from "./tools/index";
+export * from "./zero-reference";
+
+export const SHUD_HARNESS_CORE_PACKAGE = "@shud-harness/core" as const;

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -1,0 +1,8 @@
+export const CORE_TOOL_MODULES = [
+  "shud-build",
+  "shud-run",
+  "rshud-parse",
+  "water-balance"
+] as const;
+
+export type CoreToolModule = (typeof CORE_TOOL_MODULES)[number];

--- a/packages/core/src/zero-reference.ts
+++ b/packages/core/src/zero-reference.ts
@@ -1,0 +1,13 @@
+export const ZERO_PROVISIONAL_REFERENCE = {
+  status: "provisional-pending-issue-17",
+  selectedShape: "runtime-entrypoint-reference",
+  submodulePath: "zero",
+  pinnedCommit: "13e25c116c62411e6ee8a0ad67a6c53dc7c376c6",
+  runtimeEntrypoint: "zero/apps/server/src/cli.ts",
+  designReference: "openspec/changes/m1-foundation/design.md#decisions",
+  designDecision: 3,
+  finalizationIssue: 17,
+  finalizationTask: "3.1"
+} as const;
+
+export type ZeroProvisionalReference = typeof ZERO_PROVISIONAL_REFERENCE;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@shud-harness/frontend",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@shud-harness/core": "workspace:*"
+  }
+}

--- a/packages/frontend/src/api/index.ts
+++ b/packages/frontend/src/api/index.ts
@@ -1,0 +1,3 @@
+export const FRONTEND_API_NAMESPACE = "frontend/api" as const;
+
+export type FrontendApiNamespace = typeof FRONTEND_API_NAMESPACE;

--- a/packages/frontend/src/components/index.ts
+++ b/packages/frontend/src/components/index.ts
@@ -1,0 +1,3 @@
+export const FRONTEND_COMPONENTS_NAMESPACE = "frontend/components" as const;
+
+export type FrontendComponentsNamespace = typeof FRONTEND_COMPONENTS_NAMESPACE;

--- a/packages/frontend/src/hooks/index.ts
+++ b/packages/frontend/src/hooks/index.ts
@@ -1,0 +1,3 @@
+export const FRONTEND_HOOKS_NAMESPACE = "frontend/hooks" as const;
+
+export type FrontendHooksNamespace = typeof FRONTEND_HOOKS_NAMESPACE;

--- a/packages/frontend/src/index.ts
+++ b/packages/frontend/src/index.ts
@@ -1,0 +1,18 @@
+import {
+  SHUD_HARNESS_CORE_PACKAGE,
+  ZERO_PROVISIONAL_REFERENCE
+} from "@shud-harness/core";
+
+export * from "./api/index";
+export * from "./components/index";
+export * from "./hooks/index";
+export * from "./layouts/index";
+export * from "./pages/index";
+
+export const SHUD_HARNESS_FRONTEND_PACKAGE = "@shud-harness/frontend" as const;
+
+export const frontendSkeleton = {
+  packageName: SHUD_HARNESS_FRONTEND_PACKAGE,
+  corePackage: SHUD_HARNESS_CORE_PACKAGE,
+  zeroReferenceStatus: ZERO_PROVISIONAL_REFERENCE.status
+} as const;

--- a/packages/frontend/src/layouts/index.ts
+++ b/packages/frontend/src/layouts/index.ts
@@ -1,0 +1,3 @@
+export const FRONTEND_LAYOUTS_NAMESPACE = "frontend/layouts" as const;
+
+export type FrontendLayoutsNamespace = typeof FRONTEND_LAYOUTS_NAMESPACE;

--- a/packages/frontend/src/pages/index.ts
+++ b/packages/frontend/src/pages/index.ts
@@ -1,0 +1,3 @@
+export const FRONTEND_PAGES_NAMESPACE = "frontend/pages" as const;
+
+export type FrontendPagesNamespace = typeof FRONTEND_PAGES_NAMESPACE;

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "baseUrl": ".",
+    "paths": {
+      "@shud-harness/core": [
+        "packages/core/src/index.ts"
+      ],
+      "@shud-harness/core/*": [
+        "packages/core/src/*"
+      ]
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": [
+    "packages/**/*.ts",
+    "packages/**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "zero",
+    "SHUD",
+    "rSHUD",
+    "AutoSHUD",
+    "workspace"
+  ]
+}


### PR DESCRIPTION
Closes #16

## Summary
- Add the root Bun workspace skeleton for packages/core, packages/backend, and packages/frontend.
- Add shared TypeScript config and package exports so backend/frontend import @shud-harness/core.
- Record the zero reference as provisional runtime-entrypoint metadata pinned to zero@13e25c1; #17 remains responsible for validating the final technical shape.

## Boundary Notes
- No docs or submodule sources changed.
- Ran bun install with temporary Bun 1.2.19; the generated bun.lock is intentionally not committed because #14 owns packageManager, lockfile, and DependencyLock.

## Verification
- pnpm --package=bun@1.2.19 dlx bun install
- pnpm --package=bun@1.2.19 dlx bun run typecheck
- pnpm --package=typescript@5.8.3 dlx tsc --noEmit -p tsconfig.json
- openspec validate m1-foundation --strict --no-interactive
- git diff --check
- git -C zero diff --quiet
- git -C zero rev-parse HEAD == 13e25c116c62411e6ee8a0ad67a6c53dc7c376c6
