### PR TITLE
M1-3.1 policy gate wrapper spike

### DIFF
--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -29,7 +29,7 @@
 
 1. **策略门注入点 = 工具注册层横切包装**。注册时统一 wrap execute（`ToolBase.beforeExecute` throw 即拒），先过 kernel 校验再放行；loop 级 hook 仅作观测。备选"改 Zero 内核"违反 diff=0 与升级成本约束；备选"loop hook 阻断"被 zero@13e25c1 实测否决（不可否决型钩子）。出处：ADR-0001、[Zero_Reuse_Matrix §8](../../../docs/02_ARCHITECTURE/Zero_Reuse_Matrix.md)、[Control_Kernel §5](../../../docs/02_ARCHITECTURE/Control_Kernel.md)。
 2. **spike 内部顺序**：条 1（横切包装）先行；注册期 lint 与 guard_class 标注挂同一横切点其后；条 3 依赖 role→tool_id 映射表（比对基准）。判定条款：任一条 2 人周内不绿 → ADR-0001 revisit，备选顺序按 2026-07-02 修订注（① 自建薄工具注册层 ② Claude Agent SDK 迁移），不带病继续。
-3. **zero 引用姿势 [GRILL-1，已定案 2026-07-03]**：M1 不 fork——zero 保持根目录 submodule 钉 13e25c1，packages/* 相对引用；fork 决策挂 ADR-0001 触发器。引用的技术形态（workspace 纳入 zero 子包 vs `file:` 依赖 vs 运行时入口加载）在 spike 条 1 实现时确认并回写本节——zero 自身是 Bun workspace（9 packages），嵌套 workspace 的解析行为需实测，不在纸面裁决。
+3. **zero 引用姿势 [GRILL-1，已定案 2026-07-03；#17 实测回写]**：M1 不 fork——zero 保持根目录 submodule 钉 13e25c1，fork 决策挂 ADR-0001 触发器。引用技术形态在 spike 条 1 已实测定形为 **root Bun workspace 纳入 `zero/packages/*` + SHUD 包按需声明 `@zero-os/*` workspace 依赖**，当前 `packages/core` 直接依赖 `@zero-os/core` / `@zero-os/shared`。实测证据：临时真实目录 Bun workspace（`workspaces=["packages/*","zero/packages/*"]` + `@zero-os/core@workspace:*`）安装通过，当前根 workspace 下 `import("@zero-os/core")` 可解析 `BaseTool` / `ToolRegistry`；`file:` 直连 `zero/packages/core` 失败，因为 zero 内部 `@zero-os/shared|model|observe|secrets` 仍是 `workspace:*` 传递依赖；直接加载 `zero/apps/server/src/cli/dispatch.ts` 会继续引入 app 级 server 依赖（如 `qrcode-terminal`），依赖面超出 M1 package adapter 目标。因此 M1 定形为 workspace-package-reference；不纳入 `zero/apps/*`，不改 zero 源码，`git -C zero diff --quiet` 仍为硬验收。
 4. **拒绝载荷统一走 `ErrorRecord.remediation`**：`{next_action ∈ escalate_to_pi|open_gate|adjust_scope|fix_and_retry|abort, hint, ref}`（权威源 [Support_Schema_Contracts §3](../../../docs/03_SPEC/Support_Schema_Contracts.md)）；spawn 剖面超集拒绝断言 `next_action=adjust_scope`。拒绝而不导航制造重试风暴（Control_Kernel §5 拒绝载荷约定）。拒绝事件的 WS 出口不新增事件类型——复用 [WebSocket_Protocol §3](../../../docs/03_SPEC/WebSocket_Protocol.md) 注册表既有的 `tool.failed`（payload 携带含 remediation 的 ErrorRecord）；audit 最小行字段（event/tool_id/rule/decision/ts）与无任务上下文时的 fixture 任务路径（`workspace/tasks/TASK-M1-SPIKE/audit/`）见 policy-gate-spike spec。
 5. **role→tool_id 映射表 = packages/core 常量 + 快照测试**。Roles_and_Boundaries §0 只有权限类别散文，本表是唯一具象化落点，也是 spike 条 3 子集校验的比对基准。各角色工具面已 PI 确认（[GRILL-2] 定案 2026-07-03，附表见 tool-registry-governance spec），据此固化快照。
 6. **GLM provider 零开发接入**：zero `providers:` 块（`api_type: openai_chat_completions` + `base_url` + `api_key_ref` + `fallback_chain` + 按功能选模型）。`api_key_ref` 遵 [Config_Secrets §3](../../../docs/03_SPEC/Config_Secrets_And_Environment_Spec.md) SecretRef 形态（`env:GLM_API_KEY`，provider=env，purpose=llm；[GRILL-3] 定案 2026-07-03，Config_Secrets §4 已补行）。冒烟判定 = 最小 prompt 一次往返得到非空 completion 且实际命中配置的 `base_url`，exit 0。
@@ -55,7 +55,7 @@
 ## Open Questions
 
 - [GRILL-1..3] 已全部定案（2026-07-03 M1 grill，记录见 [ADR-0002 开放项处置节](../../../docs/adr/0002-mvp-reality-anchoring.md)）：不 fork + submodule 引用；工具面照准草案；`GLM_API_KEY`（Config_Secrets §4 已补行，账本例外批次 4）。
-- zero 包引用技术形态（workspace 纳入 vs `file:` 依赖 vs 运行时入口加载）：**唯一存留开放项**，spike 条 1 实现时实测确认并回写 Decision 3。
+- zero 包引用技术形态（workspace 纳入 vs `file:` 依赖 vs 运行时入口加载）：已由 #17 spike 条 1 实测解决并回写 Decision 3；M1 采用 workspace-package-reference。
 
 ## Subagent Workflow Fixture — Issue #12
 

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "private": true,
   "type": "module",
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "zero/packages/*"
   ],
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "check": "bun run typecheck"
+    "test:policy-gate": "bun test ./packages/core/src/tools/policy-gate-registry.test.ts",
+    "check": "bun run typecheck && bun run test:policy-gate"
   },
   "devDependencies": {
     "typescript": "5.8.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,5 +10,9 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@zero-os/core": "workspace:*",
+    "@zero-os/shared": "workspace:*"
   }
 }

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -6,3 +6,6 @@ export const CORE_TOOL_MODULES = [
 ] as const;
 
 export type CoreToolModule = (typeof CORE_TOOL_MODULES)[number];
+
+export * from "./policy-gate-registry";
+export * from "./zero-reference-shape";

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { BaseTool, ToolRegistry } from "@zero-os/core";
+import type { ToolContext, ToolLogger, ToolResult } from "@zero-os/shared";
+import {
+  assertAllToolsPolicyGated,
+  assertPolicyGatedToolRegistry,
+  createPolicyGatedToolRegistry,
+  isPolicyGatedTool,
+  wrapToolWithPolicyGate,
+  type PolicyGateEvaluator
+} from "./policy-gate-registry";
+
+describe("policy-gated zero tool registry", () => {
+  test("denies before executing the underlying bash BaseTool", async () => {
+    const bashTool = new RecordingTool("bash");
+    const registry = createPolicyGatedToolRegistry([bashTool], {
+      evaluate: denyAll("raw data writes are blocked")
+    });
+
+    const result = await registry.get("bash")?.run(createToolContext("worker"), {
+      command: "printf nope > data/raw/input.csv"
+    });
+
+    expect(result?.success).toBe(false);
+    expect(result?.output).toContain("policy_gate_denied");
+    expect(result?.output).toContain("raw data writes are blocked");
+    expect(bashTool.calls).toBe(0);
+  });
+
+  test("wraps all registered zero tools including spawn, bash, and edit", async () => {
+    const tools = [
+      new RecordingTool("spawn_agent"),
+      new RecordingTool("bash"),
+      new RecordingTool("edit")
+    ];
+
+    const registry = createPolicyGatedToolRegistry(tools, {
+      evaluate: async () => ({ decision: "allow" })
+    });
+
+    assertPolicyGatedToolRegistry(registry);
+    expect(registry.getDefinitions().map((definition) => definition.name)).toEqual([
+      "spawn_agent",
+      "bash",
+      "edit"
+    ]);
+
+    for (const tool of registry.list()) {
+      const result = await tool.run(createToolContext("coordinator"), {});
+      expect(result.success).toBe(true);
+      expect(isPolicyGatedTool(tool)).toBe(true);
+    }
+
+    expect(tools.map((tool) => tool.calls)).toEqual([1, 1, 1]);
+  });
+
+  test("assembly fails when any registered zero tool bypasses the wrapper", () => {
+    const registry = new ToolRegistry();
+    registry.register(
+      wrapToolWithPolicyGate(new RecordingTool("bash"), {
+        evaluate: async () => ({ decision: "allow" })
+      })
+    );
+    registry.register(new RecordingTool("edit"));
+
+    expect(() => assertPolicyGatedToolRegistry(registry)).toThrow("edit");
+  });
+
+  test("forged policy-gated symbol does not satisfy assembly", () => {
+    const forgedTool = new RecordingTool("edit");
+    (forgedTool as unknown as Record<symbol, true>)[Symbol.for("shud-harness.policy-gated-tool")] =
+      true;
+
+    expect(isPolicyGatedTool(forgedTool)).toBe(false);
+    expect(() => assertAllToolsPolicyGated([forgedTool])).toThrow("edit");
+  });
+});
+
+function denyAll(reason: string): PolicyGateEvaluator {
+  return async () => ({
+    decision: "deny",
+    reason,
+    remediation: {
+      next_action: "adjust_scope",
+      hint: "Use a governed workspace path instead of data/raw.",
+      ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+    }
+  });
+}
+
+class RecordingTool extends BaseTool {
+  description: string;
+  parameters: Record<string, unknown> = {
+    type: "object",
+    additionalProperties: true
+  };
+  calls = 0;
+
+  constructor(readonly name: string) {
+    super();
+    this.description = `Test tool ${name}`;
+  }
+
+  protected async execute(): Promise<ToolResult> {
+    this.calls += 1;
+    return {
+      success: true,
+      output: `${this.name} executed`,
+      outputSummary: `${this.name} executed`
+    };
+  }
+}
+
+function createToolContext(role: string): ToolContext & { role: string } {
+  return {
+    role,
+    sessionId: "TEST-SESSION",
+    workDir: "/tmp/shud-harness-test",
+    logger: testLogger
+  };
+}
+
+const testLogger: ToolLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {}
+};

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -1,0 +1,201 @@
+import { BaseTool, ToolRegistry } from "@zero-os/core";
+import type { ToolContext, ToolDefinition, ToolResult } from "@zero-os/shared";
+
+export type HarnessRole = "coordinator" | "repo_explorer" | "worker" | "coder" | "reviewer";
+
+export interface PolicyGateRemediation {
+  next_action: "escalate_to_pi" | "open_gate" | "adjust_scope" | "fix_and_retry" | "abort";
+  hint: string;
+  ref: string;
+}
+
+export type PolicyGateDecision =
+  | {
+      decision: "allow";
+    }
+  | {
+      decision: "deny";
+      reason: string;
+      remediation?: PolicyGateRemediation;
+    };
+
+export interface PolicyGateToolCall {
+  toolId: string;
+  role: HarnessRole | "unknown";
+  input: unknown;
+  workDir?: string;
+}
+
+export interface PolicyGateEvaluationContext {
+  tool: BaseTool;
+  toolContext: ToolContext;
+}
+
+export type PolicyGateEvaluator = (
+  call: PolicyGateToolCall,
+  context: PolicyGateEvaluationContext
+) => PolicyGateDecision | Promise<PolicyGateDecision>;
+
+export interface PolicyGateWrapperOptions {
+  toolId?: string;
+  role?: HarnessRole;
+  evaluate: PolicyGateEvaluator;
+}
+
+export type PolicyGatedTool = BaseTool & {
+  readonly innerTool: BaseTool;
+  readonly policyGateToolId: string;
+};
+
+const policyGatedTools = new WeakSet<BaseTool>();
+
+export function wrapToolWithPolicyGate(
+  tool: BaseTool,
+  options: PolicyGateWrapperOptions
+): PolicyGatedTool {
+  if (isPolicyGatedTool(tool)) {
+    return tool;
+  }
+
+  const wrapped = new PolicyGatedBaseToolAdapter(tool, options);
+  policyGatedTools.add(wrapped);
+  return wrapped;
+}
+
+export function wrapAllRegisteredTools(
+  tools: readonly BaseTool[],
+  options: Omit<PolicyGateWrapperOptions, "toolId">
+): PolicyGatedTool[] {
+  const wrappedTools = tools.map((tool) =>
+    wrapToolWithPolicyGate(tool, {
+      ...options,
+      toolId: tool.name
+    })
+  );
+  assertAllToolsPolicyGated(wrappedTools);
+  return wrappedTools;
+}
+
+export function createPolicyGatedToolRegistry(
+  tools: readonly BaseTool[],
+  options: Omit<PolicyGateWrapperOptions, "toolId">
+): ToolRegistry {
+  const registry = new ToolRegistry();
+  for (const tool of wrapAllRegisteredTools(tools, options)) {
+    registry.register(tool);
+  }
+  assertPolicyGatedToolRegistry(registry);
+  return registry;
+}
+
+export function assertPolicyGatedToolRegistry(registry: ToolRegistry): void {
+  assertAllToolsPolicyGated(registry.list());
+}
+
+export function assertAllToolsPolicyGated(tools: readonly BaseTool[]): void {
+  const unwrappedToolIds = tools
+    .filter((tool) => !isPolicyGatedTool(tool))
+    .map((tool) => tool.name || "<unknown>");
+
+  if (unwrappedToolIds.length > 0) {
+    throw new Error(
+      `Policy-gated tool assembly failed; unwrapped tool ids: ${unwrappedToolIds.join(", ")}`
+    );
+  }
+}
+
+export function isPolicyGatedTool(tool: BaseTool): tool is PolicyGatedTool {
+  return policyGatedTools.has(tool);
+}
+
+class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
+  readonly policyGateToolId: string;
+
+  constructor(
+    readonly innerTool: BaseTool,
+    private readonly options: PolicyGateWrapperOptions
+  ) {
+    super();
+    this.policyGateToolId = options.toolId ?? innerTool.name;
+    this.kind = innerTool.kind;
+    this.requiredModelCapabilities = innerTool.requiredModelCapabilities;
+  }
+
+  get name(): string {
+    return this.innerTool.name;
+  }
+
+  get description(): string {
+    return this.innerTool.description;
+  }
+
+  get parameters(): Record<string, unknown> {
+    return this.innerTool.parameters;
+  }
+
+  toDefinition(): ToolDefinition {
+    return this.innerTool.toDefinition();
+  }
+
+  async run(toolContext: ToolContext, input: unknown): Promise<ToolResult> {
+    const decision = await this.options.evaluate(
+      {
+        toolId: this.policyGateToolId,
+        role: this.options.role ?? resolveRole(toolContext),
+        input,
+        workDir: toolContext.workDir
+      },
+      {
+        tool: this.innerTool,
+        toolContext
+      }
+    );
+
+    if (decision.decision === "deny") {
+      return buildPolicyGateDeniedResult(this.policyGateToolId, decision);
+    }
+
+    return this.innerTool.run(toolContext, input);
+  }
+
+  protected async execute(): Promise<ToolResult> {
+    throw new Error("PolicyGatedBaseToolAdapter delegates through run().");
+  }
+}
+
+function buildPolicyGateDeniedResult(
+  toolId: string,
+  decision: Extract<PolicyGateDecision, { decision: "deny" }>
+): ToolResult {
+  const payload = {
+    error: "policy_gate_denied",
+    tool_id: toolId,
+    reason: decision.reason,
+    ...(decision.remediation ? { remediation: decision.remediation } : {})
+  };
+
+  return {
+    success: false,
+    output: JSON.stringify(payload),
+    outputSummary: `Policy gate denied ${toolId}: ${decision.reason}`
+  };
+}
+
+function resolveRole(toolContext: ToolContext): HarnessRole | "unknown" {
+  const contextWithRole = toolContext as ToolContext & {
+    role?: unknown;
+    agentRole?: unknown;
+  };
+  const role = contextWithRole.role ?? contextWithRole.agentRole;
+  return isHarnessRole(role) ? role : "unknown";
+}
+
+function isHarnessRole(value: unknown): value is HarnessRole {
+  return (
+    value === "coordinator" ||
+    value === "repo_explorer" ||
+    value === "worker" ||
+    value === "coder" ||
+    value === "reviewer"
+  );
+}

--- a/packages/core/src/tools/zero-reference-shape.ts
+++ b/packages/core/src/tools/zero-reference-shape.ts
@@ -1,0 +1,29 @@
+export const ZERO_REFERENCE_SHAPE_DECISION = {
+  selectedShape: "workspace-package-reference",
+  selectedAt: "2026-07-03",
+  rootWorkspacePatterns: ["packages/*", "zero/packages/*"],
+  packageDependencies: ["@zero-os/core", "@zero-os/shared"],
+  zeroPinnedCommit: "13e25c116c62411e6ee8a0ad67a6c53dc7c376c6",
+  evidence: [
+    {
+      shape: "workspace-package-reference",
+      result: "pass",
+      command:
+        "temporary Bun workspace with workspaces=['packages/*','zero/packages/*'] and @zero-os/core@workspace:* installed successfully"
+    },
+    {
+      shape: "file-dependency",
+      result: "fail",
+      reason:
+        "direct file:@zero/packages/core cannot resolve zero's transitive workspace:* dependencies such as @zero-os/shared, @zero-os/model, @zero-os/observe, and @zero-os/secrets"
+    },
+    {
+      shape: "runtime-entrypoint-loading",
+      result: "fail",
+      reason:
+        "direct import of zero/apps/server/src/cli/dispatch.ts first requires zero packages and then app-level server dependencies such as qrcode-terminal; this would broaden M1 beyond the package adapter surface"
+    }
+  ]
+} as const;
+
+export type ZeroReferenceShapeDecision = typeof ZERO_REFERENCE_SHAPE_DECISION;

--- a/packages/core/src/zero-reference.ts
+++ b/packages/core/src/zero-reference.ts
@@ -1,13 +1,17 @@
-export const ZERO_PROVISIONAL_REFERENCE = {
-  status: "provisional-pending-issue-17",
-  selectedShape: "runtime-entrypoint-reference",
+export const ZERO_REFERENCE = {
+  status: "finalized-by-issue-17",
+  selectedShape: "workspace-package-reference",
   submodulePath: "zero",
   pinnedCommit: "13e25c116c62411e6ee8a0ad67a6c53dc7c376c6",
-  runtimeEntrypoint: "zero/apps/server/src/cli.ts",
+  rootWorkspacePatterns: ["packages/*", "zero/packages/*"],
+  dependencyPackages: ["@zero-os/core", "@zero-os/shared"],
   designReference: "openspec/changes/m1-foundation/design.md#decisions",
   designDecision: 3,
   finalizationIssue: 17,
   finalizationTask: "3.1"
 } as const;
 
-export type ZeroProvisionalReference = typeof ZERO_PROVISIONAL_REFERENCE;
+export const ZERO_PROVISIONAL_REFERENCE = ZERO_REFERENCE;
+
+export type ZeroReference = typeof ZERO_REFERENCE;
+export type ZeroProvisionalReference = ZeroReference;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,5 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "include": [
     "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
   ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,9 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
+    "types": [
+      "bun-types"
+    ],
     "resolveJsonModule": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "SHUD",
     "rSHUD",
     "AutoSHUD",
-    "workspace"
+    "workspace",
+    "packages/**/*.test.ts"
   ]
 }


