### PR TITLE
M1-4.1 initial core Zod schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test:policy-gate": "bun test ./packages/core/src/tools/policy-gate-registry.test.ts",
-    "check": "bun run typecheck && bun run test:policy-gate"
+    "test:schemas": "bun test ./packages/core/src/domain/schemas/core-schemas.test.ts",
+    "check": "bun run typecheck && bun run test:policy-gate && bun run test:schemas"
   },
   "devDependencies": {
     "typescript": "5.8.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@zero-os/core": "workspace:*",
-    "@zero-os/shared": "workspace:*"
+    "@zero-os/shared": "workspace:*",
+    "zod": "4.0.1"
   }
 }

--- a/packages/core/src/domain/schemas/artifact.ts
+++ b/packages/core/src/domain/schemas/artifact.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+export const ArtifactTypeSchema = z.enum([
+  "log",
+  "metrics",
+  "figure",
+  "timeseries",
+  "report_markdown",
+  "report_export",
+  "patch",
+  "repo_context",
+  "toolcall",
+  "manifest",
+  "analysis_progress",
+  "error"
+]);
+
+export const ArtifactCreatedBySchema = z.enum(["system", "agent", "user"]);
+
+export const ArtifactRetentionClassSchema = z.enum([
+  "ephemeral",
+  "debug",
+  "evidence",
+  "accepted_report",
+  "benchmark"
+]);
+
+export const ArtifactRedactionStatusSchema = z.enum(["not_needed", "redacted", "unsafe"]);
+
+export const ArtifactSchema = z.object({
+  artifact_id: z.string().min(1),
+  task_id: z.string().min(1),
+  run_id: z.string().min(1).optional(),
+  job_id: z.string().min(1).optional(),
+  report_id: z.string().min(1).optional(),
+  analysis_plan_id: z.string().min(1).optional(),
+  type: ArtifactTypeSchema,
+  path: z.string().min(1),
+  media_type: z.string().min(1),
+  size_bytes: z.number().int().nonnegative().optional(),
+  sha256: z.string().min(1).optional(),
+  created_at: z.string().min(1),
+  created_by: ArtifactCreatedBySchema,
+  evidence_usable: z.boolean(),
+  retention_class: ArtifactRetentionClassSchema,
+  source_refs: z.array(z.string()),
+  redaction_status: ArtifactRedactionStatusSchema
+});
+
+export type ArtifactType = z.infer<typeof ArtifactTypeSchema>;
+export type ArtifactCreatedBy = z.infer<typeof ArtifactCreatedBySchema>;
+export type ArtifactRetentionClass = z.infer<typeof ArtifactRetentionClassSchema>;
+export type ArtifactRedactionStatus = z.infer<typeof ArtifactRedactionStatusSchema>;
+export type Artifact = z.infer<typeof ArtifactSchema>;

