### PR TITLE
M1-3.2 policy gate pure evaluator

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test:policy-gate": "bun test ./packages/core/src/tools/policy-gate-registry.test.ts",
+    "test:policy-gate": "bun test ./packages/core/src/tools/policy-gate-core.test.ts ./packages/core/src/tools/policy-gate-registry.test.ts",
     "test:schemas": "bun test ./packages/core/src/domain/schemas/core-schemas.test.ts",
     "check": "bun run typecheck && bun run test:policy-gate && bun run test:schemas"
   },

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -7,5 +7,6 @@ export const CORE_TOOL_MODULES = [
 
 export type CoreToolModule = (typeof CORE_TOOL_MODULES)[number];
 
+export * from "./policy-gate-core";
 export * from "./policy-gate-registry";
 export * from "./zero-reference-shape";

--- a/packages/core/src/tools/policy-gate-core.test.ts
+++ b/packages/core/src/tools/policy-gate-core.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import {
+  evaluatePolicyGate,
+  PolicyGateRemediationSchema,
+  type PolicyGateToolCall
+} from "./policy-gate-core";
+
+describe("policy gate pure evaluator", () => {
+  test("allows by default and returns identical output for identical input", () => {
+    const call = sampleToolCall();
+
+    const first = evaluatePolicyGate(call);
+    const second = evaluatePolicyGate(call);
+
+    expect(first).toEqual({ decision: "allow" });
+    expect(second).toEqual(first);
+  });
+
+  test("returns deterministic deny with remediation from the first denying rule", () => {
+    const call = sampleToolCall();
+    const context = {
+      rules: [
+        {
+          ruleId: "raw-data-write",
+          description: "Reject writes to data/raw.",
+          evaluate: () => ({
+            decision: "deny" as const,
+            reason: "data/raw is protected",
+            remediation: {
+              next_action: "adjust_scope" as const,
+              hint: "Write generated files under workspace/tasks instead.",
+              ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
+            }
+          })
+        }
+      ]
+    };
+
+    const first = evaluatePolicyGate(call, context);
+    const second = evaluatePolicyGate(call, context);
+
+    expect(first).toEqual(second);
+    expect(first).toEqual({
+      decision: "deny",
+      ruleId: "raw-data-write",
+      reason: "data/raw is protected",
+      remediation: {
+        next_action: "adjust_scope",
+        hint: "Write generated files under workspace/tasks instead.",
+        ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
+      }
+    });
+  });
+
+  test("remediation payload requires legal next_action plus hint and ref", () => {
+    const valid = PolicyGateRemediationSchema.safeParse({
+      next_action: "fix_and_retry",
+      hint: "Fix the path and retry.",
+      ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+    });
+    expect(valid.success).toBe(true);
+
+    const invalid = PolicyGateRemediationSchema.safeParse({
+      next_action: "try_anyway",
+      hint: "",
+      ref: ""
+    });
+    expect(invalid.success).toBe(false);
+    if (!invalid.success) {
+      expect(invalid.error.issues.map((issue) => issue.path.join("."))).toEqual([
+        "next_action",
+        "hint",
+        "ref"
+      ]);
+    }
+  });
+
+  test("invalid rule remediation fails before a deny result is returned", () => {
+    expect(() =>
+      evaluatePolicyGate(sampleToolCall(), {
+        rules: [
+          {
+            ruleId: "bad-rule",
+            description: "Returns invalid remediation.",
+            evaluate: () => ({
+              decision: "deny",
+              reason: "invalid",
+              remediation: {
+                next_action: "try_anyway",
+                hint: "No route.",
+                ref: "spec"
+              } as never
+            })
+          }
+        ]
+      })
+    ).toThrow("next_action");
+  });
+});
+
+function sampleToolCall(): PolicyGateToolCall {
+  return {
+    toolId: "bash",
+    role: "worker",
+    input: {
+      command: "printf nope > data/raw/input.csv"
+    },
+    workDir: "/workspace/tasks/TASK-M1-SPIKE"
+  };
+}

--- a/packages/core/src/tools/policy-gate-core.ts
+++ b/packages/core/src/tools/policy-gate-core.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+import { RemediationNextActionSchema } from "../domain/schemas";
+
+export type HarnessRole = "coordinator" | "repo_explorer" | "worker" | "coder" | "reviewer";
+
+// Policy-gate denials require a navigable ref, even though generic ErrorRecord.ref is optional.
+export const PolicyGateRemediationSchema = z.object({
+  next_action: RemediationNextActionSchema,
+  hint: z.string().min(1),
+  ref: z.string().min(1)
+});
+
+export type PolicyGateRemediation = z.infer<typeof PolicyGateRemediationSchema>;
+
+export interface PolicyGateToolCall {
+  toolId: string;
+  role: HarnessRole | "unknown";
+  input: unknown;
+  workDir?: string;
+}
+
+export type PolicyRuleDecision =
+  | {
+      decision: "allow";
+    }
+  | {
+      decision: "deny";
+      reason: string;
+      remediation: PolicyGateRemediation;
+    };
+
+export type PolicyGateDecision =
+  | {
+      decision: "allow";
+    }
+  | {
+      decision: "deny";
+      ruleId: string;
+      reason: string;
+      remediation: PolicyGateRemediation;
+    };
+
+export interface PolicyRule {
+  ruleId: string;
+  description: string;
+  evaluate(call: PolicyGateToolCall, context: PolicyGateContext): PolicyRuleDecision;
+}
+
+export interface PolicyGateContext {
+  rules: readonly PolicyRule[];
+}
+
+export const EMPTY_POLICY_GATE_CONTEXT: PolicyGateContext = {
+  rules: []
+};
+
+export function evaluatePolicyGate(
+  call: PolicyGateToolCall,
+  context: PolicyGateContext = EMPTY_POLICY_GATE_CONTEXT
+): PolicyGateDecision {
+  for (const rule of context.rules) {
+    const result = rule.evaluate(call, context);
+    if (result.decision === "allow") {
+      continue;
+    }
+
+    validatePolicyGateRemediation(rule.ruleId, result.remediation);
+    return {
+      decision: "deny",
+      ruleId: rule.ruleId,
+      reason: result.reason,
+      remediation: result.remediation
+    };
+  }
+
+  return { decision: "allow" };
+}
+
+function validatePolicyGateRemediation(ruleId: string, remediation: PolicyGateRemediation): void {
+  const parsed = PolicyGateRemediationSchema.safeParse(remediation);
+  if (parsed.success) {
+    return;
+  }
+
+  const fieldPaths = parsed.error.issues
+    .map((issue) => issue.path.join("."))
+    .filter((path) => path.length > 0)
+    .join(", ");
+
+  throw new Error(`Invalid policy gate remediation for ${ruleId}: ${fieldPaths || "remediation"}`);
+}

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -4,17 +4,33 @@ import type { ToolContext, ToolLogger, ToolResult } from "@zero-os/shared";
 import {
   assertAllToolsPolicyGated,
   assertPolicyGatedToolRegistry,
+  createPolicyGateEvaluator,
   createPolicyGatedToolRegistry,
   isPolicyGatedTool,
-  wrapToolWithPolicyGate,
-  type PolicyGateEvaluator
+  wrapToolWithPolicyGate
 } from "./policy-gate-registry";
 
 describe("policy-gated zero tool registry", () => {
   test("denies before executing the underlying bash BaseTool", async () => {
     const bashTool = new RecordingTool("bash");
     const registry = createPolicyGatedToolRegistry([bashTool], {
-      evaluate: denyAll("raw data writes are blocked")
+      evaluate: createPolicyGateEvaluator({
+        rules: [
+          {
+            ruleId: "raw-data-write",
+            description: "Reject writes to raw data.",
+            evaluate: () => ({
+              decision: "deny",
+              reason: "raw data writes are blocked",
+              remediation: {
+                next_action: "adjust_scope",
+                hint: "Use a governed workspace path instead of data/raw.",
+                ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+              }
+            })
+          }
+        ]
+      })
     });
 
     const result = await registry.get("bash")?.run(createToolContext("worker"), {
@@ -24,6 +40,22 @@ describe("policy-gated zero tool registry", () => {
     expect(result?.success).toBe(false);
     expect(result?.output).toContain("policy_gate_denied");
     expect(result?.output).toContain("raw data writes are blocked");
+    const payload = JSON.parse(result?.output ?? "{}") as {
+      ruleId?: string;
+      reason?: string;
+      remediation?: {
+        next_action?: string;
+        hint?: string;
+        ref?: string;
+      };
+    };
+    expect(payload.ruleId).toBe("raw-data-write");
+    expect(payload.reason).toBe("raw data writes are blocked");
+    expect(payload.remediation?.next_action).toBe("adjust_scope");
+    expect(payload.remediation?.hint).toBe("Use a governed workspace path instead of data/raw.");
+    expect(payload.remediation?.ref).toBe(
+      "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+    );
     expect(bashTool.calls).toBe(0);
   });
 
@@ -75,18 +107,6 @@ describe("policy-gated zero tool registry", () => {
     expect(() => assertAllToolsPolicyGated([forgedTool])).toThrow("edit");
   });
 });
-
-function denyAll(reason: string): PolicyGateEvaluator {
-  return async () => ({
-    decision: "deny",
-    reason,
-    remediation: {
-      next_action: "adjust_scope",
-      hint: "Use a governed workspace path instead of data/raw.",
-      ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
-    }
-  });
-}
 
 class RecordingTool extends BaseTool {
   description: string;

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -1,30 +1,22 @@
 import { BaseTool, ToolRegistry } from "@zero-os/core";
 import type { ToolContext, ToolDefinition, ToolResult } from "@zero-os/shared";
+import {
+  evaluatePolicyGate,
+  type HarnessRole,
+  type PolicyGateContext,
+  type PolicyGateDecision,
+  type PolicyGateToolCall
+} from "./policy-gate-core";
 
-export type HarnessRole = "coordinator" | "repo_explorer" | "worker" | "coder" | "reviewer";
-
-export interface PolicyGateRemediation {
-  next_action: "escalate_to_pi" | "open_gate" | "adjust_scope" | "fix_and_retry" | "abort";
-  hint: string;
-  ref: string;
-}
-
-export type PolicyGateDecision =
-  | {
-      decision: "allow";
-    }
-  | {
-      decision: "deny";
-      reason: string;
-      remediation?: PolicyGateRemediation;
-    };
-
-export interface PolicyGateToolCall {
-  toolId: string;
-  role: HarnessRole | "unknown";
-  input: unknown;
-  workDir?: string;
-}
+export type {
+  HarnessRole,
+  PolicyGateContext,
+  PolicyGateDecision,
+  PolicyGateRemediation,
+  PolicyGateToolCall,
+  PolicyRule,
+  PolicyRuleDecision
+} from "./policy-gate-core";
 
 export interface PolicyGateEvaluationContext {
   tool: BaseTool;
@@ -48,6 +40,10 @@ export type PolicyGatedTool = BaseTool & {
 };
 
 const policyGatedTools = new WeakSet<BaseTool>();
+
+export function createPolicyGateEvaluator(context: PolicyGateContext): PolicyGateEvaluator {
+  return (call) => evaluatePolicyGate(call, context);
+}
 
 export function wrapToolWithPolicyGate(
   tool: BaseTool,
@@ -171,6 +167,7 @@ function buildPolicyGateDeniedResult(
     error: "policy_gate_denied",
     tool_id: toolId,
     reason: decision.reason,
+    ...(decision.ruleId ? { ruleId: decision.ruleId } : {}),
     ...(decision.remediation ? { remediation: decision.remediation } : {})
   };
 


### PR DESCRIPTION
Closes #18

## Summary
- Add a synchronous pure policy-gate evaluator: ToolCall + rule context -> allow/deny with reason and remediation.
- Add policy-gate remediation schema using the ErrorRecord next_action enum and requiring hint/ref for policy denials.
- Wire the #17 BaseTool wrapper through createPolicyGateEvaluator so registered tools can use the pure evaluator.

## Boundary Notes
- No concrete governance rule is implemented here; #19/#20/#27 own specific rules.
- No WebSocket, audit persistence, or Zero source changes.

## Verification
- pnpm --package=bun@1.2.19 dlx bun run check
- pnpm --package=bun@1.2.19 dlx bun run test:policy-gate
- openspec validate m1-foundation --strict --no-interactive
- git diff --check
- git -C zero diff --quiet