### PR DESCRIPTION
Closes #17

## Summary
- Add a policy-gated tool wrapper for registered tools, including deny-before-run behavior and an assembly assertion that rejects unwrapped tools by id.
- Add Bun tests for bash deny-before-execute, spawn/bash/edit full wrapping, and unwrapped-tool assembly failure.
- Finalize the Zero reference shape as root Bun workspace inclusion of zero/packages/* with @zero-os/* workspace dependencies, and write the #17 probe conclusion back to design.md Decision 3.

## Boundary Notes
- zero remains a submodule pinned at 13e25c1 with no source changes.
- Root bun.lock is intentionally not committed because #14 owns packageManager, lockfile, and DependencyLock.
- The selected Zero shape is package workspace reference, not direct zero/apps runtime entrypoint loading.

## Zero Shape Probe Evidence
- workspace package reference: temp real-directory Bun workspace with workspaces=[packages/*, zero/packages/*] and @zero-os/core@workspace:* installed successfully; current root workspace resolves import("@zero-os/core") to BaseTool/ToolRegistry.
- file: dependency: direct file: zero/packages/core failed because zero internal @zero-os/shared|model|observe|secrets remain workspace:* transitive deps.
- runtime entrypoint: direct import of zero/apps/server/src/cli/dispatch.ts pulls app-level server deps such as qrcode-terminal, beyond the M1 package adapter surface.

## Verification
- pnpm --package=bun@1.2.19 dlx bun install
- pnpm --package=bun@1.2.19 dlx bun run check
- openspec validate m1-foundation --strict --no-interactive
- git diff --check
- git -C zero diff --quiet
- git -C zero rev-parse HEAD == 13e25c116c62411e6ee8a0ad67a6c53dc7c376c6