--- a/packages/core/src/domain/schemas/core-schemas.test.ts
+++ b/packages/core/src/domain/schemas/core-schemas.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ArtifactSchema,
+  ErrorRecordSchema,
+  IdempotencyRecordSchema,
+  LockRecordSchema,
+  TaskCardSchema
+} from "./index";
+
+describe("core Zod schemas", () => {
+  test("TaskCard accepts a valid stored object and rejects missing required fields", () => {
+    const parsed = TaskCardSchema.safeParse(validTaskCard());
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.status).toBe("created");
+      expect(parsed.data.runtime_phase).toBeNull();
+    }
+
+    const missingTitle = TaskCardSchema.safeParse(removeKey(validTaskCard(), "title"));
+    expect(missingTitle.success).toBe(false);
+    expect(issuePaths(missingTitle)).toContain("title");
+  });
+
+  test("TaskCard rejects status values outside the coarse state machine", () => {
+    const invalid = TaskCardSchema.safeParse({
+      ...validTaskCard(),
+      status: "revised"
+    });
+
+    expect(invalid.success).toBe(false);
+    expect(issuePaths(invalid)).toContain("status");
+  });
+
+  test("Artifact accepts a valid object and rejects missing required fields", () => {
+    const parsed = ArtifactSchema.safeParse(validArtifact());
+    expect(parsed.success).toBe(true);
+
+    const missingPath = ArtifactSchema.safeParse(removeKey(validArtifact(), "path"));
+    expect(missingPath.success).toBe(false);
+    expect(issuePaths(missingPath)).toContain("path");
+  });
+
+  test("ErrorRecord accepts remediation and rejects invalid next_action", () => {
+    const parsed = ErrorRecordSchema.safeParse(validErrorRecord());
+    expect(parsed.success).toBe(true);
+
+    const withoutRef = ErrorRecordSchema.safeParse({
+      ...validErrorRecord(),
+      remediation: {
+        next_action: "fix_and_retry",
+        hint: "Retry after fixing the workspace path."
+      }
+    });
+    expect(withoutRef.success).toBe(true);
+
+    const invalid = ErrorRecordSchema.safeParse({
+      ...validErrorRecord(),
+      remediation: {
+        next_action: "try_anyway",
+        hint: "Remove the unsupported tool.",
+        ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+      }
+    });
+    expect(invalid.success).toBe(false);
+    expect(issuePaths(invalid)).toContain("remediation.next_action");
+  });
+
+  test("IdempotencyRecord accepts request_digest and rejects missing required fields", () => {
+    const parsed = IdempotencyRecordSchema.safeParse(validIdempotencyRecord());
+    expect(parsed.success).toBe(true);
+
+    const missingDigest = IdempotencyRecordSchema.safeParse(
+      removeKey(validIdempotencyRecord(), "request_digest")
+    );
+    expect(missingDigest.success).toBe(false);
+    expect(issuePaths(missingDigest)).toContain("request_digest");
+
+    const invalidStatus = IdempotencyRecordSchema.safeParse({
+      ...validIdempotencyRecord(),
+      status: "running"
+    });
+    expect(invalidStatus.success).toBe(false);
+    expect(issuePaths(invalidStatus)).toContain("status");
+  });
+
+  test("LockRecord accepts a valid object and rejects missing required fields", () => {
+    const parsed = LockRecordSchema.safeParse(validLockRecord());
+    expect(parsed.success).toBe(true);
+
+    const missingHolder = LockRecordSchema.safeParse(removeKey(validLockRecord(), "holder"));
+    expect(missingHolder.success).toBe(false);
+    expect(issuePaths(missingHolder)).toContain("holder");
+
+    const invalidStatus = LockRecordSchema.safeParse({
+      ...validLockRecord(),
+      status: "open"
+    });
+    expect(invalidStatus.success).toBe(false);
+    expect(issuePaths(invalidStatus)).toContain("status");
+  });
+});
+
+function validTaskCard() {
+  return {
+    task_id: "TASK-0001",
+    type: "engineering",
+    status: "created",
+    runtime_phase: null,
+    title: "Add optional event diagnostics",
+    question_or_goal: "Add event_flux output without breaking old rSHUD readers",
+    created_by: "alice",
+    current_owner: "alice",
+    reviewer: "pi_name",
+    inference_budget: {
+      mode: "normal",
+      advisory_usd: 1,
+      advisory_model_calls: 12,
+      reviewer_enabled: false
+    },
+    linked_jobs: [],
+    linked_reports: [],
+    created_at: "2026-04-25T10:00:00Z",
+    updated_at: "2026-04-25T10:00:00Z"
+  };
+}
+
+function validArtifact() {
+  return {
+    artifact_id: "ART-0001",
+    task_id: "TASK-0001",
+    type: "report_markdown",
+    path: "reports/TASK-0001_report.md",
+    media_type: "text/markdown",
+    created_at: "2026-04-25T10:00:00Z",
+    created_by: "agent",
+    evidence_usable: false,
+    retention_class: "debug",
+    source_refs: [],
+    redaction_status: "not_needed"
+  };
+}
+
+function validErrorRecord() {
+  return {
+    error_id: "ERR-0001",
+    category: "permission_error",
+    severity: "error",
+    task_id: "TASK-0001",
+    message: "Policy gate denied bash.",
+    user_message: "This command writes to a protected path.",
+    evidence_refs: [],
+    retryable: false,
+    recommended_next_actions: ["Use a governed workspace path."],
+    remediation: {
+      next_action: "adjust_scope",
+      hint: "Use a governed workspace path instead of data/raw.",
+      ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+    },
+    created_at: "2026-04-25T10:00:00Z"
+  };
+}
+
+function validIdempotencyRecord() {
+  return {
+    key: "task:TASK-0001:create",
+    scope: "task",
+    request_digest: "sha256:abc123",
+    status: "completed",
+    result_ref: "TASK-0001",
+    created_at: "2026-04-25T10:00:00Z",
+    updated_at: "2026-04-25T10:01:00Z"
+  };
+}
+
+function validLockRecord() {
+  return {
+    lock_id: "LOCK-0001",
+    scope: "task",
+    target_id: "TASK-0001",
+    holder: "worker-1",
+    acquired_at: "2026-04-25T10:00:00Z",
+    expires_at: "2026-04-25T10:01:00Z",
+    status: "held",
+    reason: "task snapshot write"
+  };
+}
+
+function removeKey<T extends Record<string, unknown>, K extends keyof T>(object: T, key: K): Omit<T, K> {
+  const clone = { ...object };
+  delete clone[key];
+  return clone;
+}
+
+function issuePaths(result: { success: true } | { success: false; error: { issues: Array<{ path: Array<string | number> }> } }): string[] {
+  if (result.success) return [];
+  return result.error.issues.map((issue) => issue.path.join("."));
+}

--- a/packages/core/src/domain/schemas/error.ts
+++ b/packages/core/src/domain/schemas/error.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+export const ErrorCategorySchema = z.enum([
+  "schema_error",
+  "permission_error",
+  "workspace_error",
+  "sandbox_error",
+  "build_error",
+  "runtime_error",
+  "numerical_error",
+  "parser_error",
+  "report_error",
+  "agent_error",
+  "notification_error"
+]);
+
+export const ErrorSeveritySchema = z.enum(["info", "warn", "error", "critical"]);
+
+export const RemediationNextActionSchema = z.enum([
+  "escalate_to_pi",
+  "open_gate",
+  "adjust_scope",
+  "fix_and_retry",
+  "abort"
+]);
+
+export const ErrorRemediationSchema = z.object({
+  next_action: RemediationNextActionSchema,
+  hint: z.string().min(1),
+  ref: z.string().min(1).optional()
+});
+
+export const ErrorRecordSchema = z.object({
+  error_id: z.string().min(1),
+  category: ErrorCategorySchema,
+  severity: ErrorSeveritySchema,
+  task_id: z.string().min(1).optional(),
+  job_id: z.string().min(1).optional(),
+  run_id: z.string().min(1).optional(),
+  report_id: z.string().min(1).optional(),
+  message: z.string().min(1),
+  user_message: z.string().min(1),
+  evidence_refs: z.array(z.string()),
+  retryable: z.boolean(),
+  recommended_next_actions: z.array(z.string()),
+  remediation: ErrorRemediationSchema.optional(),
+  created_at: z.string().min(1)
+});
+
+export type ErrorCategory = z.infer<typeof ErrorCategorySchema>;
+export type ErrorSeverity = z.infer<typeof ErrorSeveritySchema>;
+export type RemediationNextAction = z.infer<typeof RemediationNextActionSchema>;
+export type ErrorRemediation = z.infer<typeof ErrorRemediationSchema>;
+export type ErrorRecord = z.infer<typeof ErrorRecordSchema>;

--- a/packages/core/src/domain/schemas/idempotency.ts
+++ b/packages/core/src/domain/schemas/idempotency.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+export const IdempotencyScopeSchema = z.enum([
+  "task",
+  "job",
+  "report",
+  "notification",
+  "pi_gate",
+  "export"
+]);
+
+export const IdempotencyStatusSchema = z.enum(["started", "completed", "failed"]);
+
+export const IdempotencyRecordSchema = z.object({
+  key: z.string().min(1),
+  scope: IdempotencyScopeSchema,
+  request_digest: z.string().min(1),
+  status: IdempotencyStatusSchema,
+  result_ref: z.string().min(1).optional(),
+  created_at: z.string().min(1),
+  updated_at: z.string().min(1),
+  expires_at: z.string().min(1).optional()
+});
+
+export type IdempotencyScope = z.infer<typeof IdempotencyScopeSchema>;
+export type IdempotencyStatus = z.infer<typeof IdempotencyStatusSchema>;
+export type IdempotencyRecord = z.infer<typeof IdempotencyRecordSchema>;

--- a/packages/core/src/domain/schemas/index.ts
+++ b/packages/core/src/domain/schemas/index.ts
@@ -1,3 +1,9 @@
+export * from "./artifact";
+export * from "./error";
+export * from "./idempotency";
+export * from "./lock";
+export * from "./task";
+
 export const CORE_SCHEMA_NAMESPACE = "core/domain/schemas" as const;
 
 export type CoreSchemaNamespace = typeof CORE_SCHEMA_NAMESPACE;

--- a/packages/core/src/domain/schemas/lock.ts
+++ b/packages/core/src/domain/schemas/lock.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const LockScopeSchema = z.enum(["task", "job", "run", "report", "workspace", "worktree"]);
+
+export const LockStatusSchema = z.enum([
+  "held",
+  "released",
+  "expired",
+  "stolen_after_recovery"
+]);
+
+export const LockRecordSchema = z.object({
+  lock_id: z.string().min(1),
+  scope: LockScopeSchema,
+  target_id: z.string().min(1),
+  holder: z.string().min(1),
+  acquired_at: z.string().min(1),
+  expires_at: z.string().min(1),
+  status: LockStatusSchema,
+  reason: z.string().min(1)
+});
+
+export type LockScope = z.infer<typeof LockScopeSchema>;
+export type LockStatus = z.infer<typeof LockStatusSchema>;
+export type LockRecord = z.infer<typeof LockRecordSchema>;

--- a/packages/core/src/domain/schemas/task.ts
+++ b/packages/core/src/domain/schemas/task.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+export const TaskStatusSchema = z.enum([
+  "created",
+  "planned",
+  "running",
+  "parked",
+  "reporting",
+  "awaiting_pi",
+  "done",
+  "cancelled",
+  "blocked"
+]);
+
+export const TaskRuntimePhaseSchema = z.enum([
+  "running_local",
+  "submitted_job",
+  "waiting_for_job",
+  "collecting"
+]);
+
+export const TaskTypeSchema = z.enum(["engineering", "science_assist", "ops"]);
+
+export const InferenceBudgetSchema = z.object({
+  mode: z.enum(["cheap", "normal", "deep"]),
+  advisory_usd: z.number().nonnegative().optional(),
+  advisory_model_calls: z.number().int().nonnegative().optional(),
+  reviewer_enabled: z.boolean().optional()
+});
+
+export const TaskCardSchema = z.object({
+  task_id: z.string().min(1),
+  type: TaskTypeSchema,
+  status: TaskStatusSchema,
+  runtime_phase: TaskRuntimePhaseSchema.nullable().optional(),
+  title: z.string().min(1),
+  question_or_goal: z.string().min(1),
+  created_by: z.string().min(1),
+  current_owner: z.string().min(1),
+  reviewer: z.string().min(1),
+  stack_id: z.string().min(1).optional(),
+  data_id: z.string().min(1).optional(),
+  inference_budget: InferenceBudgetSchema,
+  linked_jobs: z.array(z.string().min(1)),
+  linked_reports: z.array(z.string().min(1)),
+  created_at: z.string().min(1),
+  updated_at: z.string().min(1),
+  theory_bundle_ids: z.array(z.string().min(1)).optional()
+});
+
+export type TaskStatus = z.infer<typeof TaskStatusSchema>;
+export type TaskRuntimePhase = z.infer<typeof TaskRuntimePhaseSchema>;
+export type TaskType = z.infer<typeof TaskTypeSchema>;
+export type InferenceBudget = z.infer<typeof InferenceBudgetSchema>;
+export type TaskCard = z.infer<typeof TaskCardSchema>;


### PR DESCRIPTION
Closes #22

## Summary
- Add initial Zod schemas and inferred types for TaskCard, Artifact, ErrorRecord, IdempotencyRecord, and LockRecord.
- Add schema tests covering valid parses, missing required field paths, invalid TaskCard status, and invalid ErrorRecord remediation.next_action.
- Add zod dependency declaration and include schema tests in the root check script.

## Boundary Notes
- No schema generation or docs/generated outputs; #23 owns generation/drift.
- No lockfile committed; #14 owns packageManager, bun.lock, and DependencyLock.
- TaskCard stack_id/data_id are optional in this M1 schema slice so the M1 TaskCard create path is not blocked by M2 StackLock/DataProvenance objects.

## Verification
- pnpm --package=bun@1.2.19 dlx bun run check
- openspec validate m1-foundation --strict --no-interactive
- git diff --check
- git -C zero diff --quiet

## Dependency Note
- Local verification used zod@4.0.1 via an ignored node_modules symlink because #14 has not yet frozen the Bun lockfile. The committed dependency declaration is packages/core/package.json only.
