### PR TITLE
M1-3.3: deny data/raw writes through policy gate

### DIFF
--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -120,3 +120,76 @@ Review focus:
 - Gate list exactly matches the P0 table.
 - Runtime output cannot accidentally satisfy source-controlled evidence or enter git.
 - `decision` aggregation is conservative and cannot classify contract conflicts as pass.
+
+## Subagent Workflow Fixture — Issue #19
+
+Fixture level: expanded; repair intensity: high. Project profile: SHUD-Harness.
+
+Expanded-trigger rationale:
+- Core triggers: bash/tool entrypoint, path write boundary under `data/raw/**`, WebSocket event envelope, ErrorRecord remediation payload, and audit file output under `workspace/tasks/*/audit/`.
+- Profile triggers: `workspace`, `remediation`, `guard_class`, and Zero adapter/tool registry governance.
+
+Change surface:
+- `packages/core` policy rule and audit helper for `data/raw/**` write denials.
+- `packages/backend/src/ws` skeleton event builder for existing `tool.failed`.
+- Focused tests for pre-execution denial, remediation payload, event envelope, and fixture audit row write.
+
+Must preserve:
+- Policy-gate core remains pure; IO is outside `evaluatePolicyGate`.
+- No new WebSocket event type is introduced.
+- `zero/` remains source-clean and pinned; no full WebSocket protocol or full AuditEvent schema is implemented in M1.
+
+Must add/change:
+- Bash write attempts targeting `data/raw/**` are denied before the wrapped tool executes.
+- Denial output, `tool.failed` payload, and audit row all carry the same rule identity and navigable remediation.
+- The hard guard has a legal `guard_class` marker; #26 owns the later lint/assembly enforcement if not yet merged.
+
+Risk packs considered:
+- Public API / CLI / script entry: selected - bash tool calls are the execution entrypoint being guarded.
+- Config / project setup: not selected - no runtime config or package manager behavior changes.
+- File IO / path safety / overwrite: selected - the feature prevents protected raw-data writes and writes audit evidence.
+- Schema / columns / units / field names: selected - ErrorRecord remediation, `tool.failed` envelope, and audit row fields are contract-shaped.
+- Auth / permissions / secrets: not selected - no credential or user permission surface in this slice.
+- Concurrency / shared state / ordering: selected - WS skeleton must carry seq/event_id, but no multi-producer allocator is implemented in M1.
+- Resource limits / large input / discovery: not selected - tests use bounded command strings and a single fixture audit file.
+- Legacy compatibility / examples: selected - existing policy-gate allow behavior and wrapped tool execution must keep working.
+- Error handling / rollback / partial outputs: selected - deny path must be stable and must not execute the wrapped command.
+- Release / packaging / dependency compatibility: not selected - no lockfile/packageManager changes in this issue.
+- Documentation / migration notes: selected - PR evidence records #26 guard_class follow-up boundary.
+Domain packs:
+- Scientific governance / PI gate / evidence lineage: selected - raw data is protected evidence input; denials must be auditable.
+- Hydrology runtime / SHUD-rSHUD-AutoSHUD compatibility: not selected - no model/runtime invocation or hydrology file format changes.
+- Zero adapter / tool registry / agent role governance: selected - uses the #17 wrapper seam without modifying Zero.
+
+Invariant Matrix:
+- Governing invariant: A policy-denied bash write to `data/raw/**` must be stopped before execution and leave synchronized remediation, WS, and audit evidence for the same rule.
+- Source-of-truth identity/contract: `policy-gate-spike` rule id, `guard_class`, `ErrorRecord.remediation`, `tool.failed`, and `workspace/tasks/TASK-M1-SPIKE/audit/`.
+- Producers: data/raw write rule; policy-gated wrapped bash tool; audit helper; WS event builder.
+- Validators/preflight: rule command detector, remediation schema validation, focused tests.
+- Storage/cache/query: fixture audit file under `workspace/tasks/TASK-M1-SPIKE/audit/`; no committed runtime artifact.
+- Public routes/entrypoints: none - M1 skeleton builder only, no WS server route implementation.
+- Frontend/downstream consumers: future AgentActivityFeed consumes `tool.failed`; M1 asserts envelope/payload shape only.
+- Failure paths/rollback/stale state: deny returns stable tool error and does not execute the inner tool; audit append failure is scoped to helper tests, not policy core.
+- Evidence/audit/readiness: unit/integration tests plus PR evidence and review-loop log.
+- Regression rows:
+  - Bash `printf x > data/raw/input.csv` through the wrapped tool -> deny result, inner tool call count stays zero, remediation has `next_action`, `hint`, and `ref`.
+  - Same denial converted to WS -> type is exactly `tool.failed`, envelope has seq/event_id, payload carries remediation and rule identity.
+  - Same denial written as audit -> row lands under `workspace/tasks/TASK-M1-SPIKE/audit/` with event/tool_id/rule/decision/ts.
+  - Bash read-only command against `data/raw/input.csv` -> existing wrapped-tool allow path still executes.
+
+Boundary-surface checklist:
+- Shared helper roots: `packages/core/src/tools/*` policy helpers.
+- Public entrypoints: wrapped bash tool `run()` path only.
+- Write/delete/overwrite surfaces: blocked command detector and audit append helper.
+- Producer/consumer evidence boundaries: denial payload -> WS payload -> audit row must preserve rule/remediation identity.
+- Unchanged downstream consumers: generic ErrorRecord optional `remediation.ref` remains unchanged; policy-gate denials still require `ref`.
+
+Non-goals:
+- Full shell parser, complete WebSocket server/session bus, full AuditEvent schema, and #26 guard lint enforcement.
+- Raw data read prohibition; this issue blocks writes/mutations only.
+
+Review focus:
+- Denial happens before wrapped command execution.
+- `tool.failed` is reused without extending the event registry.
+- Audit write stays in the fixture task audit path and runtime artifacts are not committed.
+- Guard marking is present without pretending #26 enforcement already exists.

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -25,6 +25,12 @@
 - [ ] 3.1 spike 条 1：工具注册层横切包装（`ToolBase.beforeExecute` 包装/注册期 wrap；未包装工具装配失败负例；Zero 内核零改动）+ zero 引用技术形态定形（嵌套 Bun workspace 解析实测：workspace 纳入 vs `file:` 依赖 vs 运行时入口加载，实测结论回写 design.md Decision 3；验收含「Decision 3 已回写」）——依赖: 2.1
 - [ ] 3.2 spike 条 4：策略门纯函数核心（ToolCall → allow/deny + reason + remediation）+ 独立单测（正负例 + remediation 载荷断言）——依赖: 4.1（ErrorRecord.remediation 枚举）
 - [ ] 3.3 spike 条 2：`data/raw/**` 写禁区端到端穿透（bash 执行前拒 + remediation 三字段 + WS 复用注册表事件 `tool.failed` 推送（envelope 含 seq/event_id）+ audit 最小行落盘（event/tool_id/rule/decision/ts，路径与 fixture 任务见 policy-gate-spike spec））——依赖: 4.1
+  - Evidence floor (#19):
+    - Wrapped bash tool + `printf x > data/raw/input.csv` -> policy deny, command implementation not invoked, returned error includes remediation `next_action`/`hint`/`ref`.
+    - The same denial -> WS skeleton event type exactly `tool.failed`, envelope has seq/event_id, payload carries ErrorRecord/remediation and rule identity; no new WS event type is added.
+    - The same denial -> audit row appended under `workspace/tasks/TASK-M1-SPIKE/audit/` with event/tool_id/rule/decision/ts.
+    - Read-only bash command referencing `data/raw/input.csv` -> still allowed through the existing wrapper path.
+    - Rule metadata includes legal `guard_class`; #26 may later enforce missing-mark lint/assembly.
 - [ ] 3.4 spike 条 3：spawn 剖面超集拒绝负例（比对基准 = 5.1 映射表；断言 `remediation.next_action=adjust_scope`）——依赖: 5.1
 - [ ] 3.5 spike 条 5 核验 + 判定记录（`git -C zero diff --quiet` && HEAD=13e25c1；五条全绿 → Trial 转正记录；任一条 2 人周不绿 → ADR-0001 revisit 备忘并冻结 3.x/5.x 后续）——依赖: 节内 3.1–3.4 + 跨节 4.1、5.1（经 3.2/3.4 传递）
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test:policy-gate": "bun test ./packages/core/src/tools/policy-gate-core.test.ts ./packages/core/src/tools/policy-gate-registry.test.ts",
+    "test:policy-gate": "bun test ./packages/core/src/tools/policy-gate-core.test.ts ./packages/core/src/tools/policy-gate-registry.test.ts ./packages/core/src/tools/data-raw-write-rule.test.ts ./packages/backend/src/ws/policy-gate-events.test.ts",
     "test:schemas": "bun test ./packages/core/src/domain/schemas/core-schemas.test.ts",
     "check": "bun run typecheck && bun run test:policy-gate && bun run test:schemas"
   },

--- a/packages/backend/src/ws/index.ts
+++ b/packages/backend/src/ws/index.ts
@@ -1,3 +1,5 @@
 export const BACKEND_WS_NAMESPACE = "backend/ws" as const;
 
 export type BackendWsNamespace = typeof BACKEND_WS_NAMESPACE;
+
+export * from "./policy-gate-events";

--- a/packages/backend/src/ws/policy-gate-events.test.ts
+++ b/packages/backend/src/ws/policy-gate-events.test.ts
@@ -1,12 +1,29 @@
-import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { BaseTool } from "@zero-os/core";
+import type { ToolContext, ToolLogger, ToolResult } from "@zero-os/shared";
 import {
+  appendPolicyGateAuditRow,
+  buildPolicyGateAuditRowFromDeniedDecision,
+  buildPolicyGateDeniedToolPayload,
+  createPolicyGatedToolRegistry,
   DATA_RAW_WRITE_DENY_RULE_ID,
   DATA_RAW_WRITE_GUARD_CLASS,
   DATA_RAW_WRITE_RULE_REF,
   evaluatePolicyGate,
-  makeDataRawPolicyGateContext
+  makeDataRawPolicyGateContext,
+  type PolicyGateDecision
 } from "@shud-harness/core";
 import { buildPolicyGateToolFailedEvent, TOOL_FAILED_EVENT_TYPE } from "./policy-gate-events";
+
+let tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  tempDirs = [];
+});
 
 describe("policy-gate WebSocket event skeleton", () => {
   test("builds a tool.failed envelope with seq/event_id and remediation payload", () => {
@@ -56,4 +73,116 @@ describe("policy-gate WebSocket event skeleton", () => {
     });
     expect(event.payload.error.remediation?.hint).toBeTruthy();
   });
+
+  test("links wrapped tool denial, WebSocket payload, and audit row from one policy decision", async () => {
+    let capturedDecision: Extract<PolicyGateDecision, { decision: "deny" }> | undefined;
+    const bashTool = new RecordingTool("bash");
+    const registry = createPolicyGatedToolRegistry([bashTool], {
+      evaluate: (call) => {
+        const decision = evaluatePolicyGate(call, makeDataRawPolicyGateContext());
+        if (decision.decision === "deny") {
+          capturedDecision = decision;
+        }
+        return decision;
+      }
+    });
+
+    const result = await registry.get("bash")?.run(createToolContext("worker"), {
+      command: "bash -c 'printf x > data/raw/input.csv'"
+    });
+
+    expect(result?.success).toBe(false);
+    expect(bashTool.calls).toBe(0);
+    expect(capturedDecision).toBeDefined();
+    if (!capturedDecision) {
+      throw new Error("expected captured policy denial");
+    }
+
+    const toolPayload = JSON.parse(result?.output ?? "{}") as {
+      tool_id?: string;
+      rule_id?: string;
+      guard_class?: string;
+      remediation?: {
+        ref?: string;
+      };
+    };
+    expect(toolPayload).toEqual(buildPolicyGateDeniedToolPayload("bash", capturedDecision));
+
+    const event = buildPolicyGateToolFailedEvent({
+      seq: 43,
+      event_id: "EVT-ISSUE-19-LINKED",
+      session_id: "SESSION-ISSUE-19",
+      task_id: "TASK-M1-SPIKE",
+      workspace_id: "WORKSPACE-LOCAL",
+      timestamp: "2026-07-03T00:00:00.000Z",
+      tool_id: "bash",
+      decision: capturedDecision,
+      error_id: "ERR-ISSUE-19-LINKED"
+    });
+
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-ws-audit-"));
+    tempDirs.push(workspaceRoot);
+    const auditResult = await appendPolicyGateAuditRow(
+      buildPolicyGateAuditRowFromDeniedDecision({
+        toolId: "bash",
+        decision: capturedDecision
+      }),
+      {
+        workspaceRoot,
+        now: () => "2026-07-03T00:00:00.000Z"
+      }
+    );
+    const [auditRow] = (await readFile(auditResult.auditPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    expect(toolPayload.tool_id).toBe(event.payload.tool_id);
+    expect(auditRow.tool_id).toBe(toolPayload.tool_id);
+    expect(toolPayload.rule_id).toBe(event.payload.rule_id);
+    expect(auditRow.rule).toBe(toolPayload.rule_id);
+    expect(toolPayload.guard_class).toBe(event.payload.guard_class);
+    expect(auditRow.guard_class).toBe(toolPayload.guard_class);
+    expect(toolPayload.remediation?.ref).toBe(event.payload.error.remediation?.ref);
+    expect(auditRow.remediation_ref).toBe(toolPayload.remediation?.ref);
+  });
 });
+
+class RecordingTool extends BaseTool {
+  description: string;
+  parameters: Record<string, unknown> = {
+    type: "object",
+    additionalProperties: true
+  };
+  calls = 0;
+
+  constructor(readonly name: string) {
+    super();
+    this.description = `Test tool ${name}`;
+  }
+
+  protected async execute(): Promise<ToolResult> {
+    this.calls += 1;
+    return {
+      success: true,
+      output: `${this.name} executed`,
+      outputSummary: `${this.name} executed`
+    };
+  }
+}
+
+function createToolContext(role: string): ToolContext & { role: string } {
+  return {
+    role,
+    sessionId: "TEST-SESSION",
+    workDir: "/tmp/shud-harness-test",
+    logger: testLogger
+  };
+}
+
+const testLogger: ToolLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {}
+};

--- a/packages/backend/src/ws/policy-gate-events.test.ts
+++ b/packages/backend/src/ws/policy-gate-events.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DATA_RAW_WRITE_DENY_RULE_ID,
+  DATA_RAW_WRITE_GUARD_CLASS,
+  DATA_RAW_WRITE_RULE_REF,
+  evaluatePolicyGate,
+  makeDataRawPolicyGateContext
+} from "@shud-harness/core";
+import { buildPolicyGateToolFailedEvent, TOOL_FAILED_EVENT_TYPE } from "./policy-gate-events";
+
+describe("policy-gate WebSocket event skeleton", () => {
+  test("builds a tool.failed envelope with seq/event_id and remediation payload", () => {
+    const decision = evaluatePolicyGate(
+      {
+        toolId: "bash",
+        role: "worker",
+        input: {
+          command: "printf x > data/raw/input.csv"
+        }
+      },
+      makeDataRawPolicyGateContext()
+    );
+    expect(decision.decision).toBe("deny");
+    if (decision.decision !== "deny") {
+      throw new Error("expected policy denial");
+    }
+
+    const event = buildPolicyGateToolFailedEvent({
+      seq: 42,
+      event_id: "EVT-ISSUE-19",
+      session_id: "SESSION-ISSUE-19",
+      task_id: "TASK-M1-SPIKE",
+      workspace_id: "WORKSPACE-LOCAL",
+      timestamp: "2026-07-03T00:00:00.000Z",
+      tool_id: "bash",
+      decision,
+      error_id: "ERR-ISSUE-19"
+    });
+
+    expect(event.type).toBe(TOOL_FAILED_EVENT_TYPE);
+    expect(event.seq).toBe(42);
+    expect(event.event_id).toBe("EVT-ISSUE-19");
+    expect(event.payload.rule_id).toBe(DATA_RAW_WRITE_DENY_RULE_ID);
+    expect(event.payload.guard_class).toBe(DATA_RAW_WRITE_GUARD_CLASS);
+    expect(event.payload.error).toMatchObject({
+      error_id: "ERR-ISSUE-19",
+      category: "permission_error",
+      severity: "error",
+      tool_id: "bash",
+      rule_id: DATA_RAW_WRITE_DENY_RULE_ID,
+      guard_class: DATA_RAW_WRITE_GUARD_CLASS,
+      remediation: {
+        next_action: "adjust_scope",
+        ref: DATA_RAW_WRITE_RULE_REF
+      }
+    });
+    expect(event.payload.error.remediation?.hint).toBeTruthy();
+  });
+});

--- a/packages/backend/src/ws/policy-gate-events.ts
+++ b/packages/backend/src/ws/policy-gate-events.ts
@@ -1,0 +1,130 @@
+import type {
+  ErrorRecord,
+  GuardClass,
+  PolicyGateDecision,
+  PolicyGateRemediation
+} from "@shud-harness/core";
+
+export const TOOL_FAILED_EVENT_TYPE = "tool.failed" as const;
+
+export type WsEventSource =
+  | "server"
+  | "coordinator"
+  | "repo_explorer"
+  | "worker"
+  | "coder"
+  | "reviewer"
+  | "job"
+  | "tool"
+  | "client";
+
+export type WsEventVisibility = "user_visible" | "internal";
+
+export interface WsEvent<TPayload> {
+  seq: number;
+  event_id: string;
+  type: string;
+  session_id: string;
+  task_id?: string;
+  workspace_id?: string;
+  run_id?: string;
+  job_id?: string;
+  timestamp: string;
+  source: WsEventSource;
+  visibility: WsEventVisibility;
+  payload: TPayload;
+}
+
+export type PolicyGateDeniedErrorRecord = ErrorRecord & {
+  tool_id: string;
+  rule_id: string;
+  guard_class?: GuardClass;
+};
+
+export interface ToolFailedPolicyGatePayload {
+  tool_id: string;
+  rule_id: string;
+  guard_class?: GuardClass;
+  error: PolicyGateDeniedErrorRecord;
+}
+
+export type ToolFailedPolicyGateEvent = WsEvent<ToolFailedPolicyGatePayload> & {
+  type: typeof TOOL_FAILED_EVENT_TYPE;
+  source: "tool";
+};
+
+export interface BuildPolicyGateToolFailedEventInput {
+  seq: number;
+  event_id?: string;
+  session_id: string;
+  task_id?: string;
+  workspace_id?: string;
+  timestamp?: string;
+  tool_id: string;
+  decision: Extract<PolicyGateDecision, { decision: "deny" }>;
+  error_id?: string;
+}
+
+export function buildPolicyGateToolFailedEvent(
+  input: BuildPolicyGateToolFailedEventInput
+): ToolFailedPolicyGateEvent {
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const eventId = input.event_id ?? `EVT-${crypto.randomUUID()}`;
+  const error = buildPolicyGateDeniedErrorRecord({
+    error_id: input.error_id ?? `ERR-${eventId}`,
+    tool_id: input.tool_id,
+    rule_id: input.decision.ruleId,
+    guard_class: input.decision.guard_class,
+    reason: input.decision.reason,
+    remediation: input.decision.remediation,
+    timestamp
+  });
+
+  return {
+    seq: input.seq,
+    event_id: eventId,
+    type: TOOL_FAILED_EVENT_TYPE,
+    session_id: input.session_id,
+    ...(input.task_id ? { task_id: input.task_id } : {}),
+    ...(input.workspace_id ? { workspace_id: input.workspace_id } : {}),
+    timestamp,
+    source: "tool",
+    visibility: "user_visible",
+    payload: {
+      tool_id: input.tool_id,
+      rule_id: input.decision.ruleId,
+      ...(input.decision.guard_class ? { guard_class: input.decision.guard_class } : {}),
+      error
+    }
+  };
+}
+
+interface BuildPolicyGateDeniedErrorRecordInput {
+  error_id: string;
+  tool_id: string;
+  rule_id: string;
+  guard_class?: GuardClass;
+  reason: string;
+  remediation: PolicyGateRemediation;
+  timestamp: string;
+}
+
+function buildPolicyGateDeniedErrorRecord(
+  input: BuildPolicyGateDeniedErrorRecordInput
+): PolicyGateDeniedErrorRecord {
+  return {
+    error_id: input.error_id,
+    category: "permission_error",
+    severity: "error",
+    message: input.reason,
+    user_message: "A policy gate denied this tool call before execution.",
+    evidence_refs: [],
+    retryable: false,
+    recommended_next_actions: [input.remediation.hint],
+    remediation: input.remediation,
+    created_at: input.timestamp,
+    tool_id: input.tool_id,
+    rule_id: input.rule_id,
+    ...(input.guard_class ? { guard_class: input.guard_class } : {})
+  };
+}

--- a/packages/core/src/tools/data-raw-write-rule.test.ts
+++ b/packages/core/src/tools/data-raw-write-rule.test.ts
@@ -27,6 +27,8 @@ describe("data/raw write deny policy", () => {
   const largeExecutableCodeWriteCommand = `Rscript -e '${"read.csv(\"data/raw/input.csv\");".repeat(
     3000
   )}writeLines("x", "data/raw/out.csv")'`;
+  const largeNoRawCommand = `printf '${"x".repeat(300000)}'`;
+  const largeRawWriteEvidenceCommand = `${"true\n".repeat(60000)}rm data/raw/input.csv`;
   const largeNonExecutableHeredocCommand = `cat > workspace/tasks/TASK-001/script.sh <<'SH'\n${"echo filler\n".repeat(
     30000
   )}rm data/raw/input.csv\nSH`;
@@ -131,6 +133,34 @@ describe("data/raw write deny policy", () => {
       command: 'python -c \'open("data/raw/x","w").write("x")\''
     },
     {
+      name: "python executable code string raw variable write mode",
+      command: 'python -c \'path="data/raw/out.csv"; open(path, mode="w").write("x")\''
+    },
+    {
+      name: "node executable code string raw variable write",
+      command: 'node -e \'const p="data/raw/out.csv"; require("fs").writeFileSync(p, "x")\''
+    },
+    {
+      name: "R executable code string raw variable write",
+      command: 'Rscript -e \'p <- "data/raw/out.csv"; writeLines("x", p)\''
+    },
+    {
+      name: "Bun executable code string raw variable write",
+      command: 'bun -e \'const p="data/raw/out.csv"; await Bun.write(p, "x")\''
+    },
+    {
+      name: "Ruby executable code string raw variable write",
+      command: 'ruby -e \'p="data/raw/out.csv"; File.write(p, "x")\''
+    },
+    {
+      name: "PHP executable code string raw variable write",
+      command: "php -r '$p=\"data/raw/out.csv\"; file_put_contents($p, \"x\");'"
+    },
+    {
+      name: "Perl executable code string raw variable write",
+      command: 'perl -e \'my $p="data/raw/out.csv"; open(my $fh, ">", $p); print $fh "x";\''
+    },
+    {
       name: "python heredoc raw write",
       command: "python - <<'PY'\nopen(\"data/raw/input.csv\",\"w\").write(\"x\")\nPY"
     },
@@ -147,12 +177,44 @@ describe("data/raw write deny policy", () => {
       command: 'export RAW=data/raw; touch "$RAW/input.csv"'
     },
     {
+      name: "readonly variable-expanded remove",
+      command: 'readonly RAW=data/raw; rm "$RAW/input.csv"'
+    },
+    {
+      name: "declare variable-expanded remove",
+      command: 'declare RAW=data/raw; rm "$RAW/input.csv"'
+    },
+    {
+      name: "typeset variable-expanded remove",
+      command: 'typeset RAW=data/raw; rm "$RAW/input.csv"'
+    },
+    {
       name: "braced variable-expanded remove",
       command: 'RAW=data/raw; rm "${RAW}/input.csv"'
     },
     {
       name: "braced variable slice-expanded remove",
       command: 'RAW=data/raw-extra; rm "${RAW:0:8}/input.csv"'
+    },
+    {
+      name: "braced variable suffix trim remove",
+      command: 'RAW=data/raw/input.csv; rm "${RAW%/*}/out.csv"'
+    },
+    {
+      name: "braced variable prefix trim redirect write",
+      command: 'RAW=prefixdata/raw/input.csv; printf x > "${RAW#prefix}"'
+    },
+    {
+      name: "braced variable substitution remove",
+      command: 'RAW=data/processed/input.csv; rm "${RAW/processed/raw}"'
+    },
+    {
+      name: "braced variable substitution nested shell remove",
+      command: 'RAW=data/processed/input.csv bash -c \'rm "${RAW/processed/raw}"\''
+    },
+    {
+      name: "braced variable substitution eval remove",
+      command: 'RAW=data/processed/input.csv; eval \'rm "${RAW/processed/raw}"\''
     },
     {
       name: "partial variable-expanded remove",
@@ -255,6 +317,10 @@ describe("data/raw write deny policy", () => {
       command: "sed -nEi 's/a/b/' data/raw/input.csv"
     },
     {
+      name: "sed script write command raw output",
+      command: "sed -n 's/x/y/w data/raw/out.csv' /tmp/in"
+    },
+    {
       name: "find delete under raw",
       command: "find data/raw -delete"
     },
@@ -269,6 +335,22 @@ describe("data/raw write deny policy", () => {
     {
       name: "find ok remove under raw",
       command: "find data/raw -type f -ok rm {} +"
+    },
+    {
+      name: "find exec shell raw redirect write",
+      command: "find . -exec sh -c 'printf x > data/raw/out.csv' \\;"
+    },
+    {
+      name: "trap shell raw remove",
+      command: "trap 'rm data/raw/input.csv' EXIT"
+    },
+    {
+      name: "awk script raw output redirection",
+      command: "awk 'BEGIN { print \"x\" > \"data/raw/out.csv\" }'"
+    },
+    {
+      name: "awk script raw system mutation",
+      command: "awk 'BEGIN { system(\"rm data/raw/out.csv\") }'"
     },
     {
       name: "rsync destination under raw",
@@ -477,6 +559,14 @@ describe("data/raw write deny policy", () => {
       command: "ln /tmp/input.csv data/raw/input.csv"
     },
     {
+      name: "same-command relative symlink alias to data raw",
+      command: "ln -s data data-link; touch data-link/raw/input.csv"
+    },
+    {
+      name: "same-command absolute symlink alias to data raw",
+      command: "ln -s /tmp/shud-harness-test/data data-link; touch data-link/raw/input.csv"
+    },
+    {
       name: "truncate target",
       command: "truncate -s 0 data/raw/input.csv"
     },
@@ -497,12 +587,52 @@ describe("data/raw write deny policy", () => {
       command: "bash -c 'rm \"$1\"' -- data/raw/input.csv"
     },
     {
+      name: "bash shell wrapper positional zero raw remove",
+      command: "bash -c 'rm \"$0\"' data/raw/input.csv"
+    },
+    {
+      name: "bash shell wrapper positional at raw remove",
+      command: "bash -c 'rm \"$@\"' -- data/raw/input.csv"
+    },
+    {
+      name: "bash shell wrapper positional star raw remove",
+      command: "bash -c 'rm \"$*\"' -- data/raw/input.csv"
+    },
+    {
       name: "sh shell wrapper",
       command: "sh -c 'printf x > data/raw/input.csv'"
     },
     {
+      name: "sh shell wrapper positional zero raw remove",
+      command: "sh -c 'rm \"$0\"' data/raw/input.csv"
+    },
+    {
+      name: "sh shell wrapper positional at raw remove",
+      command: "sh -c 'rm \"$@\"' -- data/raw/input.csv"
+    },
+    {
+      name: "sh shell wrapper positional star raw remove",
+      command: "sh -c 'rm \"$*\"' -- data/raw/input.csv"
+    },
+    {
       name: "zsh shell wrapper",
       command: "zsh -c 'printf x > data/raw/input.csv'"
+    },
+    {
+      name: "zsh shell wrapper positional zero raw remove",
+      command: "zsh -c 'rm \"$0\"' data/raw/input.csv"
+    },
+    {
+      name: "zsh shell wrapper positional at raw remove",
+      command: "zsh -c 'rm \"$@\"' -- data/raw/input.csv"
+    },
+    {
+      name: "zsh shell wrapper positional star raw remove",
+      command: "zsh -c 'rm \"$*\"' -- data/raw/input.csv"
+    },
+    {
+      name: "implicit positional loop raw remove",
+      command: "bash -c 'for p; do rm \"$p\"; done' -- data/raw/input.csv"
     },
     {
       name: "env chdir relative remove",
@@ -537,8 +667,8 @@ describe("data/raw write deny policy", () => {
       command: largeExecutableCodeWriteCommand
     },
     {
-      name: "large non-executable heredoc is bounded",
-      command: largeNonExecutableHeredocCommand
+      name: "large shell raw write evidence is bounded",
+      command: largeRawWriteEvidenceCommand
     }
   ] as const;
 
@@ -600,8 +730,48 @@ describe("data/raw write deny policy", () => {
       command: "sha256sum data/raw/input.csv"
     },
     {
+      name: "du raw directory",
+      command: "du -sh data/raw"
+    },
+    {
+      name: "file raw input",
+      command: "file data/raw/input.csv"
+    },
+    {
+      name: "test raw input exists",
+      command: "test -f data/raw/input.csv"
+    },
+    {
+      name: "read raw input redirect",
+      command: "read p < data/raw/input.csv"
+    },
+    {
+      name: "mapfile raw input redirect",
+      command: "mapfile a < data/raw/input.csv"
+    },
+    {
+      name: "input-only raw redirect",
+      command: "< data/raw/input.csv"
+    },
+    {
       name: "python executable code string raw read",
       command: 'python -c \'print(open("data/raw/input.csv").read())\''
+    },
+    {
+      name: "node executable code string raw read",
+      command: 'node -e \'const p="data/raw/input.csv"; require("fs").readFileSync(p)\''
+    },
+    {
+      name: "Ruby executable code string raw read",
+      command: 'ruby -e \'p="data/raw/input.csv"; File.read(p)\''
+    },
+    {
+      name: "PHP executable code string raw read",
+      command: "php -r '$p=\"data/raw/input.csv\"; file_get_contents($p);'"
+    },
+    {
+      name: "Perl executable code string raw read",
+      command: 'perl -e \'my $p="data/raw/input.csv"; open(my $fh, "<", $p);\''
     },
     {
       name: "read-only find under raw",
@@ -661,6 +831,22 @@ describe("data/raw write deny policy", () => {
       command: "bash -c 'cat \"$1\"' -- data/raw/input.csv"
     },
     {
+      name: "bash shell wrapper positional zero raw read",
+      command: "bash -c 'cat \"$0\"' data/raw/input.csv"
+    },
+    {
+      name: "bash shell wrapper positional at raw read",
+      command: "bash -c 'cat \"$@\"' -- data/raw/input.csv"
+    },
+    {
+      name: "bash shell wrapper positional star raw read",
+      command: "bash -c 'cat \"$*\"' -- data/raw/input.csv"
+    },
+    {
+      name: "implicit positional loop raw read",
+      command: "bash -c 'for p; do cat \"$p\"; done' -- data/raw/input.csv"
+    },
+    {
       name: "workspace script heredoc with raw mutation text",
       command: "cat > workspace/tasks/TASK-001/script.sh <<'SH'\nrm data/raw/input.csv\nSH"
     },
@@ -675,6 +861,22 @@ describe("data/raw write deny policy", () => {
     {
       name: "single-quoted glob-like non-raw path mutation",
       command: "rm 'data/ra[w]/input.csv'"
+    },
+    {
+      name: "declare benign non-raw variable write",
+      command: 'declare OUT=workspace/tasks/TASK-001/out.csv; touch "$OUT"'
+    },
+    {
+      name: "readonly benign non-raw variable write",
+      command: 'readonly OUT=workspace/tasks/TASK-001/out.csv; touch "$OUT"'
+    },
+    {
+      name: "large command without raw path text",
+      command: largeNoRawCommand
+    },
+    {
+      name: "large non-executable workspace heredoc with raw mutation text",
+      command: largeNonExecutableHeredocCommand
     }
   ] as const;
 
@@ -687,32 +889,6 @@ describe("data/raw write deny policy", () => {
       expect(bashTool.calls).toBe(1);
     });
   }
-
-  test("denies mutation through a workspace symlink alias that resolves to data/raw", async () => {
-    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-raw-alias-"));
-    tempDirs.push(workspaceRoot);
-
-    const rawDir = path.join(workspaceRoot, "data", "raw");
-    const scratchDir = path.join(
-      workspaceRoot,
-      "workspace",
-      "tasks",
-      "TASK-001",
-      "scratch"
-    );
-    await mkdir(rawDir, { recursive: true });
-    await mkdir(scratchDir, { recursive: true });
-    await symlink(rawDir, path.join(scratchDir, "raw-link"), "dir");
-
-    const { result, bashTool } = await runWrappedBashCommand(
-      "touch workspace/tasks/TASK-001/scratch/raw-link/input.csv",
-      { workDir: workspaceRoot }
-    );
-
-    expect(result?.success).toBe(false);
-    expect(bashTool.calls).toBe(0);
-    expect(parseDeniedPayload(result).rule_id).toBe(DATA_RAW_WRITE_DENY_RULE_ID);
-  });
 
   test("audit helper appends a minimal row under the no-TaskCard fixture path", async () => {
     const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-"));

--- a/packages/core/src/tools/data-raw-write-rule.test.ts
+++ b/packages/core/src/tools/data-raw-write-rule.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
@@ -30,6 +30,14 @@ describe("data/raw write deny policy", () => {
       command: "printf x > data/raw/input.csv"
     },
     {
+      name: "fd redirect write with separated target",
+      command: "printf x >& data/raw/input.csv"
+    },
+    {
+      name: "fd redirect write with attached target",
+      command: "printf x >&data/raw/input.csv"
+    },
+    {
       name: "command substitution remove",
       command: "echo $(rm data/raw/input.csv)"
     },
@@ -42,8 +50,36 @@ describe("data/raw write deny policy", () => {
       command: 'echo "$(rm data/raw/input.csv)"'
     },
     {
+      name: "read-only command substitution with quoted open paren remove",
+      command: 'cat "$(echo "("; rm data/raw/input.csv)"'
+    },
+    {
+      name: "read-only command substitution with quoted open paren redirect write",
+      command: 'grep needle "$(echo "("; printf x > data/raw/input.csv)"'
+    },
+    {
+      name: "read-only command substitution with nested quoted command substitution remove",
+      command: 'cat "$(echo "$(echo ")")"; rm data/raw/input.csv)"'
+    },
+    {
+      name: "read-only command substitution with nested quoted backtick remove",
+      command: 'cat "$(echo "`echo )`"; rm data/raw/input.csv)"'
+    },
+    {
       name: "command substitution redirect write",
       command: "echo $(printf x > data/raw/input.csv)"
+    },
+    {
+      name: "command substitution after single quote backslash sequence",
+      command: "echo $(echo '\\'; rm data/raw/input.csv)"
+    },
+    {
+      name: "process substitution remove from input",
+      command: "cat <(rm data/raw/input.csv)"
+    },
+    {
+      name: "process substitution remove from output",
+      command: "cat >(rm data/raw/input.csv)"
     },
     {
       name: "backtick command substitution redirect write",
@@ -52,6 +88,38 @@ describe("data/raw write deny policy", () => {
     {
       name: "backtick command substitution escaped backtick",
       command: "echo `printf \\`; rm data/raw/input.csv`"
+    },
+    {
+      name: "eval single-quoted shell string remove",
+      command: "eval 'rm data/raw/input.csv'"
+    },
+    {
+      name: "eval double-quoted shell string redirect write",
+      command: 'eval "printf x > data/raw/input.csv"'
+    },
+    {
+      name: "python executable code string raw write",
+      command: 'python -c \'open("data/raw/x","w").write("x")\''
+    },
+    {
+      name: "variable-expanded remove",
+      command: 'RAW=data/raw; rm "$RAW/input.csv"'
+    },
+    {
+      name: "exported variable-expanded touch",
+      command: 'export RAW=data/raw; touch "$RAW/input.csv"'
+    },
+    {
+      name: "braced variable-expanded remove",
+      command: 'RAW=data/raw; rm "${RAW}/input.csv"'
+    },
+    {
+      name: "partial variable-expanded remove",
+      command: "RAW=raw; rm data/$RAW/file"
+    },
+    {
+      name: "exported variable-expanded shell wrapper remove",
+      command: 'export RAW=data/raw; bash -c \'rm "$RAW/input.csv"\''
     },
     {
       name: "curl short output option",
@@ -78,8 +146,141 @@ describe("data/raw write deny policy", () => {
       command: "curl --output=data/raw/input.csv https://example.invalid/input.csv"
     },
     {
+      name: "sed long in-place option",
+      command: "sed --in-place 's/a/b/' data/raw/input.csv"
+    },
+    {
+      name: "sed combined in-place edit option",
+      command: "sed -Ei 's/a/b/' data/raw/input.csv"
+    },
+    {
+      name: "sed combined no-print in-place edit option",
+      command: "sed -nEi 's/a/b/' data/raw/input.csv"
+    },
+    {
+      name: "find delete under raw",
+      command: "find data/raw -delete"
+    },
+    {
+      name: "find exec remove under raw",
+      command: "find data/raw -type f -exec rm {} +"
+    },
+    {
+      name: "find execdir remove under raw",
+      command: "find data/raw -type f -execdir rm {} +"
+    },
+    {
+      name: "find ok remove under raw",
+      command: "find data/raw -type f -ok rm {} +"
+    },
+    {
+      name: "rsync destination under raw",
+      command: "rsync /tmp/input.csv data/raw/input.csv"
+    },
+    {
+      name: "tar extraction into raw",
+      command: "tar -xf archive.tar -C data/raw"
+    },
+    {
+      name: "unzip extraction into raw",
+      command: "unzip archive.zip -d data/raw"
+    },
+    {
+      name: "wget output document under raw",
+      command: "wget -O data/raw/input.csv https://example.invalid/input.csv"
+    },
+    {
+      name: "git clone destination under raw",
+      command: "git clone https://example.invalid/repo.git data/raw/repo"
+    },
+    {
+      name: "brace expansion touching raw",
+      command: "touch data/{raw,processed}/x"
+    },
+    {
+      name: "nested brace expansion touching raw",
+      command: "touch data/{processed,{raw,tmp}}/x"
+    },
+    {
+      name: "partially quoted brace expansion touching raw",
+      command: 'touch data/{ra"w",processed}/x'
+    },
+    {
+      name: "brace expansion raw alternative beyond budget",
+      command:
+        "touch data/{a00,a01,a02,a03,a04,a05,a06,a07,a08,a09,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51,a52,a53,a54,a55,a56,a57,a58,a59,a60,a61,a62,a63,a64,raw}/x"
+    },
+    {
+      name: "raw path containing workspace tasks segment",
+      command: "touch data/raw/workspace/tasks/TASK-001/out.csv"
+    },
+    {
+      name: "fallback long option assignment raw output",
+      command: "unknown-writer --output=data/raw/out.csv"
+    },
+    {
+      name: "fallback long option assignment raw directory",
+      command: "unknown-writer --dest=data/raw"
+    },
+    {
+      name: "fallback attached short option raw output",
+      command: "unknown-writer -odata/raw/out.csv"
+    },
+    {
+      name: "fallback script option assignment raw output",
+      command: "python script.py --out=data/raw/out.csv"
+    },
+    {
+      name: "fallback quoted script option assignment raw output",
+      command: 'python script.py --out="data/raw/out.csv"'
+    },
+    {
+      name: "fallback quoted long option assignment raw output",
+      command: 'unknown-writer "--out=data/raw/out.csv"'
+    },
+    {
+      name: "fallback quoted attached short option raw output",
+      command: 'unknown-writer -o"data/raw/out.csv"'
+    },
+    {
+      name: "ansi-c quoted literal remove",
+      command: "rm $'data/raw/input.csv'"
+    },
+    {
+      name: "ansi-c quoted literal redirect write",
+      command: "printf x > $'data/raw/input.csv'"
+    },
+    {
+      name: "ansi-c quoted literal hex escape remove",
+      command: "rm $'data/ra\\x77/input.csv'"
+    },
+    {
+      name: "ansi-c quoted literal octal escape redirect write",
+      command: "printf x > $'data\\057raw/input.csv'"
+    },
+    {
+      name: "ansi-c quoted literal unicode slash redirect write",
+      command: "printf x > $'data\\u002fraw/input.csv'"
+    },
+    {
+      name: "ansi-c quoted literal unicode character remove",
+      command: "rm $'data/ra\\u0077/input.csv'"
+    },
+    {
+      name: "localized quoted literal remove",
+      command: 'rm $"data/raw/input.csv"'
+    },
+    {
+      name: "single quote does not escape command separator",
+      command: "echo '\\'; rm data/raw/input.csv"
+    },
+    {
       name: "newline command list",
       command: "cat data/raw/input.csv\nrm data/raw/input.csv"
+    },
+    {
+      name: "background command list",
+      command: "cat data/raw/input.csv & rm data/raw/input.csv"
     },
     {
       name: "nice short adjustment wrapper remove",
@@ -100,6 +301,34 @@ describe("data/raw write deny policy", () => {
     {
       name: "env long unset assignment wrapper remove",
       command: "env --unset=FOO rm data/raw/input.csv"
+    },
+    {
+      name: "sudo short user wrapper remove",
+      command: "sudo -u root rm data/raw/input.csv"
+    },
+    {
+      name: "sudo long user wrapper remove",
+      command: "sudo --user root rm data/raw/input.csv"
+    },
+    {
+      name: "sudo unknown short group wrapper raw uncertainty",
+      command: "sudo -g cat rm data/raw/input.csv"
+    },
+    {
+      name: "sudo unknown long group wrapper raw uncertainty",
+      command: "sudo --group cat rm data/raw/input.csv"
+    },
+    {
+      name: "doas short user wrapper remove",
+      command: "doas -u root rm data/raw/input.csv"
+    },
+    {
+      name: "time format wrapper remove",
+      command: "time -f '%E' rm data/raw/input.csv"
+    },
+    {
+      name: "env chdir wrapper remove",
+      command: "env --chdir /tmp rm data/raw/input.csv"
     },
     {
       name: "dd output file",
@@ -171,6 +400,38 @@ describe("data/raw write deny policy", () => {
     {
       name: "curl read-only request",
       command: "curl -fsSL https://example.invalid/input.csv"
+    },
+    {
+      name: "read-only find under raw",
+      command: "find data/raw -maxdepth 1 -type f"
+    },
+    {
+      name: "ls raw directory",
+      command: "ls data/raw"
+    },
+    {
+      name: "wc raw file",
+      command: "wc -l data/raw/input.csv"
+    },
+    {
+      name: "head raw file",
+      command: "head -n 1 data/raw/input.csv"
+    },
+    {
+      name: "tail raw file",
+      command: "tail -n 1 data/raw/input.csv"
+    },
+    {
+      name: "non-in-place sed raw file",
+      command: "sed -n 1p data/raw/input.csv"
+    },
+    {
+      name: "task scratch path containing data raw",
+      command: "touch workspace/tasks/TASK-001/scratch/data/raw/out.csv"
+    },
+    {
+      name: "quoted brace fallback option",
+      command: 'unknown-writer "--out=data/{raw,processed}/out.csv"'
     }
   ] as const;
 
@@ -260,6 +521,65 @@ describe("data/raw write deny policy", () => {
         path.join(workspaceRoot, "workspace", "tasks", "TASK-M1-SPIKE", "outside.ndjson")
       )
     ).toBe(false);
+  });
+
+  test("audit helper rejects an audit directory symlink that resolves outside the workspace", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-"));
+    const outsideDir = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-outside-"));
+    tempDirs.push(workspaceRoot, outsideDir);
+
+    const taskDir = path.join(workspaceRoot, "workspace", "tasks", "TASK-M1-SPIKE");
+    await mkdir(taskDir, { recursive: true });
+    await symlink(outsideDir, path.join(taskDir, "audit"), "dir");
+
+    await expect(
+      appendPolicyGateAuditRow(sampleAuditRow(), {
+        workspaceRoot
+      })
+    ).rejects.toThrow("Invalid policy gate audit directory: resolves outside workspace.");
+
+    expect(await pathExists(path.join(outsideDir, "policy-gate-audit.ndjson"))).toBe(false);
+  });
+
+  test("audit helper rejects an audit file symlink that resolves outside the audit directory", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-"));
+    const outsideDir = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-outside-"));
+    tempDirs.push(workspaceRoot, outsideDir);
+
+    const auditDir = path.join(workspaceRoot, "workspace", "tasks", "TASK-M1-SPIKE", "audit");
+    const outsideFile = path.join(outsideDir, "policy-gate-audit.ndjson");
+    const auditPath = path.join(auditDir, "policy-gate-audit.ndjson");
+    await mkdir(auditDir, { recursive: true });
+    await writeFile(outsideFile, "original\n", "utf8");
+    await symlink(outsideFile, auditPath);
+
+    await expect(
+      appendPolicyGateAuditRow(sampleAuditRow(), {
+        workspaceRoot
+      })
+    ).rejects.toThrow("Invalid policy gate audit fileName: resolves outside audit directory.");
+
+    expect(await readFile(outsideFile, "utf8")).toBe("original\n");
+  });
+
+  test("audit helper rejects an audit file symlink before appending through it", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-"));
+    tempDirs.push(workspaceRoot);
+
+    const auditDir = path.join(workspaceRoot, "workspace", "tasks", "TASK-M1-SPIKE", "audit");
+    const realAuditFile = path.join(auditDir, "real-policy-gate-audit.ndjson");
+    const auditPath = path.join(auditDir, "policy-gate-audit.ndjson");
+    await mkdir(auditDir, { recursive: true });
+    await writeFile(realAuditFile, "original\n", "utf8");
+    await symlink(realAuditFile, auditPath);
+
+    await expect(
+      appendPolicyGateAuditRow(sampleAuditRow(), {
+        workspaceRoot
+      })
+    ).rejects.toThrow("Invalid policy gate audit fileName: must not be a symlink.");
+
+    expect(await readFile(realAuditFile, "utf8")).toBe("original\n");
   });
 
   test("data/raw rule exposes a legal guard_class marker", () => {

--- a/packages/core/src/tools/data-raw-write-rule.test.ts
+++ b/packages/core/src/tools/data-raw-write-rule.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
@@ -36,6 +36,24 @@ describe("data/raw write deny policy", () => {
     {
       name: "fd redirect write with attached target",
       command: "printf x >&data/raw/input.csv"
+    },
+    {
+      name: "redirect write from raw workDir",
+      command: "printf x > input.csv",
+      workDir: "/tmp/shud-harness-test/data/raw"
+    },
+    {
+      name: "relative raw write from data workDir",
+      command: "touch raw/input.csv",
+      workDir: "/tmp/shud-harness-test/data"
+    },
+    {
+      name: "cd updates relative remove target",
+      command: "cd data && rm raw/input.csv"
+    },
+    {
+      name: "cd updates relative redirect target",
+      command: "cd data && printf x > raw/input.csv"
     },
     {
       name: "command substitution remove",
@@ -102,6 +120,14 @@ describe("data/raw write deny policy", () => {
       command: 'python -c \'open("data/raw/x","w").write("x")\''
     },
     {
+      name: "python heredoc raw write",
+      command: "python - <<'PY'\nopen(\"data/raw/input.csv\",\"w\").write(\"x\")\nPY"
+    },
+    {
+      name: "shell heredoc raw write",
+      command: "bash <<'SH'\nrm data/raw/input.csv\nSH"
+    },
+    {
       name: "variable-expanded remove",
       command: 'RAW=data/raw; rm "$RAW/input.csv"'
     },
@@ -118,8 +144,36 @@ describe("data/raw write deny policy", () => {
       command: "RAW=raw; rm data/$RAW/file"
     },
     {
+      name: "composed variable-expanded remove",
+      command: 'ROOT=data; KIND=raw; PATHNAME="$ROOT/$KIND"; rm "$PATHNAME/input.csv"'
+    },
+    {
+      name: "composed variable-expanded eval remove",
+      command: 'ROOT=data; KIND=raw; CMD="rm $ROOT/$KIND/input.csv"; eval "$CMD"'
+    },
+    {
       name: "exported variable-expanded shell wrapper remove",
       command: 'export RAW=data/raw; bash -c \'rm "$RAW/input.csv"\''
+    },
+    {
+      name: "command substitution path expansion remove",
+      command: "rm data/ra$(printf w)/input.csv"
+    },
+    {
+      name: "parameter default path expansion remove",
+      command: "rm ${UNSET:-data/raw/input.csv}"
+    },
+    {
+      name: "glob bracket path expansion remove",
+      command: "rm data/ra[w]/input.csv"
+    },
+    {
+      name: "glob question path expansion remove",
+      command: "rm data/ra?/input.csv"
+    },
+    {
+      name: "glob bracket redirect write",
+      command: "printf x > data/ra[w]/input.csv"
     },
     {
       name: "curl short output option",
@@ -360,9 +414,9 @@ describe("data/raw write deny policy", () => {
     }
   ] as const;
 
-  for (const { name, command } of deniedCommands) {
+  for (const { name, command, workDir } of deniedCommands) {
     test(`denies ${name} before the command implementation executes`, async () => {
-      const { result, bashTool } = await runWrappedBashCommand(command);
+      const { result, bashTool } = await runWrappedBashCommand(command, { workDir });
 
       expect(result?.success).toBe(false);
       expect(bashTool.calls).toBe(0);
@@ -402,6 +456,26 @@ describe("data/raw write deny policy", () => {
       command: "curl -fsSL https://example.invalid/input.csv"
     },
     {
+      name: "curl read-only URL containing data raw",
+      command: "curl -fsSL https://example.invalid/data/raw/input.csv"
+    },
+    {
+      name: "wget read-only URL containing data raw",
+      command: "wget https://example.invalid/data/raw/input.csv"
+    },
+    {
+      name: "stat raw input",
+      command: "stat data/raw/input.csv"
+    },
+    {
+      name: "sha256sum raw input",
+      command: "sha256sum data/raw/input.csv"
+    },
+    {
+      name: "python executable code string raw read",
+      command: 'python -c \'print(open("data/raw/input.csv").read())\''
+    },
+    {
       name: "read-only find under raw",
       command: "find data/raw -maxdepth 1 -type f"
     },
@@ -432,6 +506,10 @@ describe("data/raw write deny policy", () => {
     {
       name: "quoted brace fallback option",
       command: 'unknown-writer "--out=data/{raw,processed}/out.csv"'
+    },
+    {
+      name: "single-quoted glob-like non-raw path mutation",
+      command: "rm 'data/ra[w]/input.csv'"
     }
   ] as const;
 
@@ -582,12 +660,40 @@ describe("data/raw write deny policy", () => {
     expect(await readFile(realAuditFile, "utf8")).toBe("original\n");
   });
 
+  test("audit helper rejects a parent directory swap before writing the opened file", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-"));
+    const outsideDir = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-outside-"));
+    tempDirs.push(workspaceRoot, outsideDir);
+
+    const taskDir = path.join(workspaceRoot, "workspace", "tasks", "TASK-M1-SPIKE");
+    const auditDir = path.join(taskDir, "audit");
+    const movedAuditDir = path.join(taskDir, "audit-original");
+    const auditPathAfterMove = path.join(movedAuditDir, "policy-gate-audit.ndjson");
+    await mkdir(auditDir, { recursive: true });
+
+    await expect(
+      appendPolicyGateAuditRow(sampleAuditRow(), {
+        workspaceRoot,
+        beforeWriteForTest: async () => {
+          await rename(auditDir, movedAuditDir);
+          await symlink(outsideDir, auditDir, "dir");
+        }
+      })
+    ).rejects.toThrow("Invalid policy gate audit directory: resolves outside workspace.");
+
+    expect(await pathExists(path.join(outsideDir, "policy-gate-audit.ndjson"))).toBe(false);
+    expect(await readFile(auditPathAfterMove, "utf8")).toBe("");
+  });
+
   test("data/raw rule exposes a legal guard_class marker", () => {
     expect(DATA_RAW_WRITE_DENY_RULE.guard_class).toBe("authority");
   });
 });
 
-async function runWrappedBashCommand(command: string): Promise<{
+async function runWrappedBashCommand(
+  command: string,
+  options: { workDir?: string } = {}
+): Promise<{
   result: ToolResult | undefined;
   bashTool: RecordingTool;
 }> {
@@ -596,9 +702,12 @@ async function runWrappedBashCommand(command: string): Promise<{
     evaluate: createPolicyGateEvaluator(makeDataRawPolicyGateContext())
   });
 
-  const result = await registry.get("bash")?.run(createToolContext("worker"), {
-    command
-  });
+  const result = await registry.get("bash")?.run(
+    createToolContext("worker", options.workDir),
+    {
+      command
+    }
+  );
 
   return {
     result,
@@ -683,11 +792,13 @@ class RecordingTool extends BaseTool {
   }
 }
 
-function createToolContext(role: string): ToolContext & { role: string } {
+function createToolContext(role: string, workDir = "/tmp/shud-harness-test"): ToolContext & {
+  role: string;
+} {
   return {
     role,
     sessionId: "TEST-SESSION",
-    workDir: "/tmp/shud-harness-test",
+    workDir,
     logger: testLogger
   };
 }

--- a/packages/core/src/tools/data-raw-write-rule.test.ts
+++ b/packages/core/src/tools/data-raw-write-rule.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { link, mkdir, mkdtemp, readFile, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
@@ -29,6 +29,9 @@ describe("data/raw write deny policy", () => {
   )}writeLines("x", "data/raw/out.csv")'`;
   const largeNoRawCommand = `printf '${"x".repeat(300000)}'`;
   const largeRawWriteEvidenceCommand = `${"true\n".repeat(60000)}rm data/raw/input.csv`;
+  const largeDynamicRawWriteEvidenceCommand = `${"true\n".repeat(
+    60000
+  )}rm data/ra$(printf w)/input.csv`;
   const largeNonExecutableHeredocCommand = `cat > workspace/tasks/TASK-001/script.sh <<'SH'\n${"echo filler\n".repeat(
     30000
   )}rm data/raw/input.csv\nSH`;
@@ -161,6 +164,40 @@ describe("data/raw write deny policy", () => {
       command: 'perl -e \'my $p="data/raw/out.csv"; open(my $fh, ">", $p); print $fh "x";\''
     },
     {
+      name: "python executable code string concat raw write",
+      command: 'python -c \'open("data/"+"raw/out.csv","w").write("x")\''
+    },
+    {
+      name: "python pathlib executable code string raw write",
+      command:
+        'python -c \'from pathlib import Path; p=Path("data")/"raw"/"out.csv"; p.write_text("x")\''
+    },
+    {
+      name: "node path join executable code string raw write",
+      command:
+        'node -e \'const path=require("path"); require("fs").writeFileSync(path.join("data","raw","out.csv"), "x")\''
+    },
+    {
+      name: "R file.path executable code string raw write",
+      command: 'Rscript -e \'writeLines("x", file.path("data","raw","out.csv"))\''
+    },
+    {
+      name: "Deno writeTextFile raw write",
+      command: 'deno eval \'await Deno.writeTextFile("data/raw/out.txt", "x")\''
+    },
+    {
+      name: "Deno writeTextFileSync raw write",
+      command: 'deno eval \'Deno.writeTextFileSync("data/raw/out.txt", "x")\''
+    },
+    {
+      name: "Perl in-place raw edit",
+      command: "perl -pi -e 's/a/b/' data/raw/input.csv"
+    },
+    {
+      name: "Ruby in-place raw edit",
+      command: "ruby -pi -e 'gsub(/a/, \"b\")' data/raw/input.csv"
+    },
+    {
       name: "python heredoc raw write",
       command: "python - <<'PY'\nopen(\"data/raw/input.csv\",\"w\").write(\"x\")\nPY"
     },
@@ -249,6 +286,22 @@ describe("data/raw write deny policy", () => {
       command: "rm data/ra$(printf w)/input.csv"
     },
     {
+      name: "dynamic variable assignment full raw path remove",
+      command: 'RAW=$(printf data/raw); rm "$RAW/input.csv"'
+    },
+    {
+      name: "dynamic variable assignment partial raw redirect write",
+      command: 'KIND=$(printf raw); printf x > "data/$KIND/out.csv"'
+    },
+    {
+      name: "dynamic default assignment composed raw remove",
+      command: 'unset MISSING; ROOT=${MISSING:-data}; KIND=raw; rm "$ROOT/$KIND/input.csv"'
+    },
+    {
+      name: "dynamic default assignment partial raw remove",
+      command: "unset KIND; KIND=${KIND:-raw}; rm data/$KIND/input.csv"
+    },
+    {
       name: "parameter default path expansion remove",
       command: "rm ${UNSET:-data/raw/input.csv}"
     },
@@ -281,6 +334,14 @@ describe("data/raw write deny policy", () => {
       command: "printf x > DATA/RAW/input.csv"
     },
     {
+      name: "braced variable lowercase transform raw touch",
+      command: 'RAW=DATA/RAW; touch "${RAW,,}/x"'
+    },
+    {
+      name: "braced variable uppercase transform raw touch",
+      command: 'RAW=data/raw; touch "${RAW^^}/x"'
+    },
+    {
       name: "curl short output option",
       command: "curl -o data/raw/input.csv https://example.invalid/input.csv"
     },
@@ -303,6 +364,18 @@ describe("data/raw write deny policy", () => {
     {
       name: "curl long output assignment option",
       command: "curl --output=data/raw/input.csv https://example.invalid/input.csv"
+    },
+    {
+      name: "curl output directory with relative output",
+      command: "curl --output-dir data/raw -o input.csv https://example.invalid/input.csv"
+    },
+    {
+      name: "curl remote-name output directory",
+      command: "curl -O --output-dir data/raw https://example.invalid/input.csv"
+    },
+    {
+      name: "curl remote-name-all output directory assignment",
+      command: "curl --output-dir=data/raw --remote-name-all https://example.invalid/input.csv"
     },
     {
       name: "sed long in-place option",
@@ -535,6 +608,10 @@ describe("data/raw write deny policy", () => {
       command: "time -f '%E' rm data/raw/input.csv"
     },
     {
+      name: "command path wrapper remove",
+      command: "command -p rm data/raw/input.csv"
+    },
+    {
       name: "env chdir wrapper remove",
       command: "env --chdir /tmp rm data/raw/input.csv"
     },
@@ -557,6 +634,10 @@ describe("data/raw write deny policy", () => {
     {
       name: "ln raw destination",
       command: "ln /tmp/input.csv data/raw/input.csv"
+    },
+    {
+      name: "symlink target exposes raw ancestor",
+      command: "ln -s data data-link"
     },
     {
       name: "same-command relative symlink alias to data raw",
@@ -669,6 +750,10 @@ describe("data/raw write deny policy", () => {
     {
       name: "large shell raw write evidence is bounded",
       command: largeRawWriteEvidenceCommand
+    },
+    {
+      name: "large shell dynamic raw write evidence is bounded",
+      command: largeDynamicRawWriteEvidenceCommand
     }
   ] as const;
 
@@ -692,6 +777,14 @@ describe("data/raw write deny policy", () => {
     {
       name: "cat raw input",
       command: "cat data/raw/input.csv"
+    },
+    {
+      name: "echo raw input path",
+      command: "echo data/raw/input.csv"
+    },
+    {
+      name: "printf raw input path",
+      command: "printf '%s\\n' data/raw/input.csv"
     },
     {
       name: "copy raw input outside raw",
@@ -778,6 +871,14 @@ describe("data/raw write deny policy", () => {
       command: "find data/raw -maxdepth 1 -type f"
     },
     {
+      name: "read-only find exec cat under raw",
+      command: "find data/raw -type f -exec cat {} +"
+    },
+    {
+      name: "read-only find exec grep under raw",
+      command: "find data/raw -type f -exec grep needle {} +"
+    },
+    {
       name: "ls raw directory",
       command: "ls data/raw"
     },
@@ -825,6 +926,10 @@ describe("data/raw write deny policy", () => {
     {
       name: "rsync raw source to governed destination",
       command: "rsync data/raw/input.csv workspace/tasks/TASK-001/input.csv"
+    },
+    {
+      name: "command path wrapper raw read",
+      command: "command -p cat data/raw/input.csv"
     },
     {
       name: "bash shell wrapper positional raw read",
@@ -889,6 +994,33 @@ describe("data/raw write deny policy", () => {
       expect(bashTool.calls).toBe(1);
     });
   }
+
+  test("data/raw rule treats missing workDir as an unknown cwd", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-cwd-"));
+    tempDirs.push(workspaceRoot);
+    const dataDir = path.join(workspaceRoot, "data");
+    await mkdir(path.join(dataDir, "raw"), { recursive: true });
+
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(os.tmpdir());
+      const outsideDecision = DATA_RAW_WRITE_DENY_RULE.evaluate({
+        toolId: "bash",
+        input: { command: "touch raw/input.csv" }
+      });
+
+      process.chdir(dataDir);
+      const dataDirDecision = DATA_RAW_WRITE_DENY_RULE.evaluate({
+        toolId: "bash",
+        input: { command: "touch raw/input.csv" }
+      });
+
+      expect(outsideDecision.decision).toBe("allow");
+      expect(dataDirDecision.decision).toBe("allow");
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
 
   test("audit helper appends a minimal row under the no-TaskCard fixture path", async () => {
     const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-"));
@@ -1044,6 +1176,27 @@ describe("data/raw write deny policy", () => {
     ).rejects.toThrow("Invalid policy gate audit fileName: must not be a symlink.");
 
     expect(await readFile(realAuditFile, "utf8")).toBe("original\n");
+  });
+
+  test("audit helper rejects a hardlinked audit file before appending through it", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-"));
+    const outsideDir = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-outside-"));
+    tempDirs.push(workspaceRoot, outsideDir);
+
+    const auditDir = path.join(workspaceRoot, "workspace", "tasks", "TASK-M1-SPIKE", "audit");
+    const outsideFile = path.join(outsideDir, "policy-gate-audit.ndjson");
+    const auditPath = path.join(auditDir, "policy-gate-audit.ndjson");
+    await mkdir(auditDir, { recursive: true });
+    await writeFile(outsideFile, "original\n", "utf8");
+    await link(outsideFile, auditPath);
+
+    await expect(
+      appendPolicyGateAuditRow(sampleAuditRow(), {
+        workspaceRoot
+      })
+    ).rejects.toThrow("Invalid policy gate audit fileName: must not be a hardlink.");
+
+    expect(await readFile(outsideFile, "utf8")).toBe("original\n");
   });
 
   test("audit helper rejects a parent directory swap before writing the opened file", async () => {

--- a/packages/core/src/tools/data-raw-write-rule.test.ts
+++ b/packages/core/src/tools/data-raw-write-rule.test.ts
@@ -30,8 +30,76 @@ describe("data/raw write deny policy", () => {
       command: "printf x > data/raw/input.csv"
     },
     {
+      name: "command substitution remove",
+      command: "echo $(rm data/raw/input.csv)"
+    },
+    {
+      name: "backtick command substitution remove",
+      command: "echo `rm data/raw/input.csv`"
+    },
+    {
+      name: "double-quoted command substitution remove",
+      command: 'echo "$(rm data/raw/input.csv)"'
+    },
+    {
+      name: "command substitution redirect write",
+      command: "echo $(printf x > data/raw/input.csv)"
+    },
+    {
+      name: "backtick command substitution redirect write",
+      command: "echo `printf x > data/raw/input.csv`"
+    },
+    {
+      name: "backtick command substitution escaped backtick",
+      command: "echo `printf \\`; rm data/raw/input.csv`"
+    },
+    {
+      name: "curl short output option",
+      command: "curl -o data/raw/input.csv https://example.invalid/input.csv"
+    },
+    {
+      name: "curl clustered short output option",
+      command: "curl -Lo data/raw/input.csv https://example.invalid/input.csv"
+    },
+    {
+      name: "curl clustered flags short output option",
+      command: "curl -fsSLo data/raw/input.csv https://example.invalid/input.csv"
+    },
+    {
+      name: "curl attached short output option",
+      command: "curl -odata/raw/input.csv https://example.invalid/input.csv"
+    },
+    {
+      name: "curl long output option",
+      command: "curl --output data/raw/input.csv https://example.invalid/input.csv"
+    },
+    {
+      name: "curl long output assignment option",
+      command: "curl --output=data/raw/input.csv https://example.invalid/input.csv"
+    },
+    {
       name: "newline command list",
       command: "cat data/raw/input.csv\nrm data/raw/input.csv"
+    },
+    {
+      name: "nice short adjustment wrapper remove",
+      command: "nice -n 5 rm data/raw/input.csv"
+    },
+    {
+      name: "nice long adjustment wrapper remove",
+      command: "nice --adjustment 5 rm data/raw/input.csv"
+    },
+    {
+      name: "env short unset wrapper remove",
+      command: "env -u FOO rm data/raw/input.csv"
+    },
+    {
+      name: "env long unset wrapper remove",
+      command: "env --unset FOO rm data/raw/input.csv"
+    },
+    {
+      name: "env long unset assignment wrapper remove",
+      command: "env --unset=FOO rm data/raw/input.csv"
     },
     {
       name: "dd output file",
@@ -91,6 +159,18 @@ describe("data/raw write deny policy", () => {
     {
       name: "read-only multiline command list",
       command: "cat data/raw/input.csv\ncp data/raw/input.csv /tmp/out.csv"
+    },
+    {
+      name: "quoted operator pattern",
+      command: "grep '>' data/raw/input.csv"
+    },
+    {
+      name: "single-quoted backtick literal",
+      command: "grep '`' data/raw/input.csv"
+    },
+    {
+      name: "curl read-only request",
+      command: "curl -fsSL https://example.invalid/input.csv"
     }
   ] as const;
 

--- a/packages/core/src/tools/data-raw-write-rule.test.ts
+++ b/packages/core/src/tools/data-raw-write-rule.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
@@ -8,7 +8,7 @@ import {
   createPolicyGateEvaluator,
   createPolicyGatedToolRegistry
 } from "./policy-gate-registry";
-import { appendPolicyGateAuditRow } from "./policy-gate-audit";
+import { appendPolicyGateAuditRow, getPolicyGateAuditDir } from "./policy-gate-audit";
 import {
   DATA_RAW_WRITE_DENY_RULE,
   DATA_RAW_WRITE_DENY_RULE_ID,
@@ -24,49 +24,85 @@ afterEach(async () => {
 });
 
 describe("data/raw write deny policy", () => {
-  test("denies wrapped bash writes before the command implementation executes", async () => {
-    const bashTool = new RecordingTool("bash");
-    const registry = createPolicyGatedToolRegistry([bashTool], {
-      evaluate: createPolicyGateEvaluator(makeDataRawPolicyGateContext())
-    });
-
-    const result = await registry.get("bash")?.run(createToolContext("worker"), {
+  const deniedCommands = [
+    {
+      name: "redirect write",
       command: "printf x > data/raw/input.csv"
+    },
+    {
+      name: "newline command list",
+      command: "cat data/raw/input.csv\nrm data/raw/input.csv"
+    },
+    {
+      name: "dd output file",
+      command: "dd if=/dev/zero of=data/raw/input.csv"
+    },
+    {
+      name: "truncate target",
+      command: "truncate -s 0 data/raw/input.csv"
+    },
+    {
+      name: "cp short target directory",
+      command: "cp -t data/raw /tmp/input.csv"
+    },
+    {
+      name: "cp long target directory",
+      command: "cp --target-directory=data/raw /tmp/input.csv"
+    },
+    {
+      name: "bash shell wrapper",
+      command: "bash -c 'printf x > data/raw/input.csv'"
+    },
+    {
+      name: "sh shell wrapper",
+      command: "sh -c 'printf x > data/raw/input.csv'"
+    },
+    {
+      name: "zsh shell wrapper",
+      command: "zsh -c 'printf x > data/raw/input.csv'"
+    }
+  ] as const;
+
+  for (const { name, command } of deniedCommands) {
+    test(`denies ${name} before the command implementation executes`, async () => {
+      const { result, bashTool } = await runWrappedBashCommand(command);
+
+      expect(result?.success).toBe(false);
+      expect(bashTool.calls).toBe(0);
+
+      const payload = parseDeniedPayload(result);
+      expect(payload.rule_id).toBe(DATA_RAW_WRITE_DENY_RULE_ID);
+      expect(payload.guard_class).toBe(DATA_RAW_WRITE_GUARD_CLASS);
+      expect(payload.remediation?.next_action).toBeTruthy();
+      expect(payload.remediation?.hint).toBeTruthy();
+      expect(payload.remediation?.ref).toBeTruthy();
     });
+  }
 
-    expect(result?.success).toBe(false);
-    expect(bashTool.calls).toBe(0);
-
-    const payload = JSON.parse(result?.output ?? "{}") as {
-      rule_id?: string;
-      guard_class?: string;
-      remediation?: {
-        next_action?: string;
-        hint?: string;
-        ref?: string;
-      };
-    };
-    expect(payload.rule_id).toBe(DATA_RAW_WRITE_DENY_RULE_ID);
-    expect(payload.guard_class).toBe(DATA_RAW_WRITE_GUARD_CLASS);
-    expect(payload.remediation?.next_action).toBeTruthy();
-    expect(payload.remediation?.hint).toBeTruthy();
-    expect(payload.remediation?.ref).toBeTruthy();
-  });
-
-  test("read-only data/raw bash commands still execute through the wrapper", async () => {
-    const bashTool = new RecordingTool("bash");
-    const registry = createPolicyGatedToolRegistry([bashTool], {
-      evaluate: createPolicyGateEvaluator(makeDataRawPolicyGateContext())
-    });
-
-    const result = await registry.get("bash")?.run(createToolContext("worker"), {
+  const allowedCommands = [
+    {
+      name: "cat raw input",
       command: "cat data/raw/input.csv"
-    });
+    },
+    {
+      name: "copy raw input outside raw",
+      command: "cp data/raw/input.csv /tmp/out.csv"
+    },
+    {
+      name: "read-only multiline command list",
+      command: "cat data/raw/input.csv\ncp data/raw/input.csv /tmp/out.csv"
+    }
+  ] as const;
 
-    expect(result?.success).toBe(true);
-    expect(result?.output).toBe("bash executed");
-    expect(bashTool.calls).toBe(1);
-  });
+  for (const { name, command } of allowedCommands) {
+    test(`allows ${name} through the wrapper`, async () => {
+      const { result, bashTool } = await runWrappedBashCommand(command);
+
+      expect(result?.success).toBe(true);
+      expect(result?.output).toBe("bash executed");
+      expect(bashTool.calls).toBe(1);
+    });
+  }
 
   test("audit helper appends a minimal row under the no-TaskCard fixture path", async () => {
     const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-"));
@@ -104,10 +140,122 @@ describe("data/raw write deny policy", () => {
     });
   });
 
+  test("audit helper rejects traversal task ids before writing outside the task audit directory", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-"));
+    tempDirs.push(workspaceRoot);
+
+    expect(() => getPolicyGateAuditDir({ workspaceRoot, taskId: "../../outside" })).toThrow(
+      "Invalid policy gate audit taskId: must be a single path segment."
+    );
+    await expect(
+      appendPolicyGateAuditRow(sampleAuditRow(), {
+        workspaceRoot,
+        taskId: "../../outside"
+      })
+    ).rejects.toThrow("Invalid policy gate audit taskId: must be a single path segment.");
+
+    expect(
+      await pathExists(
+        path.join(workspaceRoot, "workspace", "outside", "audit", "policy-gate-audit.ndjson")
+      )
+    ).toBe(false);
+  });
+
+  test("audit helper rejects path-bearing file names before writing outside the audit directory", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-"));
+    tempDirs.push(workspaceRoot);
+
+    expect(() => getPolicyGateAuditDir({ workspaceRoot, fileName: "../outside.ndjson" })).toThrow(
+      "Invalid policy gate audit fileName: must be a single path segment."
+    );
+    await expect(
+      appendPolicyGateAuditRow(sampleAuditRow(), {
+        workspaceRoot,
+        fileName: "../outside.ndjson"
+      })
+    ).rejects.toThrow("Invalid policy gate audit fileName: must be a single path segment.");
+
+    expect(
+      await pathExists(
+        path.join(workspaceRoot, "workspace", "tasks", "TASK-M1-SPIKE", "outside.ndjson")
+      )
+    ).toBe(false);
+  });
+
   test("data/raw rule exposes a legal guard_class marker", () => {
     expect(DATA_RAW_WRITE_DENY_RULE.guard_class).toBe("authority");
   });
 });
+
+async function runWrappedBashCommand(command: string): Promise<{
+  result: ToolResult | undefined;
+  bashTool: RecordingTool;
+}> {
+  const bashTool = new RecordingTool("bash");
+  const registry = createPolicyGatedToolRegistry([bashTool], {
+    evaluate: createPolicyGateEvaluator(makeDataRawPolicyGateContext())
+  });
+
+  const result = await registry.get("bash")?.run(createToolContext("worker"), {
+    command
+  });
+
+  return {
+    result,
+    bashTool
+  };
+}
+
+function parseDeniedPayload(result: ToolResult | undefined): {
+  rule_id?: string;
+  guard_class?: string;
+  remediation?: {
+    next_action?: string;
+    hint?: string;
+    ref?: string;
+  };
+} {
+  return JSON.parse(result?.output ?? "{}") as {
+    rule_id?: string;
+    guard_class?: string;
+    remediation?: {
+      next_action?: string;
+      hint?: string;
+      ref?: string;
+    };
+  };
+}
+
+function sampleAuditRow() {
+  return {
+    event: "tool.failed",
+    tool_id: "bash",
+    rule: DATA_RAW_WRITE_DENY_RULE_ID,
+    decision: "deny" as const,
+    guard_class: DATA_RAW_WRITE_GUARD_CLASS
+  };
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENOENT"
+  );
+}
 
 class RecordingTool extends BaseTool {
   description: string;

--- a/packages/core/src/tools/data-raw-write-rule.test.ts
+++ b/packages/core/src/tools/data-raw-write-rule.test.ts
@@ -1,0 +1,152 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { BaseTool } from "@zero-os/core";
+import type { ToolContext, ToolLogger, ToolResult } from "@zero-os/shared";
+import {
+  createPolicyGateEvaluator,
+  createPolicyGatedToolRegistry
+} from "./policy-gate-registry";
+import { appendPolicyGateAuditRow } from "./policy-gate-audit";
+import {
+  DATA_RAW_WRITE_DENY_RULE,
+  DATA_RAW_WRITE_DENY_RULE_ID,
+  DATA_RAW_WRITE_GUARD_CLASS,
+  makeDataRawPolicyGateContext
+} from "./data-raw-write-rule";
+
+let tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  tempDirs = [];
+});
+
+describe("data/raw write deny policy", () => {
+  test("denies wrapped bash writes before the command implementation executes", async () => {
+    const bashTool = new RecordingTool("bash");
+    const registry = createPolicyGatedToolRegistry([bashTool], {
+      evaluate: createPolicyGateEvaluator(makeDataRawPolicyGateContext())
+    });
+
+    const result = await registry.get("bash")?.run(createToolContext("worker"), {
+      command: "printf x > data/raw/input.csv"
+    });
+
+    expect(result?.success).toBe(false);
+    expect(bashTool.calls).toBe(0);
+
+    const payload = JSON.parse(result?.output ?? "{}") as {
+      rule_id?: string;
+      guard_class?: string;
+      remediation?: {
+        next_action?: string;
+        hint?: string;
+        ref?: string;
+      };
+    };
+    expect(payload.rule_id).toBe(DATA_RAW_WRITE_DENY_RULE_ID);
+    expect(payload.guard_class).toBe(DATA_RAW_WRITE_GUARD_CLASS);
+    expect(payload.remediation?.next_action).toBeTruthy();
+    expect(payload.remediation?.hint).toBeTruthy();
+    expect(payload.remediation?.ref).toBeTruthy();
+  });
+
+  test("read-only data/raw bash commands still execute through the wrapper", async () => {
+    const bashTool = new RecordingTool("bash");
+    const registry = createPolicyGatedToolRegistry([bashTool], {
+      evaluate: createPolicyGateEvaluator(makeDataRawPolicyGateContext())
+    });
+
+    const result = await registry.get("bash")?.run(createToolContext("worker"), {
+      command: "cat data/raw/input.csv"
+    });
+
+    expect(result?.success).toBe(true);
+    expect(result?.output).toBe("bash executed");
+    expect(bashTool.calls).toBe(1);
+  });
+
+  test("audit helper appends a minimal row under the no-TaskCard fixture path", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-"));
+    tempDirs.push(workspaceRoot);
+
+    const result = await appendPolicyGateAuditRow(
+      {
+        event: "tool.failed",
+        tool_id: "bash",
+        rule: DATA_RAW_WRITE_DENY_RULE_ID,
+        decision: "deny",
+        guard_class: DATA_RAW_WRITE_GUARD_CLASS
+      },
+      {
+        workspaceRoot,
+        now: () => "2026-07-03T00:00:00.000Z"
+      }
+    );
+
+    expect(path.relative(workspaceRoot, result.auditDir)).toBe(
+      "workspace/tasks/TASK-M1-SPIKE/audit"
+    );
+
+    const rows = (await readFile(result.auditPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      event: "tool.failed",
+      tool_id: "bash",
+      rule: DATA_RAW_WRITE_DENY_RULE_ID,
+      decision: "deny",
+      ts: "2026-07-03T00:00:00.000Z"
+    });
+  });
+
+  test("data/raw rule exposes a legal guard_class marker", () => {
+    expect(DATA_RAW_WRITE_DENY_RULE.guard_class).toBe("authority");
+  });
+});
+
+class RecordingTool extends BaseTool {
+  description: string;
+  parameters: Record<string, unknown> = {
+    type: "object",
+    properties: {
+      command: { type: "string" }
+    },
+    required: ["command"]
+  };
+  calls = 0;
+
+  constructor(readonly name: string) {
+    super();
+    this.description = `Test tool ${name}`;
+  }
+
+  protected async execute(): Promise<ToolResult> {
+    this.calls += 1;
+    return {
+      success: true,
+      output: `${this.name} executed`,
+      outputSummary: `${this.name} executed`
+    };
+  }
+}
+
+function createToolContext(role: string): ToolContext & { role: string } {
+  return {
+    role,
+    sessionId: "TEST-SESSION",
+    workDir: "/tmp/shud-harness-test",
+    logger: testLogger
+  };
+}
+
+const testLogger: ToolLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {}
+};

--- a/packages/core/src/tools/data-raw-write-rule.test.ts
+++ b/packages/core/src/tools/data-raw-write-rule.test.ts
@@ -24,6 +24,10 @@ afterEach(async () => {
 });
 
 describe("data/raw write deny policy", () => {
+  const largeExecutableCodeWriteCommand = `Rscript -e '${"read.csv(\"data/raw/input.csv\");".repeat(
+    3000
+  )}writeLines("x", "data/raw/out.csv")'`;
+
   const deniedCommands = [
     {
       name: "redirect write",
@@ -156,6 +160,18 @@ describe("data/raw write deny policy", () => {
       command: 'export RAW=data/raw; bash -c \'rm "$RAW/input.csv"\''
     },
     {
+      name: "command-scoped assignment shell wrapper remove",
+      command: 'RAW=data/raw bash -c \'rm "$RAW/input.csv"\''
+    },
+    {
+      name: "env assignment shell wrapper redirect write",
+      command: 'env RAW=data/raw sh -c \'printf x > "$RAW/out.csv"\''
+    },
+    {
+      name: "env assignment partial path shell wrapper remove",
+      command: "env KIND=raw sh -c 'rm data/$KIND/input.csv'"
+    },
+    {
       name: "command substitution path expansion remove",
       command: "rm data/ra$(printf w)/input.csv"
     },
@@ -174,6 +190,14 @@ describe("data/raw write deny policy", () => {
     {
       name: "glob bracket redirect write",
       command: "printf x > data/ra[w]/input.csv"
+    },
+    {
+      name: "posix class glob remove",
+      command: "rm data/ra[[:lower:]]/input.csv"
+    },
+    {
+      name: "mac case-insensitive raw redirect write",
+      command: "printf x > DATA/RAW/input.csv"
     },
     {
       name: "curl short output option",
@@ -246,6 +270,31 @@ describe("data/raw write deny policy", () => {
     {
       name: "git clone destination under raw",
       command: "git clone https://example.invalid/repo.git data/raw/repo"
+    },
+    {
+      name: "curl remote-name output in raw cwd",
+      command: "curl -O https://example.invalid/input.csv",
+      workDir: "/tmp/shud-harness-test/data/raw"
+    },
+    {
+      name: "curl remote-header-name output in raw cwd",
+      command: "curl -OJ https://example.invalid/input.csv",
+      workDir: "/tmp/shud-harness-test/data/raw"
+    },
+    {
+      name: "wget default output in raw cwd",
+      command: "wget https://example.invalid/input.csv",
+      workDir: "/tmp/shud-harness-test/data/raw"
+    },
+    {
+      name: "git clone default destination in raw cwd",
+      command: "git clone https://example.invalid/repo.git",
+      workDir: "/tmp/shud-harness-test/data/raw"
+    },
+    {
+      name: "tar default extraction in raw cwd",
+      command: "tar -xf archive.tar",
+      workDir: "/tmp/shud-harness-test/data/raw"
     },
     {
       name: "brace expansion touching raw",
@@ -411,6 +460,38 @@ describe("data/raw write deny policy", () => {
     {
       name: "zsh shell wrapper",
       command: "zsh -c 'printf x > data/raw/input.csv'"
+    },
+    {
+      name: "env chdir relative remove",
+      command: "env -C data rm raw/input.csv"
+    },
+    {
+      name: "env long chdir shell wrapper relative remove",
+      command: "env --chdir=data bash -c 'rm raw/input.csv'"
+    },
+    {
+      name: "subshell cd relative remove",
+      command: "(cd data && rm raw/input.csv)"
+    },
+    {
+      name: "group cd relative remove",
+      command: "{ cd data; rm raw/input.csv; }"
+    },
+    {
+      name: "R writeLines raw write",
+      command: 'Rscript -e \'writeLines("x", "data/raw/input.csv")\''
+    },
+    {
+      name: "R write.csv raw write",
+      command: 'Rscript -e \'write.csv(data.frame(x=1), "data/raw/input.csv")\''
+    },
+    {
+      name: "R saveRDS raw write",
+      command: 'Rscript -e \'saveRDS(list(x=1), "data/raw/input.rds")\''
+    },
+    {
+      name: "large executable code raw write is bounded",
+      command: largeExecutableCodeWriteCommand
     }
   ] as const;
 
@@ -504,6 +585,27 @@ describe("data/raw write deny policy", () => {
       command: "touch workspace/tasks/TASK-001/scratch/data/raw/out.csv"
     },
     {
+      name: "cd raw then read relative input",
+      command: "cd data/raw && cat input.csv"
+    },
+    {
+      name: "task scratch workDir relative data raw write",
+      command: "touch data/raw/out.csv",
+      workDir: "/tmp/shud-harness-test/workspace/tasks/TASK-001/scratch"
+    },
+    {
+      name: "awk reads raw input",
+      command: "awk '{print $1}' data/raw/input.csv"
+    },
+    {
+      name: "rsync raw source to governed destination",
+      command: "rsync data/raw/input.csv workspace/tasks/TASK-001/input.csv"
+    },
+    {
+      name: "R read.csv raw read",
+      command: 'Rscript -e \'read.csv("data/raw/input.csv")\''
+    },
+    {
       name: "quoted brace fallback option",
       command: 'unknown-writer "--out=data/{raw,processed}/out.csv"'
     },
@@ -513,9 +615,9 @@ describe("data/raw write deny policy", () => {
     }
   ] as const;
 
-  for (const { name, command } of allowedCommands) {
+  for (const { name, command, workDir } of allowedCommands) {
     test(`allows ${name} through the wrapper`, async () => {
-      const { result, bashTool } = await runWrappedBashCommand(command);
+      const { result, bashTool } = await runWrappedBashCommand(command, { workDir });
 
       expect(result?.success).toBe(true);
       expect(result?.output).toBe("bash executed");
@@ -683,6 +785,27 @@ describe("data/raw write deny policy", () => {
 
     expect(await pathExists(path.join(outsideDir, "policy-gate-audit.ndjson"))).toBe(false);
     expect(await readFile(auditPathAfterMove, "utf8")).toBe("");
+  });
+
+  test("audit helper rejects a preexisting FIFO audit file without blocking", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-"));
+    tempDirs.push(workspaceRoot);
+
+    const auditDir = path.join(workspaceRoot, "workspace", "tasks", "TASK-M1-SPIKE", "audit");
+    const auditPath = path.join(auditDir, "policy-gate-audit.ndjson");
+    await mkdir(auditDir, { recursive: true });
+
+    const mkfifo = Bun.spawn(["mkfifo", auditPath], {
+      stdout: "pipe",
+      stderr: "pipe"
+    });
+    expect(await mkfifo.exited).toBe(0);
+
+    await expect(
+      appendPolicyGateAuditRow(sampleAuditRow(), {
+        workspaceRoot
+      })
+    ).rejects.toThrow("Invalid policy gate audit fileName: must be a regular file.");
   });
 
   test("data/raw rule exposes a legal guard_class marker", () => {

--- a/packages/core/src/tools/data-raw-write-rule.test.ts
+++ b/packages/core/src/tools/data-raw-write-rule.test.ts
@@ -27,6 +27,9 @@ describe("data/raw write deny policy", () => {
   const largeExecutableCodeWriteCommand = `Rscript -e '${"read.csv(\"data/raw/input.csv\");".repeat(
     3000
   )}writeLines("x", "data/raw/out.csv")'`;
+  const largeNonExecutableHeredocCommand = `cat > workspace/tasks/TASK-001/script.sh <<'SH'\n${"echo filler\n".repeat(
+    30000
+  )}rm data/raw/input.csv\nSH`;
 
   const deniedCommands = [
     {
@@ -54,6 +57,10 @@ describe("data/raw write deny policy", () => {
     {
       name: "cd updates relative remove target",
       command: "cd data && rm raw/input.csv"
+    },
+    {
+      name: "brace group cd side effect updates following remove target",
+      command: "{ cd data; }; rm raw/input.csv"
     },
     {
       name: "cd updates relative redirect target",
@@ -144,6 +151,10 @@ describe("data/raw write deny policy", () => {
       command: 'RAW=data/raw; rm "${RAW}/input.csv"'
     },
     {
+      name: "braced variable slice-expanded remove",
+      command: 'RAW=data/raw-extra; rm "${RAW:0:8}/input.csv"'
+    },
+    {
       name: "partial variable-expanded remove",
       command: "RAW=raw; rm data/$RAW/file"
     },
@@ -182,6 +193,14 @@ describe("data/raw write deny policy", () => {
     {
       name: "glob bracket path expansion remove",
       command: "rm data/ra[w]/input.csv"
+    },
+    {
+      name: "glob negated bracket path expansion remove",
+      command: "rm data/ra[!x]/input.csv"
+    },
+    {
+      name: "glob caret-negated bracket path expansion remove",
+      command: "rm data/ra[^x]/input.csv"
     },
     {
       name: "glob question path expansion remove",
@@ -254,6 +273,10 @@ describe("data/raw write deny policy", () => {
     {
       name: "rsync destination under raw",
       command: "rsync /tmp/input.csv data/raw/input.csv"
+    },
+    {
+      name: "rsync remove-source-files mutates raw source",
+      command: "rsync --remove-source-files data/raw/input.csv /tmp/out.csv"
     },
     {
       name: "tar extraction into raw",
@@ -438,6 +461,22 @@ describe("data/raw write deny policy", () => {
       command: "dd if=/dev/zero of=data/raw/input.csv"
     },
     {
+      name: "tee raw target",
+      command: "tee data/raw/input.csv"
+    },
+    {
+      name: "mv raw destination",
+      command: "mv /tmp/input.csv data/raw/input.csv"
+    },
+    {
+      name: "install raw destination",
+      command: "install /tmp/input.csv data/raw/input.csv"
+    },
+    {
+      name: "ln raw destination",
+      command: "ln /tmp/input.csv data/raw/input.csv"
+    },
+    {
       name: "truncate target",
       command: "truncate -s 0 data/raw/input.csv"
     },
@@ -452,6 +491,10 @@ describe("data/raw write deny policy", () => {
     {
       name: "bash shell wrapper",
       command: "bash -c 'printf x > data/raw/input.csv'"
+    },
+    {
+      name: "bash shell wrapper positional raw remove",
+      command: "bash -c 'rm \"$1\"' -- data/raw/input.csv"
     },
     {
       name: "sh shell wrapper",
@@ -492,6 +535,10 @@ describe("data/raw write deny policy", () => {
     {
       name: "large executable code raw write is bounded",
       command: largeExecutableCodeWriteCommand
+    },
+    {
+      name: "large non-executable heredoc is bounded",
+      command: largeNonExecutableHeredocCommand
     }
   ] as const;
 
@@ -589,6 +636,14 @@ describe("data/raw write deny policy", () => {
       command: "cd data/raw && cat input.csv"
     },
     {
+      name: "subshell cd does not leak into following remove target",
+      command: "(cd data); rm raw/input.csv"
+    },
+    {
+      name: "brace group cd does not affect preceding remove target",
+      command: "rm raw/input.csv; { cd data; }"
+    },
+    {
       name: "task scratch workDir relative data raw write",
       command: "touch data/raw/out.csv",
       workDir: "/tmp/shud-harness-test/workspace/tasks/TASK-001/scratch"
@@ -600,6 +655,14 @@ describe("data/raw write deny policy", () => {
     {
       name: "rsync raw source to governed destination",
       command: "rsync data/raw/input.csv workspace/tasks/TASK-001/input.csv"
+    },
+    {
+      name: "bash shell wrapper positional raw read",
+      command: "bash -c 'cat \"$1\"' -- data/raw/input.csv"
+    },
+    {
+      name: "workspace script heredoc with raw mutation text",
+      command: "cat > workspace/tasks/TASK-001/script.sh <<'SH'\nrm data/raw/input.csv\nSH"
     },
     {
       name: "R read.csv raw read",
@@ -624,6 +687,32 @@ describe("data/raw write deny policy", () => {
       expect(bashTool.calls).toBe(1);
     });
   }
+
+  test("denies mutation through a workspace symlink alias that resolves to data/raw", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-raw-alias-"));
+    tempDirs.push(workspaceRoot);
+
+    const rawDir = path.join(workspaceRoot, "data", "raw");
+    const scratchDir = path.join(
+      workspaceRoot,
+      "workspace",
+      "tasks",
+      "TASK-001",
+      "scratch"
+    );
+    await mkdir(rawDir, { recursive: true });
+    await mkdir(scratchDir, { recursive: true });
+    await symlink(rawDir, path.join(scratchDir, "raw-link"), "dir");
+
+    const { result, bashTool } = await runWrappedBashCommand(
+      "touch workspace/tasks/TASK-001/scratch/raw-link/input.csv",
+      { workDir: workspaceRoot }
+    );
+
+    expect(result?.success).toBe(false);
+    expect(bashTool.calls).toBe(0);
+    expect(parseDeniedPayload(result).rule_id).toBe(DATA_RAW_WRITE_DENY_RULE_ID);
+  });
 
   test("audit helper appends a minimal row under the no-TaskCard fixture path", async () => {
     const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-"));
@@ -719,6 +808,25 @@ describe("data/raw write deny policy", () => {
     ).rejects.toThrow("Invalid policy gate audit directory: resolves outside workspace.");
 
     expect(await pathExists(path.join(outsideDir, "policy-gate-audit.ndjson"))).toBe(false);
+  });
+
+  test("audit helper rejects an audit directory symlink that resolves inside the workspace", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "shud-policy-audit-"));
+    tempDirs.push(workspaceRoot);
+
+    const taskDir = path.join(workspaceRoot, "workspace", "tasks", "TASK-M1-SPIKE");
+    const otherAuditDir = path.join(workspaceRoot, "workspace", "tasks", "TASK-OTHER", "audit");
+    await mkdir(taskDir, { recursive: true });
+    await mkdir(otherAuditDir, { recursive: true });
+    await symlink(otherAuditDir, path.join(taskDir, "audit"), "dir");
+
+    await expect(
+      appendPolicyGateAuditRow(sampleAuditRow(), {
+        workspaceRoot
+      })
+    ).rejects.toThrow("Invalid policy gate audit directory: must not be a symlink.");
+
+    expect(await pathExists(path.join(otherAuditDir, "policy-gate-audit.ndjson"))).toBe(false);
   });
 
   test("audit helper rejects an audit file symlink that resolves outside the audit directory", async () => {

--- a/packages/core/src/tools/data-raw-write-rule.ts
+++ b/packages/core/src/tools/data-raw-write-rule.ts
@@ -20,7 +20,16 @@ const ANY_RAW_PATH_MUTATION_COMMANDS = new Set([
 ]);
 const DESTINATION_RAW_PATH_COMMANDS = new Set(["cp", "install", "ln", "rsync"]);
 const ANY_ENDPOINT_RAW_PATH_COMMANDS = new Set(["mv"]);
-const READ_ONLY_RAW_PATH_COMMANDS = new Set(["cat", "grep", "head", "ls", "tail", "wc"]);
+const READ_ONLY_RAW_PATH_COMMANDS = new Set([
+  "cat",
+  "grep",
+  "head",
+  "ls",
+  "sha256sum",
+  "stat",
+  "tail",
+  "wc"
+]);
 const WRAPPER_COMMANDS = new Set(["command", "doas", "env", "nice", "nohup", "sudo", "time"]);
 const WRAPPER_OPTIONS_WITH_OPERANDS = new Map<string, ReadonlySet<string>>([
   ["doas", new Set(["-u"])],
@@ -31,6 +40,8 @@ const WRAPPER_OPTIONS_WITH_OPERANDS = new Map<string, ReadonlySet<string>>([
 ]);
 const SHELL_COMMANDS = new Set(["bash", "sh", "zsh"]);
 const FIND_MUTATION_ACTIONS = new Set(["-delete", "-exec", "-execdir", "-ok", "-okdir"]);
+const LOCAL_URL_SCHEME_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*:\/\//;
+const EXECUTABLE_CODE_STDIN_ARG = "-";
 
 type ShellToken = {
   value: string;
@@ -50,6 +61,16 @@ type PathCandidate = {
   value: string;
   quoted: boolean;
   fullyQuoted: boolean;
+  expandsParameters: boolean;
+};
+
+type PathEvaluationContext = {
+  cwd?: string;
+};
+
+type ShellScanState = {
+  variables: Map<string, string>;
+  cwd?: string;
 };
 
 export const DATA_RAW_WRITE_DENY_RULE: PolicyRule = {
@@ -66,7 +87,7 @@ export const DATA_RAW_WRITE_DENY_RULE: PolicyRule = {
       return { decision: "allow" };
     }
 
-    const target = findProtectedDataRawWriteTarget(command);
+    const target = findProtectedDataRawWriteTarget(command, new Map(), call.workDir);
     if (!target) {
       return { decision: "allow" };
     }
@@ -101,29 +122,50 @@ export function extractBashCommand(input: unknown): string | undefined {
 
 export function findProtectedDataRawWriteTarget(
   command: string,
-  initialVariables: ReadonlyMap<string, string> = new Map()
+  initialVariables: ReadonlyMap<string, string> = new Map(),
+  workDir?: string
 ): string | undefined {
-  const substitutionTarget = findCommandSubstitutionWriteTarget(command, initialVariables);
+  return findProtectedDataRawWriteTargetWithState(command, {
+    variables: new Map(initialVariables),
+    cwd: normalizeInitialCwd(workDir)
+  });
+}
+
+function findProtectedDataRawWriteTargetWithState(
+  command: string,
+  state: ShellScanState
+): string | undefined {
+  const heredocTarget = findExecutableHeredocRawWriteTarget(command, state);
+  if (heredocTarget) {
+    return heredocTarget;
+  }
+
+  const substitutionTarget = findCommandSubstitutionWriteTarget(command, state);
   if (substitutionTarget) {
     return substitutionTarget;
   }
 
   const tokens = tokenizeShellCommand(command);
-  const variables = new Map(initialVariables);
+  const pathContext = (): PathEvaluationContext => ({ cwd: state.cwd });
 
   for (const segment of splitCommandSegments(tokens)) {
-    const expandedSegment = expandSegmentParameterReferences(segment, variables);
-    const redirectTarget = findRedirectWriteTarget(expandedSegment);
+    const expandedSegment = expandSegmentParameterReferences(segment, state.variables);
+    const redirectTarget = findRedirectWriteTarget(expandedSegment, pathContext());
     if (redirectTarget) {
       return redirectTarget;
     }
 
-    const mutationTarget = findMutationCommandTarget(expandedSegment, variables);
+    const mutationTarget = findMutationCommandTarget(
+      expandedSegment,
+      state.variables,
+      pathContext()
+    );
     if (mutationTarget) {
       return mutationTarget;
     }
 
-    recordVariableAssignments(segment, variables);
+    updateCwdFromCdSegment(expandedSegment, state);
+    recordVariableAssignments(expandedSegment, state.variables);
   }
 
   return undefined;
@@ -137,7 +179,10 @@ export function makeDataRawPolicyGateContext() {
 
 export type DataRawWritePolicyCall = PolicyGateToolCall;
 
-function findRedirectWriteTarget(tokens: readonly ShellToken[]): string | undefined {
+function findRedirectWriteTarget(
+  tokens: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
   for (let index = 0; index < tokens.length; index += 1) {
     const token = tokens[index];
     if (!isUnquotedOperatorToken(token, REDIRECT_WRITE_OPERATORS)) {
@@ -145,7 +190,7 @@ function findRedirectWriteTarget(tokens: readonly ShellToken[]): string | undefi
     }
 
     const target = tokens[index + 1];
-    if (target && isProtectedDataRawCandidate(target)) {
+    if (target && isProtectedDataRawCandidate(target, context)) {
       return target.value;
     }
   }
@@ -181,9 +226,10 @@ function isUnquotedOperatorToken(token: ShellToken, operators: ReadonlySet<strin
 
 function findMutationCommandTarget(
   segment: readonly ShellToken[],
-  variables: ReadonlyMap<string, string>
+  variables: ReadonlyMap<string, string>,
+  context: PathEvaluationContext
 ): string | undefined {
-  const wrapperUncertaintyTarget = findWrapperUncertaintyRawCandidate(segment);
+  const wrapperUncertaintyTarget = findWrapperUncertaintyRawCandidate(segment, context);
   if (wrapperUncertaintyTarget) {
     return wrapperUncertaintyTarget;
   }
@@ -196,100 +242,106 @@ function findMutationCommandTarget(
   const command = path.posix.basename(segment[commandIndex].value);
   const args = segment.slice(commandIndex + 1);
   if (command === "eval") {
-    const target = findEvalCommandTarget(args, variables);
+    const target = findEvalCommandTarget(args, variables, context);
     if (target) {
       return target;
     }
   }
   if (isExecutableCodeStringCommand(command)) {
-    const target = findExecutableCodeStringRawTarget(command, args);
+    const target = findExecutableCodeStringRawMutationTarget(command, args, context);
     if (target) {
       return target;
     }
   }
   if (ANY_RAW_PATH_MUTATION_COMMANDS.has(command)) {
-    const target = findRawPathArgument(args);
+    const target = findRawPathArgument(args, context);
     if (target) {
       return target;
     }
   }
   if (DESTINATION_RAW_PATH_COMMANDS.has(command)) {
-    const target = findDestinationRawPathTarget(args);
+    const target = findDestinationRawPathTarget(args, context);
     if (target) {
       return target;
     }
   }
   if (ANY_ENDPOINT_RAW_PATH_COMMANDS.has(command)) {
-    const target = findRawPathArgument(args);
+    const target = findRawPathArgument(args, context);
     if (target) {
       return target;
     }
   }
   if (command === "dd") {
-    const target = findDdOutputTarget(args);
+    const target = findDdOutputTarget(args, context);
     if (target) {
       return target;
     }
   }
   if (command === "tee") {
-    const target = args.find((arg) => !arg.value.startsWith("-") && isProtectedDataRawCandidate(arg))
-      ?.value;
+    const target = args.find(
+      (arg) => !arg.value.startsWith("-") && isProtectedDataRawCandidate(arg, context)
+    )?.value;
     if (target) {
       return target;
     }
   }
   if (command === "sed" && args.some(isSedInPlaceOption)) {
-    const target = findRawPathArgument(args);
+    const target = findRawPathArgument(args, context);
     if (target) {
       return target;
     }
   }
   if (command === "curl") {
-    const target = findCurlOutputTarget(args);
+    const target = findCurlOutputTarget(args, context);
     if (target) {
       return target;
     }
   }
   if (command === "find") {
-    const target = findFindMutationTarget(args);
+    const target = findFindMutationTarget(args, context);
     if (target) {
       return target;
     }
   }
   if (command === "git") {
-    const target = findGitCloneTarget(args);
+    const target = findGitCloneTarget(args, context);
     if (target) {
       return target;
     }
   }
   if (command === "tar") {
-    const target = findTarExtractionTarget(args);
+    const target = findTarExtractionTarget(args, context);
     if (target) {
       return target;
     }
   }
   if (command === "unzip") {
-    const target = findUnzipExtractionTarget(args);
+    const target = findUnzipExtractionTarget(args, context);
     if (target) {
       return target;
     }
   }
   if (command === "wget") {
-    const target = findWgetOutputTarget(args);
+    const target = findWgetOutputTarget(args, context);
     if (target) {
       return target;
     }
   }
   if (SHELL_COMMANDS.has(command)) {
     const shellCommand = findShellCommandArgument(args);
-    const target = shellCommand ? findProtectedDataRawWriteTarget(shellCommand, variables) : undefined;
+    const target = shellCommand
+      ? findProtectedDataRawWriteTargetWithState(shellCommand, {
+          variables: new Map(variables),
+          cwd: context.cwd
+        })
+      : undefined;
     if (target) {
       return target;
     }
   }
 
-  const rawPathCandidate = findRawPathCandidate(segment);
-  if (!rawPathCandidate || isReadOnlySafeRawPathCommand(command, args)) {
+  const rawPathCandidate = findRawPathCandidate(segment, context);
+  if (!rawPathCandidate || isReadOnlySafeRawPathCommand(command, args, context)) {
     return undefined;
   }
 
@@ -318,8 +370,11 @@ function findCommandTokenIndex(segment: readonly ShellToken[]): number | undefin
   return undefined;
 }
 
-function findWrapperUncertaintyRawCandidate(segment: readonly ShellToken[]): string | undefined {
-  const rawPathCandidate = findRawPathCandidate(segment);
+function findWrapperUncertaintyRawCandidate(
+  segment: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
+  const rawPathCandidate = findRawPathCandidate(segment, context);
   if (!rawPathCandidate) {
     return undefined;
   }
@@ -404,13 +459,19 @@ function wrapperOptionOperandMode(
     : undefined;
 }
 
-function findRawPathArgument(args: readonly ShellToken[]): string | undefined {
-  return args.find(isProtectedDataRawCandidate)?.value;
+function findRawPathArgument(
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
+  return args.find((arg) => isProtectedDataRawCandidate(arg, context))?.value;
 }
 
-function findRawPathCandidate(tokens: readonly ShellToken[]): string | undefined {
+function findRawPathCandidate(
+  tokens: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
   for (const token of tokens) {
-    const candidate = findProtectedRawPathCandidate(token);
+    const candidate = findProtectedRawPathCandidate(token, context);
     if (candidate) {
       return candidate.value;
     }
@@ -419,9 +480,12 @@ function findRawPathCandidate(tokens: readonly ShellToken[]): string | undefined
   return undefined;
 }
 
-function findProtectedRawPathCandidate(token: ShellToken): PathCandidate | undefined {
+function findProtectedRawPathCandidate(
+  token: ShellToken,
+  context: PathEvaluationContext
+): PathCandidate | undefined {
   const wholeTokenCandidate = pathCandidateFromToken(token);
-  if (isProtectedDataRawCandidate(wholeTokenCandidate)) {
+  if (isProtectedDataRawCandidate(wholeTokenCandidate, context)) {
     return wholeTokenCandidate;
   }
 
@@ -436,19 +500,24 @@ function findProtectedRawPathCandidate(token: ShellToken): PathCandidate | undef
         token,
         token.value.slice(assignmentIndex + 1)
       );
-      return isProtectedDataRawCandidate(assignmentCandidate) ? assignmentCandidate : undefined;
+      return isProtectedDataRawCandidate(assignmentCandidate, context)
+        ? assignmentCandidate
+        : undefined;
     }
 
     return undefined;
   }
 
-  return findAttachedShortOptionRawPathCandidate(token);
+  return findAttachedShortOptionRawPathCandidate(token, context);
 }
 
-function findAttachedShortOptionRawPathCandidate(token: ShellToken): PathCandidate | undefined {
+function findAttachedShortOptionRawPathCandidate(
+  token: ShellToken,
+  context: PathEvaluationContext
+): PathCandidate | undefined {
   for (let valueStart = 2; valueStart < token.value.length; valueStart += 1) {
     const candidate = pathCandidateFromToken(token, token.value.slice(valueStart));
-    if (isProtectedDataRawCandidate(candidate)) {
+    if (isProtectedDataRawCandidate(candidate, context)) {
       return candidate;
     }
   }
@@ -458,7 +527,8 @@ function findAttachedShortOptionRawPathCandidate(token: ShellToken): PathCandida
 
 function isReadOnlySafeRawPathCommand(
   command: string,
-  args: readonly ShellToken[]
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
 ): boolean {
   if (READ_ONLY_RAW_PATH_COMMANDS.has(command)) {
     return true;
@@ -469,37 +539,57 @@ function isReadOnlySafeRawPathCommand(
   if (command === "sed") {
     return !args.some(isSedInPlaceOption);
   }
+  if (command === "curl") {
+    return findCurlOutputTarget(args, context) === undefined;
+  }
+  if (command === "wget") {
+    return findWgetOutputTarget(args, context) === undefined;
+  }
 
-  return command === "cp" && isCopyOutOfRawCommand(args);
+  return command === "cp" && isCopyOutOfRawCommand(args, context);
 }
 
-function isCopyOutOfRawCommand(args: readonly ShellToken[]): boolean {
+function isCopyOutOfRawCommand(
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): boolean {
   const targetDirectory = findTargetDirectoryArgument(args);
   if (targetDirectory !== undefined) {
-    return !isProtectedDataRawCandidate(targetDirectory) && args.some(isProtectedDataRawCandidate);
+    return (
+      !isProtectedDataRawCandidate(targetDirectory, context) &&
+      args.some((arg) => isProtectedDataRawCandidate(arg, context))
+    );
   }
 
   const positionalArgs = args.filter((arg) => !arg.value.startsWith("-"));
   const destination = positionalArgs.at(-1);
-  if (!destination || isProtectedDataRawCandidate(destination)) {
+  if (!destination || isProtectedDataRawCandidate(destination, context)) {
     return false;
   }
 
-  return positionalArgs.slice(0, -1).some(isProtectedDataRawCandidate);
+  return positionalArgs.slice(0, -1).some((arg) => isProtectedDataRawCandidate(arg, context));
 }
 
-function lastNonOptionArgument(args: readonly ShellToken[]): string | undefined {
+function lastNonOptionArgument(
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
   const target = args.filter((arg) => !arg.value.startsWith("-")).at(-1);
-  return target && isProtectedDataRawCandidate(target) ? target.value : undefined;
+  return target && isProtectedDataRawCandidate(target, context) ? target.value : undefined;
 }
 
-function findDestinationRawPathTarget(args: readonly ShellToken[]): string | undefined {
+function findDestinationRawPathTarget(
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
   const targetDirectory = findTargetDirectoryArgument(args);
   if (targetDirectory !== undefined) {
-    return isProtectedDataRawCandidate(targetDirectory) ? targetDirectory.value : undefined;
+    return isProtectedDataRawCandidate(targetDirectory, context)
+      ? targetDirectory.value
+      : undefined;
   }
 
-  return lastNonOptionArgument(args);
+  return lastNonOptionArgument(args, context);
 }
 
 function findTargetDirectoryArgument(args: readonly ShellToken[]): PathCandidate | undefined {
@@ -507,7 +597,9 @@ function findTargetDirectoryArgument(args: readonly ShellToken[]): PathCandidate
     const arg = args[index].value;
     if (arg === "-t" || arg === "--target-directory") {
       const target = args[index + 1];
-      return target ? pathCandidateFromToken(target) : { value: "", quoted: false, fullyQuoted: false };
+      return target
+        ? pathCandidateFromToken(target)
+        : { value: "", quoted: false, fullyQuoted: false, expandsParameters: false };
     }
     if (arg.startsWith("--target-directory=")) {
       return pathCandidateFromToken(args[index], arg.slice("--target-directory=".length));
@@ -520,14 +612,17 @@ function findTargetDirectoryArgument(args: readonly ShellToken[]): PathCandidate
   return undefined;
 }
 
-function findDdOutputTarget(args: readonly ShellToken[]): string | undefined {
+function findDdOutputTarget(
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
   for (const arg of args) {
     if (!arg.value.startsWith("of=")) {
       continue;
     }
 
     const target = pathCandidateFromToken(arg, arg.value.slice("of=".length));
-    if (isProtectedDataRawCandidate(target)) {
+    if (isProtectedDataRawCandidate(target, context)) {
       return target.value;
     }
   }
@@ -535,25 +630,28 @@ function findDdOutputTarget(args: readonly ShellToken[]): string | undefined {
   return undefined;
 }
 
-function findCurlOutputTarget(args: readonly ShellToken[]): string | undefined {
+function findCurlOutputTarget(
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index].value;
     if (arg === "-o" || arg === "--output") {
       const target = args[index + 1];
-      if (target && isProtectedDataRawCandidate(target)) {
+      if (target && isProtectedDataRawCandidate(target, context)) {
         return target.value;
       }
       continue;
     }
     if (arg.startsWith("--output=")) {
       const target = pathCandidateFromToken(args[index], arg.slice("--output=".length));
-      if (isProtectedDataRawCandidate(target)) {
+      if (isProtectedDataRawCandidate(target, context)) {
         return target.value;
       }
       continue;
     }
 
-    const shortOptionTarget = findCurlShortOutputTarget(args, index);
+    const shortOptionTarget = findCurlShortOutputTarget(args, index, context);
     if (shortOptionTarget) {
       return shortOptionTarget;
     }
@@ -564,7 +662,8 @@ function findCurlOutputTarget(args: readonly ShellToken[]): string | undefined {
 
 function findCurlShortOutputTarget(
   args: readonly ShellToken[],
-  index: number
+  index: number,
+  context: PathEvaluationContext
 ): string | undefined {
   const arg = args[index].value;
   if (!arg.startsWith("-") || arg.startsWith("--") || arg.length < 3) {
@@ -582,7 +681,7 @@ function findCurlShortOutputTarget(
     attachedTarget.length > 0
       ? pathCandidateFromToken(args[index], attachedTarget)
       : args[index + 1];
-  return target && isProtectedDataRawCandidate(target) ? target.value : undefined;
+  return target && isProtectedDataRawCandidate(target, context) ? target.value : undefined;
 }
 
 function isSedInPlaceOption(arg: ShellToken): boolean {
@@ -595,19 +694,25 @@ function isSedInPlaceOption(arg: ShellToken): boolean {
   );
 }
 
-function findFindMutationTarget(args: readonly ShellToken[]): string | undefined {
+function findFindMutationTarget(
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
   if (!hasFindMutationAction(args)) {
     return undefined;
   }
 
-  return findRawPathArgument(args);
+  return findRawPathArgument(args, context);
 }
 
 function hasFindMutationAction(args: readonly ShellToken[]): boolean {
   return args.some((arg) => FIND_MUTATION_ACTIONS.has(arg.value));
 }
 
-function findGitCloneTarget(args: readonly ShellToken[]): string | undefined {
+function findGitCloneTarget(
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
   const cloneIndex = args.findIndex((arg) => arg.value === "clone");
   if (cloneIndex === -1) {
     return undefined;
@@ -621,10 +726,15 @@ function findGitCloneTarget(args: readonly ShellToken[]): string | undefined {
   }
 
   const destination = positionalArgs.at(-1);
-  return destination && isProtectedDataRawCandidate(destination) ? destination.value : undefined;
+  return destination && isProtectedDataRawCandidate(destination, context)
+    ? destination.value
+    : undefined;
 }
 
-function findTarExtractionTarget(args: readonly ShellToken[]): string | undefined {
+function findTarExtractionTarget(
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
   if (!isTarExtractCommand(args)) {
     return undefined;
   }
@@ -634,7 +744,7 @@ function findTarExtractionTarget(args: readonly ShellToken[]): string | undefine
     longAssignments: ["--directory="],
     shortAttached: "-C"
   });
-  if (targetDirectory && isProtectedDataRawCandidate(targetDirectory)) {
+  if (targetDirectory && isProtectedDataRawCandidate(targetDirectory, context)) {
     return targetDirectory.value;
   }
 
@@ -653,22 +763,28 @@ function isTarExtractCommand(args: readonly ShellToken[]): boolean {
   });
 }
 
-function findUnzipExtractionTarget(args: readonly ShellToken[]): string | undefined {
+function findUnzipExtractionTarget(
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
   const targetDirectory = findOptionValue(args, {
     separate: new Set(["-d"]),
     shortAttached: "-d"
   });
-  return targetDirectory && isProtectedDataRawCandidate(targetDirectory)
+  return targetDirectory && isProtectedDataRawCandidate(targetDirectory, context)
     ? targetDirectory.value
     : undefined;
 }
 
-function findWgetOutputTarget(args: readonly ShellToken[]): string | undefined {
+function findWgetOutputTarget(
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg.value === "-O" || arg.value === "--output-document") {
       const target = args[index + 1];
-      if (target && isProtectedDataRawCandidate(target)) {
+      if (target && isProtectedDataRawCandidate(target, context)) {
         return target.value;
       }
       continue;
@@ -678,20 +794,20 @@ function findWgetOutputTarget(args: readonly ShellToken[]): string | undefined {
         arg,
         arg.value.slice("--output-document=".length)
       );
-      if (isProtectedDataRawCandidate(target)) {
+      if (isProtectedDataRawCandidate(target, context)) {
         return target.value;
       }
       continue;
     }
     if (arg.value.startsWith("-O") && !arg.value.startsWith("--") && arg.value.length > 2) {
       const target = pathCandidateFromToken(arg, arg.value.slice("-O".length));
-      if (isProtectedDataRawCandidate(target)) {
+      if (isProtectedDataRawCandidate(target, context)) {
         return target.value;
       }
       continue;
     }
 
-    const targetDirectory = findWgetDirectoryPrefixTarget(args, index);
+    const targetDirectory = findWgetDirectoryPrefixTarget(args, index, context);
     if (targetDirectory) {
       return targetDirectory;
     }
@@ -702,14 +818,15 @@ function findWgetOutputTarget(args: readonly ShellToken[]): string | undefined {
 
 function findWgetDirectoryPrefixTarget(
   args: readonly ShellToken[],
-  index: number
+  index: number,
+  context: PathEvaluationContext
 ): string | undefined {
   const target = findOptionValueAt(args, index, {
     separate: new Set(["-P", "--directory-prefix"]),
     longAssignments: ["--directory-prefix="],
     shortAttached: "-P"
   });
-  return target && isProtectedDataRawCandidate(target) ? target.value : undefined;
+  return target && isProtectedDataRawCandidate(target, context) ? target.value : undefined;
 }
 
 function findOptionValue(
@@ -768,10 +885,16 @@ function findOptionValueAt(
 
 function findEvalCommandTarget(
   args: readonly ShellToken[],
-  variables: ReadonlyMap<string, string>
+  variables: ReadonlyMap<string, string>,
+  context: PathEvaluationContext
 ): string | undefined {
   const command = args.map((arg) => arg.value).join(" ").trim();
-  return command ? findProtectedDataRawWriteTarget(command, variables) : undefined;
+  return command
+    ? findProtectedDataRawWriteTargetWithState(command, {
+        variables: new Map(variables),
+        cwd: context.cwd
+      })
+    : undefined;
 }
 
 function isExecutableCodeStringCommand(command: string): boolean {
@@ -790,11 +913,12 @@ function isExecutableCodeStringCommand(command: string): boolean {
   );
 }
 
-function findExecutableCodeStringRawTarget(
+function findExecutableCodeStringRawMutationTarget(
   command: string,
-  args: readonly ShellToken[]
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
 ): string | undefined {
-  const denoEvalTarget = findDenoEvalRawTarget(command, args);
+  const denoEvalTarget = findDenoEvalRawMutationTarget(command, args, context);
   if (denoEvalTarget) {
     return denoEvalTarget;
   }
@@ -805,7 +929,7 @@ function findExecutableCodeStringRawTarget(
       continue;
     }
 
-    const target = findProtectedRawPathInText(codeString);
+    const target = findExecutableCodeRawMutationTargetInText(codeString, context);
     if (target) {
       return target;
     }
@@ -814,13 +938,17 @@ function findExecutableCodeStringRawTarget(
   return undefined;
 }
 
-function findDenoEvalRawTarget(command: string, args: readonly ShellToken[]): string | undefined {
+function findDenoEvalRawMutationTarget(
+  command: string,
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
   if (command.toLowerCase() !== "deno" || args[0]?.value !== "eval") {
     return undefined;
   }
 
   const codeString = args.find((arg, index) => index > 0 && !arg.value.startsWith("-"))?.value;
-  return codeString ? findProtectedRawPathInText(codeString) : undefined;
+  return codeString ? findExecutableCodeRawMutationTargetInText(codeString, context) : undefined;
 }
 
 function findExecutableCodeStringAt(
@@ -879,6 +1007,190 @@ function findShellCommandArgument(args: readonly ShellToken[]): string | undefin
   }
 
   return undefined;
+}
+
+function findExecutableHeredocRawWriteTarget(
+  command: string,
+  state: ShellScanState
+): string | undefined {
+  const lines = command.split(/\r?\n/);
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const heredoc = parseHeredocStart(lines[lineIndex]);
+    if (!heredoc) {
+      continue;
+    }
+
+    const bodyLines: string[] = [];
+    let bodyIndex = lineIndex + 1;
+    for (; bodyIndex < lines.length; bodyIndex += 1) {
+      const delimiterLine = heredoc.stripLeadingTabs
+        ? lines[bodyIndex].replace(/^\t+/, "")
+        : lines[bodyIndex];
+      if (delimiterLine === heredoc.delimiter) {
+        break;
+      }
+      bodyLines.push(lines[bodyIndex]);
+    }
+
+    if (bodyIndex >= lines.length) {
+      continue;
+    }
+
+    const target = findExecutableStdinRawWriteTarget(
+      heredoc.preamble,
+      bodyLines.join("\n"),
+      state
+    );
+    if (target) {
+      return target;
+    }
+
+    lineIndex = bodyIndex;
+  }
+
+  return undefined;
+}
+
+function parseHeredocStart(line: string):
+  | {
+      preamble: string;
+      delimiter: string;
+      stripLeadingTabs: boolean;
+    }
+  | undefined {
+  const match = line.match(/<<(-)?\s*(?:"([^"]+)"|'([^']+)'|([^ \t;&|<>]+))/);
+  if (!match || match.index === undefined) {
+    return undefined;
+  }
+
+  return {
+    preamble: line.slice(0, match.index).trimEnd(),
+    delimiter: match[2] ?? match[3] ?? match[4] ?? "",
+    stripLeadingTabs: match[1] === "-"
+  };
+}
+
+function findExecutableStdinRawWriteTarget(
+  preamble: string,
+  body: string,
+  state: ShellScanState
+): string | undefined {
+  const tokens = tokenizeShellCommand(preamble);
+  const segment = splitCommandSegments(tokens).at(-1);
+  if (!segment) {
+    return undefined;
+  }
+
+  const expandedSegment = expandSegmentParameterReferences(segment, state.variables);
+  const commandIndex = findCommandTokenIndex(expandedSegment);
+  if (commandIndex === undefined) {
+    return undefined;
+  }
+
+  const command = path.posix.basename(expandedSegment[commandIndex].value);
+  const args = expandedSegment.slice(commandIndex + 1);
+  if (SHELL_COMMANDS.has(command)) {
+    return findProtectedDataRawWriteTargetWithState(body, {
+      variables: new Map(state.variables),
+      cwd: state.cwd
+    });
+  }
+
+  if (!isExecutableCodeStringCommand(command) || !receivesExecutableCodeFromStdin(args)) {
+    return undefined;
+  }
+
+  return findExecutableCodeRawMutationTargetInText(body, { cwd: state.cwd });
+}
+
+function receivesExecutableCodeFromStdin(args: readonly ShellToken[]): boolean {
+  const firstPositional = args.find((arg) => !arg.value.startsWith("-"));
+  return firstPositional === undefined || firstPositional.value === EXECUTABLE_CODE_STDIN_ARG;
+}
+
+function updateCwdFromCdSegment(segment: readonly ShellToken[], state: ShellScanState): void {
+  const commandIndex = findCommandTokenIndex(segment);
+  if (commandIndex === undefined) {
+    return;
+  }
+
+  const command = path.posix.basename(segment[commandIndex].value);
+  if (command !== "cd") {
+    return;
+  }
+
+  const target = segment.slice(commandIndex + 1).find((arg) => !arg.value.startsWith("-"));
+  if (!target || target.value === "-" || !isSimpleLiteralCdTarget(target)) {
+    return;
+  }
+
+  state.cwd = resolveShellPath(state.cwd, target.value);
+}
+
+function isSimpleLiteralCdTarget(target: ShellToken): boolean {
+  return !/[`$*?\[\]{}]/.test(target.value);
+}
+
+function resolveShellPath(cwd: string | undefined, target: string): string {
+  if (path.isAbsolute(target) || path.posix.isAbsolute(target)) {
+    return path.resolve(target);
+  }
+  return path.resolve(cwd ?? process.cwd(), target);
+}
+
+function normalizeInitialCwd(workDir: string | undefined): string | undefined {
+  return workDir ? path.resolve(workDir) : undefined;
+}
+
+function findExecutableCodeRawMutationTargetInText(
+  value: string,
+  context: PathEvaluationContext
+): string | undefined {
+  for (const target of findProtectedRawPathsInText(value, context)) {
+    if (hasExecutableCodeWriteIntentForRawPath(value, target)) {
+      return target;
+    }
+  }
+
+  return undefined;
+}
+
+function findProtectedRawPathsInText(
+  value: string,
+  context: PathEvaluationContext
+): string[] {
+  const targets: string[] = [];
+  const rawPathPattern = /(?:file:\/\/)?[A-Za-z0-9_./@%:+-]*data\/raw(?:\/[A-Za-z0-9_./@%:+-]*)?/g;
+  for (const match of value.matchAll(rawPathPattern)) {
+    const candidate = match[0];
+    if (isProtectedDataRawPath(candidate, context)) {
+      targets.push(candidate);
+      continue;
+    }
+
+    const rawPathIndex = candidate.indexOf("data/raw");
+    if (rawPathIndex !== -1) {
+      const relativeCandidate = candidate.slice(rawPathIndex);
+      if (isProtectedDataRawPath(relativeCandidate, context)) {
+        targets.push(relativeCandidate);
+      }
+    }
+  }
+
+  return targets;
+}
+
+function hasExecutableCodeWriteIntentForRawPath(value: string, target: string): boolean {
+  const escapedTarget = escapeRegExp(target);
+  const codeBeforeRawCloseParen = `[^)]*${escapedTarget}[^)]*`;
+
+  return [
+    new RegExp(`\\bopen\\s*\\(${codeBeforeRawCloseParen},\\s*["'][^"']*[wax+][^"']*["']`, "i"),
+    new RegExp(`\\b(?:writeFile|writeFileSync|appendFile|appendFileSync|createWriteStream)\\s*\\(${codeBeforeRawCloseParen}`, "i"),
+    new RegExp(`\\b(?:unlink|unlinkSync|rm|rmSync|remove|removeSync|rename|renameSync|mkdir|mkdirSync|rmdir|rmdirSync|truncate|truncateSync)\\s*\\(${codeBeforeRawCloseParen}`, "i"),
+    new RegExp(`\\bPath\\s*\\(${codeBeforeRawCloseParen}\\)\\.write_(?:text|bytes)\\s*\\(`, "i"),
+    new RegExp(`${escapedTarget}[^\\n;)]*\\.write_(?:text|bytes)\\s*\\(`, "i")
+  ].some((pattern) => pattern.test(value));
 }
 
 function expandSegmentParameterReferences(
@@ -964,59 +1276,246 @@ function pathCandidateFromToken(token: ShellToken, value = token.value): PathCan
   return {
     value,
     quoted: token.quoted,
-    fullyQuoted: token.fullyQuoted
+    fullyQuoted: token.fullyQuoted,
+    expandsParameters: token.expandsParameters
   };
 }
 
-function isProtectedDataRawCandidate(candidate: PathCandidate): boolean {
-  if (isProtectedDataRawPath(candidate.value)) {
+function isProtectedDataRawCandidate(
+  candidate: PathCandidate,
+  context: PathEvaluationContext
+): boolean {
+  if (isProtectedDataRawPath(candidate.value, context)) {
     return true;
   }
-  return (
+  if (
     !candidate.fullyQuoted &&
     expandShellBraceAlternatives(candidate.value).some((expanded) =>
-      isProtectedDataRawPath(expanded)
+      isProtectedDataRawPath(expanded, context)
     )
+  ) {
+    return true;
+  }
+
+  return canUnresolvedShellPathResolveToProtectedRaw(candidate, context);
+}
+
+function isProtectedDataRawPath(
+  candidate: string,
+  context: PathEvaluationContext = {}
+): boolean {
+  return candidatePathVariants(candidate, context).some((variant) =>
+    isProtectedDataRawPathVariant(variant)
   );
 }
 
-function findProtectedRawPathInText(value: string): string | undefined {
-  const rawPathPattern = /(?:file:\/\/)?[A-Za-z0-9_./@%:+-]*data\/raw(?:\/[A-Za-z0-9_./@%:+-]*)?/g;
-  for (const match of value.matchAll(rawPathPattern)) {
-    const candidate = match[0];
-    if (isProtectedDataRawPath(candidate)) {
-      return candidate;
-    }
-
-    const rawPathIndex = candidate.indexOf("data/raw");
-    if (rawPathIndex !== -1) {
-      const relativeCandidate = candidate.slice(rawPathIndex);
-      if (isProtectedDataRawPath(relativeCandidate)) {
-        return relativeCandidate;
-      }
-    }
-  }
-
-  return undefined;
-}
-
-function isProtectedDataRawPath(candidate: string): boolean {
-  const normalized = path.posix.normalize(candidate.replace(/^file:\/\//, ""));
-  const withoutDotPrefix = normalized.replace(/^\.\/+/, "");
-  if (isGovernedTaskWorkspacePath(withoutDotPrefix)) {
+function isProtectedDataRawPathVariant(candidate: string): boolean {
+  const normalized = path.posix.normalize(candidate).replace(/^\.\/+/, "");
+  const segments = pathSegments(normalized);
+  const rawIndex = findAdjacentSegmentIndex(segments, "data", "raw");
+  if (rawIndex === -1) {
     return false;
   }
-  return (
-    withoutDotPrefix === "data/raw" ||
-    withoutDotPrefix.startsWith("data/raw/") ||
-    withoutDotPrefix.endsWith("/data/raw") ||
-    withoutDotPrefix.includes("/data/raw/")
+
+  const workspaceIndex = findAdjacentSegmentIndex(segments, "workspace", "tasks");
+  return workspaceIndex === -1 || rawIndex < workspaceIndex;
+}
+
+function candidatePathVariants(
+  candidate: string,
+  context: PathEvaluationContext
+): string[] {
+  const localCandidate = normalizeLocalPathCandidate(candidate);
+  if (!localCandidate) {
+    return [];
+  }
+
+  const variants = [localCandidate];
+  if (context.cwd && isRelativeLocalPath(localCandidate)) {
+    variants.push(path.resolve(context.cwd, localCandidate));
+  }
+
+  return variants;
+}
+
+function normalizeLocalPathCandidate(candidate: string): string | undefined {
+  if (candidate.startsWith("file://")) {
+    return candidate.slice("file://".length);
+  }
+  if (LOCAL_URL_SCHEME_PATTERN.test(candidate)) {
+    return undefined;
+  }
+  return candidate;
+}
+
+function isRelativeLocalPath(candidate: string): boolean {
+  return !path.isAbsolute(candidate) && !path.posix.isAbsolute(candidate);
+}
+
+function pathSegments(candidate: string): string[] {
+  return candidate.split(/[\\/]+/).filter((segment) => segment.length > 0);
+}
+
+function findAdjacentSegmentIndex(
+  segments: readonly string[],
+  first: string,
+  second: string
+): number {
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    if (segments[index] === first && segments[index + 1] === second) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function canUnresolvedShellPathResolveToProtectedRaw(
+  candidate: PathCandidate,
+  context: PathEvaluationContext
+): boolean {
+  if (candidate.fullyQuoted && !candidate.expandsParameters) {
+    return false;
+  }
+
+  for (const expandedDefault of expandParameterDefaultCandidates(candidate.value)) {
+    if (isProtectedDataRawPath(expandedDefault, context)) {
+      return true;
+    }
+  }
+
+  const pattern = shellExpansionPattern(candidate);
+  if (!pattern) {
+    return false;
+  }
+
+  return candidatePathVariants(pattern, context).some((variant) =>
+    shellPathPatternCanMatchProtectedRaw(variant)
   );
 }
 
-function isGovernedTaskWorkspacePath(candidate: string): boolean {
-  const withoutLeadingSlash = candidate.replace(/^\/+/, "");
-  return withoutLeadingSlash.startsWith("workspace/tasks/");
+function expandParameterDefaultCandidates(value: string): string[] {
+  if (!value.includes("${")) {
+    return [];
+  }
+
+  const expanded = value.replace(
+    /\$\{[A-Za-z_][A-Za-z0-9_]*(?::[-=+?]|[-=+?])([^}]*)\}/g,
+    (_match, defaultValue: string) => defaultValue
+  );
+  return expanded === value ? [] : [expanded];
+}
+
+function shellExpansionPattern(candidate: PathCandidate): string | undefined {
+  let pattern = candidate.value;
+  let changed = false;
+
+  if (candidate.expandsParameters) {
+    const withCommandSubstitutions = replaceCommandSubstitutionsWithWildcard(pattern);
+    changed = changed || withCommandSubstitutions !== pattern;
+    pattern = withCommandSubstitutions;
+
+    const withParameterExpansions = pattern.replace(/\$\{[^}]+\}/g, "*");
+    changed = changed || withParameterExpansions !== pattern;
+    pattern = withParameterExpansions;
+  }
+
+  if (!candidate.quoted && /[*?\[]/.test(pattern)) {
+    changed = true;
+  }
+
+  return changed ? pattern : undefined;
+}
+
+function replaceCommandSubstitutionsWithWildcard(value: string): string {
+  let result = "";
+  let index = 0;
+
+  while (index < value.length) {
+    if (value[index] === "$" && value[index + 1] === "(") {
+      const substitution = readCommandSubstitution(value, index + 1);
+      if (!substitution) {
+        result += "*";
+        index += 2;
+        continue;
+      }
+      result += "*";
+      index = substitution.endIndex + 1;
+      continue;
+    }
+
+    if (value[index] === "`") {
+      const substitution = readBacktickCommandSubstitution(value, index);
+      if (!substitution) {
+        result += "*";
+        index += 1;
+        continue;
+      }
+      result += "*";
+      index = substitution.endIndex + 1;
+      continue;
+    }
+
+    result += value[index];
+    index += 1;
+  }
+
+  return result;
+}
+
+function shellPathPatternCanMatchProtectedRaw(pattern: string): boolean {
+  const segments = pathSegments(path.posix.normalize(pattern));
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    if (
+      shellSegmentPatternCanMatchLiteral(segments[index], "data") &&
+      shellSegmentPatternCanMatchLiteral(segments[index + 1], "raw")
+    ) {
+      const workspaceIndex = findAdjacentSegmentIndex(segments, "workspace", "tasks");
+      return workspaceIndex === -1 || index < workspaceIndex;
+    }
+  }
+
+  return false;
+}
+
+function shellSegmentPatternCanMatchLiteral(pattern: string, literal: string): boolean {
+  const regex = globSegmentPatternToRegex(pattern);
+  return regex ? regex.test(literal) : pattern === literal;
+}
+
+function globSegmentPatternToRegex(pattern: string): RegExp | undefined {
+  let source = "";
+  let changed = false;
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    if (char === "*") {
+      source += ".*";
+      changed = true;
+      continue;
+    }
+    if (char === "?") {
+      source += ".";
+      changed = true;
+      continue;
+    }
+    if (char === "[") {
+      const closeIndex = pattern.indexOf("]", index + 1);
+      if (closeIndex !== -1) {
+        source += pattern.slice(index, closeIndex + 1);
+        index = closeIndex;
+        changed = true;
+        continue;
+      }
+    }
+    source += escapeRegExp(char);
+  }
+
+  return changed ? new RegExp(`^${source}$`) : undefined;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
 }
 
 function expandShellBraceAlternatives(candidate: string): string[] {
@@ -1203,6 +1702,28 @@ function tokenizeShellCommand(command: string): ShellToken[] {
       continue;
     }
 
+    if (char === "$" && command[index + 1] === "(") {
+      const substitution = readCommandSubstitution(command, index + 1);
+      if (substitution) {
+        current += command.slice(index, substitution.endIndex + 1);
+        currentHasUnquotedContent = true;
+        currentExpandsParameters = true;
+        index = substitution.endIndex + 1;
+        continue;
+      }
+    }
+
+    if (char === "`") {
+      const substitution = readBacktickCommandSubstitution(command, index);
+      if (substitution) {
+        current += command.slice(index, substitution.endIndex + 1);
+        currentHasUnquotedContent = true;
+        currentExpandsParameters = true;
+        index = substitution.endIndex + 1;
+        continue;
+      }
+    }
+
     const operator = readShellOperator(command, index);
     if (operator) {
       flush();
@@ -1240,7 +1761,7 @@ function tokenizeShellCommand(command: string): ShellToken[] {
 
 function findCommandSubstitutionWriteTarget(
   command: string,
-  variables: ReadonlyMap<string, string> = new Map()
+  state: ShellScanState
 ): string | undefined {
   let quote: ShellQuote | undefined;
   let index = 0;
@@ -1298,7 +1819,10 @@ function findCommandSubstitutionWriteTarget(
         return undefined;
       }
 
-      const target = findProtectedDataRawWriteTarget(substitution.content, variables);
+      const target = findProtectedDataRawWriteTargetWithState(substitution.content, {
+        variables: new Map(state.variables),
+        cwd: state.cwd
+      });
       if (target) {
         return target;
       }
@@ -1312,7 +1836,10 @@ function findCommandSubstitutionWriteTarget(
         return undefined;
       }
 
-      const target = findProtectedDataRawWriteTarget(substitution.content, variables);
+      const target = findProtectedDataRawWriteTargetWithState(substitution.content, {
+        variables: new Map(state.variables),
+        cwd: state.cwd
+      });
       if (target) {
         return target;
       }
@@ -1326,7 +1853,10 @@ function findCommandSubstitutionWriteTarget(
         return undefined;
       }
 
-      const target = findProtectedDataRawWriteTarget(substitution.content, variables);
+      const target = findProtectedDataRawWriteTargetWithState(substitution.content, {
+        variables: new Map(state.variables),
+        cwd: state.cwd
+      });
       if (target) {
         return target;
       }

--- a/packages/core/src/tools/data-raw-write-rule.ts
+++ b/packages/core/src/tools/data-raw-write-rule.ts
@@ -1,3 +1,4 @@
+import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
 import type { PolicyGateToolCall, PolicyRule } from "./policy-gate-core";
 
@@ -42,6 +43,7 @@ const SHELL_COMMANDS = new Set(["bash", "sh", "zsh"]);
 const FIND_MUTATION_ACTIONS = new Set(["-delete", "-exec", "-execdir", "-ok", "-okdir"]);
 const LOCAL_URL_SCHEME_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*:\/\//;
 const EXECUTABLE_CODE_STDIN_ARG = "-";
+const MAX_SHELL_COMMAND_SCAN_CHARS = 256 * 1024;
 const MAX_EXECUTABLE_CODE_SCAN_CHARS = 64 * 1024;
 const MAX_EXECUTABLE_RAW_TARGETS = 64;
 
@@ -79,8 +81,14 @@ type ShellScanState = {
 };
 
 type ShellScanBudget = {
+  remainingShellCommandChars: number;
   remainingExecutableCodeChars: number;
   remainingExecutableRawTargets: number;
+};
+
+type ShellCommandInvocation = {
+  command: string;
+  positionalArgs: readonly ShellToken[];
 };
 
 type SegmentCommandScanState = ShellScanState & {
@@ -152,22 +160,28 @@ function findProtectedDataRawWriteTargetWithState(
   command: string,
   state: ShellScanState
 ): string | undefined {
+  if (!reserveShellCommandScanBudget(command, state.scanBudget)) {
+    return "data/raw";
+  }
+
   const heredocTarget = findExecutableHeredocRawWriteTarget(command, state);
   if (heredocTarget) {
     return heredocTarget;
   }
 
-  const substitutionTarget = findCommandSubstitutionWriteTarget(command, state);
+  const commandWithoutHeredocBodies = stripHeredocBodies(command);
+
+  const substitutionTarget = findCommandSubstitutionWriteTarget(commandWithoutHeredocBodies, state);
   if (substitutionTarget) {
     return substitutionTarget;
   }
 
-  const groupedTarget = findGroupedCommandWriteTarget(command, state);
+  const groupedTarget = findGroupedCommandWriteTarget(commandWithoutHeredocBodies, state);
   if (groupedTarget) {
     return groupedTarget;
   }
 
-  const tokens = tokenizeShellCommand(command);
+  const tokens = tokenizeShellCommand(commandWithoutHeredocBodies);
   const pathContext = (): PathEvaluationContext => pathContextFromState(state);
 
   for (const segment of splitCommandSegments(tokens)) {
@@ -254,14 +268,24 @@ function findGroupedCommandWriteTarget(
       continue;
     }
 
-    const target = findProtectedDataRawWriteTargetWithState(group.body, {
+    const groupState = {
       variables: new Map(state.variables),
       cwd: state.cwd,
       cwdKnown: state.cwdKnown,
       scanBudget: state.scanBudget
-    });
+    };
+    const target = findProtectedDataRawWriteTargetWithState(group.body, groupState);
     if (target) {
       return target;
+    }
+    if (group.kind === "brace") {
+      const suffixTarget = findProtectedDataRawWriteTargetWithState(
+        command.slice(group.endIndex + 1),
+        groupState
+      );
+      if (suffixTarget) {
+        return suffixTarget;
+      }
     }
     index = group.endIndex + 1;
   }
@@ -272,10 +296,11 @@ function findGroupedCommandWriteTarget(
 function readSimpleCommandGroup(
   command: string,
   startIndex: number
-): { body: string; endIndex: number } | undefined {
+): { body: string; endIndex: number; kind: "brace" | "subshell" } | undefined {
   const char = command[startIndex];
   if (char === "(" && isShellGroupBoundary(command, startIndex - 1)) {
-    return readBalancedCommandGroup(command, startIndex, "(", ")");
+    const group = readBalancedCommandGroup(command, startIndex, "(", ")");
+    return group ? { ...group, kind: "subshell" } : undefined;
   }
   if (
     char === "{" &&
@@ -283,7 +308,9 @@ function readSimpleCommandGroup(
     isShellGroupBoundary(command, startIndex + 1)
   ) {
     const group = readBalancedCommandGroup(command, startIndex, "{", "}");
-    return group ? { body: group.body.replace(/;?\s*$/, ""), endIndex: group.endIndex } : undefined;
+    return group
+      ? { body: group.body.replace(/;?\s*$/, ""), endIndex: group.endIndex, kind: "brace" }
+      : undefined;
   }
 
   return undefined;
@@ -465,6 +492,12 @@ function findMutationCommandTarget(
       return target;
     }
   }
+  if (command === "rsync") {
+    const target = findRsyncSourceMutationTarget(args, context);
+    if (target) {
+      return target;
+    }
+  }
   if (ANY_ENDPOINT_RAW_PATH_COMMANDS.has(command)) {
     const target = findRawPathArgument(args, context);
     if (target) {
@@ -528,17 +561,20 @@ function findMutationCommandTarget(
     }
   }
   if (SHELL_COMMANDS.has(command)) {
-    const shellCommand = findShellCommandArgument(args);
-    const target = shellCommand
-      ? findProtectedDataRawWriteTargetWithState(shellCommand, {
-          variables: new Map(commandState.variables),
+    const shellInvocation = findShellCommandInvocation(args);
+    if (shellInvocation) {
+      const shellVariables = new Map(commandState.variables);
+      bindShellPositionalParameters(shellVariables, shellInvocation.positionalArgs);
+      const target = findProtectedDataRawWriteTargetWithState(shellInvocation.command, {
+          variables: shellVariables,
           cwd: commandState.cwd,
           cwdKnown: commandState.cwdKnown,
           scanBudget: commandState.scanBudget
-        })
-      : undefined;
-    if (target) {
-      return target;
+        });
+      if (target) {
+        return target;
+      }
+      return undefined;
     }
   }
 
@@ -798,6 +834,10 @@ function findProtectedRawPathCandidate(
   token: ShellToken,
   context: PathEvaluationContext
 ): PathCandidate | undefined {
+  if (token.value === "{" || token.value === "}") {
+    return undefined;
+  }
+
   const wholeTokenCandidate = pathCandidateFromToken(token);
   if (isProtectedDataRawCandidate(wholeTokenCandidate, context)) {
     return wholeTokenCandidate;
@@ -885,6 +925,10 @@ function isCopyOutOfRawCommand(
   args: readonly ShellToken[],
   context: PathEvaluationContext
 ): boolean {
+  if (args.some(isRsyncSourceMutationOption)) {
+    return false;
+  }
+
   const targetDirectory = findTargetDirectoryArgument(args);
   if (targetDirectory !== undefined) {
     return (
@@ -900,6 +944,21 @@ function isCopyOutOfRawCommand(
   }
 
   return positionalArgs.slice(0, -1).some((arg) => isProtectedDataRawCandidate(arg, context));
+}
+
+function findRsyncSourceMutationTarget(
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
+  if (!args.some(isRsyncSourceMutationOption)) {
+    return undefined;
+  }
+
+  return findRawPathArgument(args, context);
+}
+
+function isRsyncSourceMutationOption(arg: ShellToken): boolean {
+  return arg.value === "--remove-source-files";
 }
 
 function lastNonOptionArgument(
@@ -1382,21 +1441,45 @@ function findExecutableCodeStringAt(
   return undefined;
 }
 
-function findShellCommandArgument(args: readonly ShellToken[]): string | undefined {
+function findShellCommandInvocation(args: readonly ShellToken[]): ShellCommandInvocation | undefined {
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index].value;
     if (arg === "--") {
       continue;
     }
     if (arg === "-c") {
-      return args[index + 1]?.value;
+      return shellCommandInvocationAt(args, index + 1);
     }
     if (arg.startsWith("-") && !arg.startsWith("--") && arg.includes("c")) {
-      return args[index + 1]?.value;
+      return shellCommandInvocationAt(args, index + 1);
     }
   }
 
   return undefined;
+}
+
+function shellCommandInvocationAt(
+  args: readonly ShellToken[],
+  commandIndex: number
+): ShellCommandInvocation | undefined {
+  const command = args[commandIndex]?.value;
+  if (!command) {
+    return undefined;
+  }
+
+  return {
+    command,
+    positionalArgs: args.slice(commandIndex + 2)
+  };
+}
+
+function bindShellPositionalParameters(
+  variables: Map<string, string>,
+  positionalArgs: readonly ShellToken[]
+): void {
+  for (let index = 0; index < positionalArgs.length; index += 1) {
+    variables.set(String(index + 1), positionalArgs[index].value);
+  }
 }
 
 function findExecutableHeredocRawWriteTarget(
@@ -1439,6 +1522,37 @@ function findExecutableHeredocRawWriteTarget(
   }
 
   return undefined;
+}
+
+function stripHeredocBodies(command: string): string {
+  const lines = command.split(/\r?\n/);
+  const strippedLines: string[] = [];
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
+    const heredoc = parseHeredocStart(line);
+    strippedLines.push(line);
+    if (!heredoc) {
+      continue;
+    }
+
+    let bodyIndex = lineIndex + 1;
+    for (; bodyIndex < lines.length; bodyIndex += 1) {
+      const delimiterLine = heredoc.stripLeadingTabs
+        ? lines[bodyIndex].replace(/^\t+/, "")
+        : lines[bodyIndex];
+      if (delimiterLine === heredoc.delimiter) {
+        strippedLines.push(lines[bodyIndex]);
+        break;
+      }
+    }
+
+    if (bodyIndex < lines.length) {
+      lineIndex = bodyIndex;
+    }
+  }
+
+  return strippedLines.join("\n");
 }
 
 function parseHeredocStart(line: string):
@@ -1563,9 +1677,23 @@ function pathContextFromState(state: Pick<ShellScanState, "cwd" | "cwdKnown">): 
 
 function makeShellScanBudget(): ShellScanBudget {
   return {
+    remainingShellCommandChars: MAX_SHELL_COMMAND_SCAN_CHARS,
     remainingExecutableCodeChars: MAX_EXECUTABLE_CODE_SCAN_CHARS,
     remainingExecutableRawTargets: MAX_EXECUTABLE_RAW_TARGETS
   };
+}
+
+function reserveShellCommandScanBudget(
+  command: string,
+  scanBudget: ShellScanBudget
+): boolean {
+  if (command.length > scanBudget.remainingShellCommandChars) {
+    scanBudget.remainingShellCommandChars = 0;
+    return false;
+  }
+
+  scanBudget.remainingShellCommandChars -= command.length;
+  return true;
 }
 
 function findExecutableCodeRawMutationTargetInText(
@@ -1684,16 +1812,40 @@ function expandTokenParameterReferences(
     return token;
   }
 
-  const expandedValue = token.value.replace(
-    /\$(?:{([A-Za-z_][A-Za-z0-9_]*)}|([A-Za-z_][A-Za-z0-9_]*))/g,
-    (match, bracedName: string | undefined, bareName: string | undefined) => {
-      const variableName = bracedName ?? bareName;
-      const value = variableName ? variables.get(variableName) : undefined;
-      return value ?? match;
-    }
+  const expandedBraces = token.value.replace(/\$\{([^}]+)\}/g, (match, expression: string) =>
+    expandBracedParameterExpression(match, expression, variables)
+  );
+  const expandedValue = expandedBraces.replace(
+    /\$([A-Za-z_][A-Za-z0-9_]*|[0-9]+)/g,
+    (match, variableName: string) => variables.get(variableName) ?? match
   );
 
   return expandedValue === token.value ? token : { ...token, value: expandedValue };
+}
+
+function expandBracedParameterExpression(
+  match: string,
+  expression: string,
+  variables: ReadonlyMap<string, string>
+): string {
+  const simple = expression.match(/^([A-Za-z_][A-Za-z0-9_]*|[0-9]+)$/);
+  if (simple) {
+    return variables.get(simple[1]) ?? match;
+  }
+
+  const slice = expression.match(/^([A-Za-z_][A-Za-z0-9_]*|[0-9]+):([0-9]+)(?::([0-9]+))?$/);
+  if (!slice) {
+    return match;
+  }
+
+  const value = variables.get(slice[1]);
+  if (value === undefined) {
+    return match;
+  }
+
+  const start = Number(slice[2]);
+  const length = slice[3] === undefined ? undefined : Number(slice[3]);
+  return length === undefined ? value.slice(start) : value.slice(start, start + length);
 }
 
 function recordVariableAssignments(
@@ -1760,6 +1912,9 @@ function isProtectedDataRawCandidate(
   if (isProtectedDataRawPath(candidate.value, context)) {
     return true;
   }
+  if (isProtectedDataRawAlias(candidate.value, context)) {
+    return true;
+  }
   if (
     !candidate.fullyQuoted &&
     expandShellBraceAlternatives(candidate.value).some((expanded) =>
@@ -1770,6 +1925,40 @@ function isProtectedDataRawCandidate(
   }
 
   return canUnresolvedShellPathResolveToProtectedRaw(candidate, context);
+}
+
+function isProtectedDataRawAlias(candidate: string, context: PathEvaluationContext): boolean {
+  const localCandidate = normalizeLocalPathCandidate(candidate);
+  if (!localCandidate || !context.cwdKnown) {
+    return false;
+  }
+
+  const absoluteCandidate =
+    context.cwd && isRelativeLocalPath(localCandidate)
+      ? path.resolve(context.cwd, localCandidate)
+      : path.resolve(localCandidate);
+  const resolvedCandidate = resolveExistingPathAlias(absoluteCandidate);
+  return resolvedCandidate ? isProtectedDataRawPathVariant(resolvedCandidate) : false;
+}
+
+function resolveExistingPathAlias(absoluteCandidate: string): string | undefined {
+  let existingPrefix = absoluteCandidate;
+  const suffixSegments: string[] = [];
+
+  while (!existsSync(existingPrefix)) {
+    const parent = path.dirname(existingPrefix);
+    if (parent === existingPrefix) {
+      return undefined;
+    }
+    suffixSegments.unshift(path.basename(existingPrefix));
+    existingPrefix = parent;
+  }
+
+  try {
+    return path.join(realpathSync(existingPrefix), ...suffixSegments);
+  } catch {
+    return undefined;
+  }
 }
 
 function isProtectedDataRawPath(
@@ -1988,11 +2177,22 @@ function globSegmentPatternToRegex(pattern: string): RegExp | undefined {
         changed = true;
         continue;
       }
+      source += ".";
+      changed = true;
+      continue;
     }
     source += escapeRegExp(char);
   }
 
-  return changed ? new RegExp(`^${source}$`, "i") : undefined;
+  if (!changed) {
+    return undefined;
+  }
+
+  try {
+    return new RegExp(`^${source}$`, "i");
+  } catch {
+    return /^.*$/i;
+  }
 }
 
 function findGlobBracketExpressionEnd(pattern: string, openIndex: number): number {
@@ -2007,6 +2207,9 @@ function findGlobBracketExpressionEnd(pattern: string, openIndex: number): numbe
 function globBracketExpressionToRegexSource(expression: string): string {
   const posixClass = expression.match(/^\[\[:([A-Za-z]+):\]\]$/);
   if (!posixClass) {
+    if (expression.startsWith("[!")) {
+      return `[^${expression.slice(2, -1)}]`;
+    }
     return expression;
   }
 

--- a/packages/core/src/tools/data-raw-write-rule.ts
+++ b/packages/core/src/tools/data-raw-write-rule.ts
@@ -1,0 +1,285 @@
+import path from "node:path";
+import type { PolicyGateToolCall, PolicyRule } from "./policy-gate-core";
+
+export const DATA_RAW_WRITE_DENY_RULE_ID = "policy-gate-spike.data_raw_write_forbidden" as const;
+export const DATA_RAW_WRITE_GUARD_CLASS = "authority" as const;
+export const DATA_RAW_WRITE_RULE_REF =
+  "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md" as const;
+
+const BASH_TOOL_IDS = new Set(["bash"]);
+const REDIRECT_WRITE_OPERATORS = new Set([">", ">>", ">|", "1>", "1>>", "2>", "2>>", "&>", "&>>"]);
+const SEGMENT_SEPARATORS = new Set([";", "&&", "||", "|"]);
+const ANY_RAW_PATH_MUTATION_COMMANDS = new Set([
+  "chmod",
+  "chown",
+  "mkdir",
+  "rm",
+  "rmdir",
+  "touch"
+]);
+const DESTINATION_RAW_PATH_COMMANDS = new Set(["cp", "install", "ln"]);
+const ANY_ENDPOINT_RAW_PATH_COMMANDS = new Set(["mv"]);
+const WRAPPER_COMMANDS = new Set(["command", "doas", "env", "nice", "nohup", "sudo", "time"]);
+
+export const DATA_RAW_WRITE_DENY_RULE: PolicyRule = {
+  ruleId: DATA_RAW_WRITE_DENY_RULE_ID,
+  guard_class: DATA_RAW_WRITE_GUARD_CLASS,
+  description: "Deny bash mutations targeting protected data/raw paths.",
+  evaluate(call) {
+    if (!BASH_TOOL_IDS.has(call.toolId)) {
+      return { decision: "allow" };
+    }
+
+    const command = extractBashCommand(call.input);
+    if (!command) {
+      return { decision: "allow" };
+    }
+
+    const target = findProtectedDataRawWriteTarget(command);
+    if (!target) {
+      return { decision: "allow" };
+    }
+
+    return {
+      decision: "deny",
+      reason: `bash command attempts to mutate protected raw data path: ${target}`,
+      remediation: {
+        next_action: "adjust_scope",
+        hint:
+          "Write generated or edited data under a governed task workspace path instead of data/raw.",
+        ref: DATA_RAW_WRITE_RULE_REF
+      }
+    };
+  }
+};
+
+export function extractBashCommand(input: unknown): string | undefined {
+  if (!input || typeof input !== "object") {
+    return undefined;
+  }
+
+  const record = input as Record<string, unknown>;
+  if (typeof record.command === "string") {
+    return record.command;
+  }
+  if (typeof record.cmd === "string") {
+    return record.cmd;
+  }
+  return undefined;
+}
+
+export function findProtectedDataRawWriteTarget(command: string): string | undefined {
+  const tokens = tokenizeShellCommand(command);
+  const redirectTarget = findRedirectWriteTarget(tokens);
+  if (redirectTarget) {
+    return redirectTarget;
+  }
+
+  for (const segment of splitCommandSegments(tokens)) {
+    const mutationTarget = findMutationCommandTarget(segment);
+    if (mutationTarget) {
+      return mutationTarget;
+    }
+  }
+
+  return undefined;
+}
+
+export function makeDataRawPolicyGateContext() {
+  return {
+    rules: [DATA_RAW_WRITE_DENY_RULE]
+  };
+}
+
+export type DataRawWritePolicyCall = PolicyGateToolCall;
+
+function findRedirectWriteTarget(tokens: readonly string[]): string | undefined {
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (!REDIRECT_WRITE_OPERATORS.has(token)) {
+      continue;
+    }
+
+    const target = tokens[index + 1];
+    if (target && isProtectedDataRawPath(target)) {
+      return target;
+    }
+  }
+
+  return undefined;
+}
+
+function splitCommandSegments(tokens: readonly string[]): string[][] {
+  const segments: string[][] = [];
+  let current: string[] = [];
+
+  for (const token of tokens) {
+    if (SEGMENT_SEPARATORS.has(token)) {
+      if (current.length > 0) {
+        segments.push(current);
+        current = [];
+      }
+      continue;
+    }
+    current.push(token);
+  }
+
+  if (current.length > 0) {
+    segments.push(current);
+  }
+
+  return segments;
+}
+
+function findMutationCommandTarget(segment: readonly string[]): string | undefined {
+  const commandIndex = findCommandTokenIndex(segment);
+  if (commandIndex === undefined) {
+    return undefined;
+  }
+
+  const command = path.posix.basename(segment[commandIndex]);
+  const args = segment.slice(commandIndex + 1);
+  if (ANY_RAW_PATH_MUTATION_COMMANDS.has(command)) {
+    return args.find(isProtectedDataRawPath);
+  }
+  if (DESTINATION_RAW_PATH_COMMANDS.has(command)) {
+    return lastNonOptionArgument(args);
+  }
+  if (ANY_ENDPOINT_RAW_PATH_COMMANDS.has(command)) {
+    return args.find(isProtectedDataRawPath);
+  }
+  if (command === "tee") {
+    return args.find((arg) => !arg.startsWith("-") && isProtectedDataRawPath(arg));
+  }
+  if (command === "sed" && args.some((arg) => arg === "-i" || arg.startsWith("-i"))) {
+    return args.find(isProtectedDataRawPath);
+  }
+
+  return undefined;
+}
+
+function findCommandTokenIndex(segment: readonly string[]): number | undefined {
+  let index = 0;
+  while (index < segment.length) {
+    const token = segment[index];
+    if (isAssignment(token)) {
+      index += 1;
+      continue;
+    }
+
+    const command = path.posix.basename(token);
+    if (WRAPPER_COMMANDS.has(command)) {
+      index += 1;
+      while (index < segment.length && segment[index].startsWith("-")) {
+        index += 1;
+      }
+      continue;
+    }
+
+    return index;
+  }
+
+  return undefined;
+}
+
+function lastNonOptionArgument(args: readonly string[]): string | undefined {
+  const target = args.filter((arg) => !arg.startsWith("-")).at(-1);
+  return target && isProtectedDataRawPath(target) ? target : undefined;
+}
+
+function isAssignment(token: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
+}
+
+function isProtectedDataRawPath(candidate: string): boolean {
+  const normalized = path.posix.normalize(candidate.replace(/^file:\/\//, ""));
+  const withoutDotPrefix = normalized.replace(/^\.\/+/, "");
+  return (
+    withoutDotPrefix === "data/raw" ||
+    withoutDotPrefix.startsWith("data/raw/") ||
+    withoutDotPrefix.endsWith("/data/raw") ||
+    withoutDotPrefix.includes("/data/raw/")
+  );
+}
+
+function tokenizeShellCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+  let index = 0;
+
+  const flush = () => {
+    if (current.length > 0) {
+      tokens.push(current);
+      current = "";
+    }
+  };
+
+  while (index < command.length) {
+    const char = command[index];
+
+    if (quote) {
+      if (char === "\\") {
+        const next = command[index + 1];
+        if (next !== undefined) {
+          current += next;
+          index += 2;
+          continue;
+        }
+      }
+      if (char === quote) {
+        quote = undefined;
+        index += 1;
+        continue;
+      }
+      current += char;
+      index += 1;
+      continue;
+    }
+
+    if (char === "'" || char === `"`) {
+      quote = char;
+      index += 1;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      flush();
+      index += 1;
+      continue;
+    }
+
+    const operator = readShellOperator(command, index);
+    if (operator) {
+      flush();
+      tokens.push(operator);
+      index += operator.length;
+      continue;
+    }
+
+    if (char === "\\") {
+      const next = command[index + 1];
+      if (next !== undefined) {
+        current += next;
+        index += 2;
+        continue;
+      }
+    }
+
+    current += char;
+    index += 1;
+  }
+
+  flush();
+  return tokens;
+}
+
+function readShellOperator(command: string, index: number): string | undefined {
+  for (const operator of ["&>>", "&&", "||", ">>", ">|", "1>>", "2>>", "&>", "1>", "2>", ">", "|", ";"]) {
+    if (command.startsWith(operator, index)) {
+      return operator;
+    }
+  }
+
+  return undefined;
+}

--- a/packages/core/src/tools/data-raw-write-rule.ts
+++ b/packages/core/src/tools/data-raw-write-rule.ts
@@ -23,11 +23,13 @@ const ANY_ENDPOINT_RAW_PATH_COMMANDS = new Set(["mv"]);
 const READ_ONLY_RAW_PATH_COMMANDS = new Set([
   "cat",
   "du",
+  "echo",
   "file",
   "grep",
   "head",
   "ls",
   "mapfile",
+  "printf",
   "read",
   "sha256sum",
   "stat",
@@ -37,6 +39,9 @@ const READ_ONLY_RAW_PATH_COMMANDS = new Set([
 ]);
 const ASSIGNMENT_BUILTIN_COMMANDS = new Set(["declare", "export", "readonly", "typeset"]);
 const WRAPPER_COMMANDS = new Set(["command", "doas", "env", "nice", "nohup", "sudo", "time"]);
+const WRAPPER_OPTIONS_WITHOUT_OPERANDS = new Map<string, ReadonlySet<string>>([
+  ["command", new Set(["-p"])]
+]);
 const WRAPPER_OPTIONS_WITH_OPERANDS = new Map<string, ReadonlySet<string>>([
   ["doas", new Set(["-u"])],
   ["env", new Set(["-C", "--chdir", "-u", "--unset"])],
@@ -45,7 +50,8 @@ const WRAPPER_OPTIONS_WITH_OPERANDS = new Map<string, ReadonlySet<string>>([
   ["time", new Set(["-f", "--format"])]
 ]);
 const SHELL_COMMANDS = new Set(["bash", "sh", "zsh"]);
-const FIND_MUTATION_ACTIONS = new Set(["-delete", "-exec", "-execdir", "-ok", "-okdir"]);
+const FIND_EXEC_ACTIONS = new Set(["-exec", "-execdir", "-ok", "-okdir"]);
+const FIND_MUTATION_ACTIONS = new Set(["-delete"]);
 const LOCAL_URL_SCHEME_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*:\/\//;
 const EXECUTABLE_CODE_STDIN_ARG = "-";
 const MAX_SHELL_COMMAND_SCAN_CHARS = 256 * 1024;
@@ -157,10 +163,11 @@ export function findProtectedDataRawWriteTarget(
   initialVariables: ReadonlyMap<string, string> = new Map(),
   workDir?: string
 ): string | undefined {
+  const initialCwd = normalizeInitialCwd(workDir);
   return findProtectedDataRawWriteTargetWithState(command, {
     variables: new Map(initialVariables),
-    cwd: normalizeInitialCwd(workDir),
-    cwdKnown: true,
+    cwd: initialCwd.cwd,
+    cwdKnown: initialCwd.cwdKnown,
     pathAliases: new Map(),
     scanBudget: makeShellScanBudget()
   });
@@ -177,7 +184,7 @@ function findProtectedDataRawWriteTargetWithState(
 
   const commandWithoutHeredocBodies = stripHeredocBodies(command);
   if (!reserveShellCommandScanBudget(commandWithoutHeredocBodies, state.scanBudget)) {
-    return hasProtectedRawPathText(commandWithoutHeredocBodies) &&
+    return hasPotentialProtectedRawPathText(commandWithoutHeredocBodies) &&
       hasShellWriteIntentMarker(commandWithoutHeredocBodies)
       ? "data/raw"
       : undefined;
@@ -201,7 +208,11 @@ function findProtectedDataRawWriteTargetWithState(
     return positionalLoopTarget;
   }
 
-  const tokens = tokenizeShellCommand(commandWithoutHeredocBodies);
+  const commandWithoutHandledLoops = stripHandledImplicitPositionalLoops(
+    commandWithoutHeredocBodies,
+    state
+  );
+  const tokens = tokenizeShellCommand(commandWithoutHandledLoops);
   const pathContext = (): PathEvaluationContext => pathContextFromState(state);
 
   for (const segment of splitCommandSegments(tokens)) {
@@ -502,6 +513,12 @@ function findMutationCommandTarget(
       return target;
     }
   }
+  if ((command === "perl" || command === "ruby") && args.some(isInterpreterInPlaceOption)) {
+    const target = findRawPathArgument(args, context);
+    if (target) {
+      return target;
+    }
+  }
   if (isExecutableCodeStringCommand(command)) {
     const target = findExecutableCodeStringRawMutationTarget(command, args, commandState);
     if (target) {
@@ -513,6 +530,12 @@ function findMutationCommandTarget(
   }
   if (ANY_RAW_PATH_MUTATION_COMMANDS.has(command)) {
     const target = findRawPathArgument(args, context);
+    if (target) {
+      return target;
+    }
+  }
+  if (command === "ln") {
+    const target = findLnRawAncestorSymlinkTarget(args, commandState);
     if (target) {
       return target;
     }
@@ -568,7 +591,7 @@ function findMutationCommandTarget(
     }
   }
   if (command === "find") {
-    const execTarget = findFindExecMutationTarget(args, commandState);
+    const execTarget = findFindExecMutationTarget(args, commandState, context);
     if (execTarget) {
       return execTarget;
     }
@@ -834,7 +857,12 @@ function parseWrapperOptions(
 function wrapperOptionOperandMode(
   command: string,
   option: string
-): "inline" | "separate" | undefined {
+): "inline" | "separate" | "none" | undefined {
+  const optionsWithoutOperands = WRAPPER_OPTIONS_WITHOUT_OPERANDS.get(command);
+  if (optionsWithoutOperands?.has(option)) {
+    return "none";
+  }
+
   const optionsWithOperands = WRAPPER_OPTIONS_WITH_OPERANDS.get(command);
   if (!optionsWithOperands) {
     return undefined;
@@ -946,7 +974,7 @@ function isReadOnlySafeRawPathCommand(
     return true;
   }
   if (command === "find") {
-    return !hasFindMutationAction(args);
+    return findFindMutationTarget(args, context) === undefined;
   }
   if (command === "sed") {
     return !args.some(isSedInPlaceOption);
@@ -1128,20 +1156,46 @@ function findCurlOutputTarget(
   context: PathEvaluationContext
 ): string | undefined {
   let usesRemoteNameOutput = false;
+  let hasRelativeExplicitOutputTarget = false;
+  let outputDirectory: PathCandidate | undefined;
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index].value;
     if (arg === "-o" || arg === "--output") {
       const target = args[index + 1];
+      hasRelativeExplicitOutputTarget =
+        hasRelativeExplicitOutputTarget || (target !== undefined && isRelativeLocalPath(target.value));
       if (target && isProtectedDataRawCandidate(target, context)) {
         return target.value;
+      }
+      if (
+        target &&
+        outputDirectory &&
+        isRelativeLocalPath(target.value) &&
+        isProtectedDataRawCandidate(outputDirectory, context)
+      ) {
+        return outputDirectory.value;
       }
       continue;
     }
     if (arg.startsWith("--output=")) {
       const target = pathCandidateFromToken(args[index], arg.slice("--output=".length));
+      hasRelativeExplicitOutputTarget =
+        hasRelativeExplicitOutputTarget || isRelativeLocalPath(target.value);
       if (isProtectedDataRawCandidate(target, context)) {
         return target.value;
       }
+      if (
+        outputDirectory &&
+        isRelativeLocalPath(target.value) &&
+        isProtectedDataRawCandidate(outputDirectory, context)
+      ) {
+        return outputDirectory.value;
+      }
+      continue;
+    }
+    const directoryTarget = findCurlOutputDirectoryAt(args, index);
+    if (directoryTarget) {
+      outputDirectory = directoryTarget;
       continue;
     }
 
@@ -1155,6 +1209,13 @@ function findCurlOutputTarget(
     }
   }
 
+  if (
+    outputDirectory &&
+    (usesRemoteNameOutput || hasRelativeExplicitOutputTarget) &&
+    isProtectedDataRawCandidate(outputDirectory, context)
+  ) {
+    return outputDirectory.value;
+  }
   return usesRemoteNameOutput ? protectedCurrentWorkingDirectoryTarget(context) : undefined;
 }
 
@@ -1162,8 +1223,19 @@ function isCurlRemoteNameOption(arg: string): boolean {
   return (
     arg === "-O" ||
     arg === "--remote-name" ||
+    arg === "--remote-name-all" ||
     (!arg.startsWith("--") && arg.startsWith("-") && arg.slice(1).includes("O"))
   );
+}
+
+function findCurlOutputDirectoryAt(
+  args: readonly ShellToken[],
+  index: number
+): PathCandidate | undefined {
+  return findOptionValueAt(args, index, {
+    separate: new Set(["--output-dir"]),
+    longAssignments: ["--output-dir="]
+  });
 }
 
 function findCurlShortOutputTarget(
@@ -1191,6 +1263,16 @@ function findCurlShortOutputTarget(
 }
 
 function isSedInPlaceOption(arg: ShellToken): boolean {
+  return (
+    arg.value === "-i" ||
+    arg.value.startsWith("-i") ||
+    (arg.value.startsWith("-") && !arg.value.startsWith("--") && arg.value.slice(1).includes("i")) ||
+    arg.value === "--in-place" ||
+    arg.value.startsWith("--in-place=")
+  );
+}
+
+function isInterpreterInPlaceOption(arg: ShellToken): boolean {
   return (
     arg.value === "-i" ||
     arg.value.startsWith("-i") ||
@@ -1513,10 +1595,12 @@ function findTrapCommandTarget(
 
 function findFindExecMutationTarget(
   args: readonly ShellToken[],
-  state: ShellScanState
+  state: ShellScanState,
+  context: PathEvaluationContext
 ): string | undefined {
+  const rawSearchRoot = findFindSearchRootRawPath(args, context);
   for (let index = 0; index < args.length; index += 1) {
-    if (!["-exec", "-execdir", "-ok", "-okdir"].includes(args[index].value)) {
+    if (!FIND_EXEC_ACTIONS.has(args[index].value)) {
       continue;
     }
 
@@ -1530,10 +1614,77 @@ function findFindExecMutationTarget(
     if (target) {
       return target;
     }
+    if (rawSearchRoot && findExecPayloadMutatesSelection(execSegment, state)) {
+      return rawSearchRoot;
+    }
     index = endIndex;
   }
 
   return undefined;
+}
+
+function findFindSearchRootRawPath(
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
+  const firstActionIndex = args.findIndex(
+    (arg) => FIND_EXEC_ACTIONS.has(arg.value) || FIND_MUTATION_ACTIONS.has(arg.value)
+  );
+  const searchArgs = firstActionIndex === -1 ? args : args.slice(0, firstActionIndex);
+  return findRawPathArgument(searchArgs, context);
+}
+
+function findExecPayloadMutatesSelection(
+  execSegment: readonly ShellToken[],
+  state: ShellScanState
+): boolean {
+  if (!execSegment.some((arg) => arg.value.includes("{}"))) {
+    return false;
+  }
+
+  const commandState = buildSegmentCommandScanState(execSegment, state);
+  const { commandIndex } = commandState;
+  if (commandIndex === undefined) {
+    return false;
+  }
+
+  if (commandState.uncertainWrapper) {
+    return true;
+  }
+
+  const command = path.posix.basename(execSegment[commandIndex].value);
+  const args = execSegment.slice(commandIndex + 1);
+  if (READ_ONLY_RAW_PATH_COMMANDS.has(command)) {
+    return false;
+  }
+  if (command === "sed") {
+    return args.some(isSedInPlaceOption);
+  }
+  if (command === "awk") {
+    return !isReadOnlyAwkCommand(args);
+  }
+  if ((command === "perl" || command === "ruby") && args.some(isInterpreterInPlaceOption)) {
+    return true;
+  }
+  if (SHELL_COMMANDS.has(command)) {
+    return hasShellWriteIntentMarker(args.map((arg) => arg.value).join(" "));
+  }
+  if (DESTINATION_RAW_PATH_COMMANDS.has(command)) {
+    return findDestinationArgumentIncludesPlaceholder(args);
+  }
+  return ANY_RAW_PATH_MUTATION_COMMANDS.has(command) || ANY_ENDPOINT_RAW_PATH_COMMANDS.has(command);
+}
+
+function findDestinationArgumentIncludesPlaceholder(args: readonly ShellToken[]): boolean {
+  const targetDirectory = findTargetDirectoryArgument(args);
+  if (targetDirectory !== undefined) {
+    return targetDirectory.value.includes("{}");
+  }
+
+  return args
+    .filter((arg) => !arg.value.startsWith("-"))
+    .at(-1)
+    ?.value.includes("{}") === true;
 }
 
 function findFindExecTerminatorIndex(args: readonly ShellToken[], startIndex: number): number {
@@ -1745,6 +1896,14 @@ function findImplicitPositionalLoopWriteTarget(
   }
 
   return undefined;
+}
+
+function stripHandledImplicitPositionalLoops(command: string, state: ShellScanState): string {
+  if (knownShellPositionalValues(state.variables).length === 0) {
+    return command;
+  }
+
+  return command.replace(/\bfor\s+[A-Za-z_][A-Za-z0-9_]*\s*;?\s*do\b[\s\S]*?\bdone\b/g, ":");
 }
 
 function knownShellPositionalValues(variables: ReadonlyMap<string, string>): string[] {
@@ -1994,6 +2153,25 @@ function parseLnSymlinkAlias(
   return { linkPath, targetPath };
 }
 
+function findLnRawAncestorSymlinkTarget(
+  args: readonly ShellToken[],
+  state: Pick<ShellScanState, "cwd" | "cwdKnown">
+): string | undefined {
+  const alias = parseLnSymlinkAlias(args, state);
+  if (!alias) {
+    return undefined;
+  }
+
+  return isProtectedRawSymlinkTarget(alias.targetPath) ? alias.targetPath : undefined;
+}
+
+function isProtectedRawSymlinkTarget(targetPath: string): boolean {
+  return (
+    isProtectedDataRawPath(targetPath) ||
+    isProtectedDataRawPath(path.join(targetPath, "raw"))
+  );
+}
+
 function isSimpleLiteralCdTarget(target: ShellToken): boolean {
   return isSimpleLiteralPathValue(target.value);
 }
@@ -2017,8 +2195,10 @@ function resolveShellPathWithKnowledge(
   return { cwd: path.resolve(cwd, target), cwdKnown: true };
 }
 
-function normalizeInitialCwd(workDir: string | undefined): string {
-  return path.resolve(workDir ?? process.cwd());
+function normalizeInitialCwd(workDir: string | undefined): { cwd?: string; cwdKnown: boolean } {
+  return workDir === undefined
+    ? { cwd: undefined, cwdKnown: false }
+    : { cwd: path.resolve(workDir), cwdKnown: true };
 }
 
 function pathContextFromState(
@@ -2060,9 +2240,14 @@ function findExecutableCodeRawMutationTargetInText(
   scanBudget: ShellScanBudget
 ): string | undefined {
   if (!reserveExecutableCodeScanBudget(value, scanBudget)) {
-    return hasProtectedRawPathText(value) && hasExecutableCodeWriteIntentMarker(value)
+    return hasPotentialExecutableProtectedRawPathText(value) && hasExecutableCodeWriteIntentMarker(value)
       ? "data/raw"
       : undefined;
+  }
+
+  const constructedTarget = findConstructedExecutableRawPathTarget(value, context);
+  if (constructedTarget && hasExecutableCodeWriteIntentMarker(value)) {
+    return constructedTarget;
   }
 
   const scanResult = findProtectedRawPathsInText(value, context, scanBudget);
@@ -2144,6 +2329,29 @@ function findFirstProtectedRawPathInText(
   return undefined;
 }
 
+function findConstructedExecutableRawPathTarget(
+  value: string,
+  context: PathEvaluationContext
+): string | undefined {
+  return hasExecutableRawPathConstruction(value) && isProtectedDataRawPath("data/raw", context)
+    ? "data/raw"
+    : undefined;
+}
+
+function hasPotentialExecutableProtectedRawPathText(value: string): boolean {
+  return hasProtectedRawPathText(value) || hasExecutableRawPathConstruction(value);
+}
+
+function hasExecutableRawPathConstruction(value: string): boolean {
+  return [
+    /["']data\/?["']\s*\+\s*["']\/?raw(?:\/[^"']*)?["']/i,
+    /["']data["']\s*\+\s*["']\/raw(?:\/[^"']*)?["']/i,
+    /\bPath\s*\(\s*["']data["']\s*\)\s*\/\s*["']raw(?:\/[^"']*)?["']/i,
+    /\bpath\.join\s*\(\s*["']data["']\s*,\s*["']raw["']/i,
+    /\bfile\.path\s*\(\s*["']data["']\s*,\s*["']raw["']/i
+  ].some((pattern) => pattern.test(value));
+}
+
 function reserveExecutableCodeScanBudget(
   value: string,
   scanBudget: ShellScanBudget
@@ -2161,11 +2369,19 @@ function hasProtectedRawPathText(value: string): boolean {
   return value.toLowerCase().includes("data/raw");
 }
 
+function hasPotentialProtectedRawPathText(value: string): boolean {
+  return (
+    hasProtectedRawPathText(value) ||
+    /\bdata\//i.test(value) &&
+      /(?:\$\(|`|\$\{|\$[A-Za-z_][A-Za-z0-9_]*|[*?\[\]{}])/.test(value)
+  );
+}
+
 function hasShellWriteIntentMarker(value: string): boolean {
   return (
     /(?:^|[\s;&|(){}])(?:rm|touch|truncate|mkdir|rmdir|chmod|chown|mv|cp|install|ln|rsync|dd|tee|curl|wget|tar|unzip|git|sed|awk|find|eval|bash|sh|zsh|python|python\d+(?:\.\d+)?|node|bun|deno|r|rscript|ruby|php|perl)\b/i.test(
       value
-    ) || /(?:^|\s)(?:>|>>|>\||1>|1>>|2>|2>>|&>|&>>|>&)\s*/.test(value)
+    ) || /(?:^|\s)(?:[0-9]*<>|>|>>|>\||1>|1>>|2>|2>>|&>|&>>|>&)\s*/.test(value)
   );
 }
 
@@ -2174,7 +2390,7 @@ function hasExecutableCodeWriteIntentMarker(value: string): boolean {
     /\bopen\s*\([^)]*(?:,\s*(?:mode\s*=\s*)?["'][^"']*[wax+][^"']*["']|\bmode\s*=\s*["'][^"']*[wax+][^"']*["']|["']>{1,2}["'])/i.test(
       value
     ) ||
-    /\b(?:writeFile|writeFileSync|appendFile|appendFileSync|createWriteStream|unlink|unlinkSync|rm|rmSync|remove|removeSync|rename|renameSync|mkdir|mkdirSync|rmdir|rmdirSync|truncate|truncateSync|writeLines|write\.csv|write\.table|saveRDS|save|file_put_contents)\s*\(/i.test(
+    /\b(?:writeFile|writeFileSync|writeTextFile|writeTextFileSync|appendFile|appendFileSync|createWriteStream|unlink|unlinkSync|rm|rmSync|remove|removeSync|rename|renameSync|mkdir|mkdirSync|rmdir|rmdirSync|truncate|truncateSync|writeLines|write\.csv|write\.table|saveRDS|save|file_put_contents)\s*\(/i.test(
       value
     ) ||
     /\b(?:Bun\.write|File\.write)\s*\(/i.test(value) ||
@@ -2188,7 +2404,7 @@ function hasExecutableCodeWriteIntentForRawPath(value: string, target: string): 
 
   return [
     new RegExp(`\\bopen\\s*\\(${codeBeforeRawCloseParen},\\s*["'][^"']*[wax+][^"']*["']`, "i"),
-    new RegExp(`\\b(?:writeFile|writeFileSync|appendFile|appendFileSync|createWriteStream)\\s*\\(${codeBeforeRawCloseParen}`, "i"),
+    new RegExp(`\\b(?:writeFile|writeFileSync|writeTextFile|writeTextFileSync|appendFile|appendFileSync|createWriteStream)\\s*\\(${codeBeforeRawCloseParen}`, "i"),
     new RegExp(`\\b(?:unlink|unlinkSync|rm|rmSync|remove|removeSync|rename|renameSync|mkdir|mkdirSync|rmdir|rmdirSync|truncate|truncateSync)\\s*\\(${codeBeforeRawCloseParen}`, "i"),
     new RegExp(`\\b(?:writeLines|write\\.csv|write\\.table|saveRDS|save)\\s*\\([\\s\\S]{0,1024}${escapedTarget}`, "i"),
     new RegExp(`\\bPath\\s*\\(${codeBeforeRawCloseParen}\\)\\.write_(?:text|bytes)\\s*\\(`, "i"),
@@ -2234,6 +2450,26 @@ function expandBracedParameterExpression(
   const simple = expression.match(/^([A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*])$/);
   if (simple) {
     return variables.get(simple[1]) ?? match;
+  }
+
+  const caseModification = expression.match(
+    /^([A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*])([,]{1,2}|\^{1,2})$/
+  );
+  if (caseModification) {
+    const value = variables.get(caseModification[1]);
+    if (value === undefined) {
+      return match;
+    }
+    const operator = caseModification[2];
+    if (operator === ",,") {
+      return value.toLowerCase();
+    }
+    if (operator === "^^") {
+      return value.toUpperCase();
+    }
+    return operator === ","
+      ? `${value.slice(0, 1).toLowerCase()}${value.slice(1)}`
+      : `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
   }
 
   const prefixOrSuffixRemoval = expression.match(
@@ -2592,9 +2828,16 @@ function shellExpansionPattern(candidate: PathCandidate): string | undefined {
     changed = changed || withCommandSubstitutions !== pattern;
     pattern = withCommandSubstitutions;
 
-    const withParameterExpansions = pattern.replace(/\$\{[^}]+\}/g, "*");
-    changed = changed || withParameterExpansions !== pattern;
-    pattern = withParameterExpansions;
+    const withBracedParameterExpansions = pattern.replace(/\$\{[^}]+\}/g, "data/raw");
+    changed = changed || withBracedParameterExpansions !== pattern;
+    pattern = withBracedParameterExpansions;
+
+    const withUnbracedParameterExpansions = pattern.replace(
+      /\$([A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*])/g,
+      "data/raw"
+    );
+    changed = changed || withUnbracedParameterExpansions !== pattern;
+    pattern = withUnbracedParameterExpansions;
   }
 
   if (!candidate.quoted && /[*?\[]/.test(pattern)) {

--- a/packages/core/src/tools/data-raw-write-rule.ts
+++ b/packages/core/src/tools/data-raw-write-rule.ts
@@ -42,6 +42,8 @@ const SHELL_COMMANDS = new Set(["bash", "sh", "zsh"]);
 const FIND_MUTATION_ACTIONS = new Set(["-delete", "-exec", "-execdir", "-ok", "-okdir"]);
 const LOCAL_URL_SCHEME_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*:\/\//;
 const EXECUTABLE_CODE_STDIN_ARG = "-";
+const MAX_EXECUTABLE_CODE_SCAN_CHARS = 64 * 1024;
+const MAX_EXECUTABLE_RAW_TARGETS = 64;
 
 type ShellToken = {
   value: string;
@@ -66,11 +68,24 @@ type PathCandidate = {
 
 type PathEvaluationContext = {
   cwd?: string;
+  cwdKnown: boolean;
 };
 
 type ShellScanState = {
   variables: Map<string, string>;
   cwd?: string;
+  cwdKnown: boolean;
+  scanBudget: ShellScanBudget;
+};
+
+type ShellScanBudget = {
+  remainingExecutableCodeChars: number;
+  remainingExecutableRawTargets: number;
+};
+
+type SegmentCommandScanState = ShellScanState & {
+  commandIndex?: number;
+  uncertainWrapper: boolean;
 };
 
 export const DATA_RAW_WRITE_DENY_RULE: PolicyRule = {
@@ -127,7 +142,9 @@ export function findProtectedDataRawWriteTarget(
 ): string | undefined {
   return findProtectedDataRawWriteTargetWithState(command, {
     variables: new Map(initialVariables),
-    cwd: normalizeInitialCwd(workDir)
+    cwd: normalizeInitialCwd(workDir),
+    cwdKnown: true,
+    scanBudget: makeShellScanBudget()
   });
 }
 
@@ -145,8 +162,13 @@ function findProtectedDataRawWriteTargetWithState(
     return substitutionTarget;
   }
 
+  const groupedTarget = findGroupedCommandWriteTarget(command, state);
+  if (groupedTarget) {
+    return groupedTarget;
+  }
+
   const tokens = tokenizeShellCommand(command);
-  const pathContext = (): PathEvaluationContext => ({ cwd: state.cwd });
+  const pathContext = (): PathEvaluationContext => pathContextFromState(state);
 
   for (const segment of splitCommandSegments(tokens)) {
     const expandedSegment = expandSegmentParameterReferences(segment, state.variables);
@@ -157,8 +179,7 @@ function findProtectedDataRawWriteTargetWithState(
 
     const mutationTarget = findMutationCommandTarget(
       expandedSegment,
-      state.variables,
-      pathContext()
+      state
     );
     if (mutationTarget) {
       return mutationTarget;
@@ -166,6 +187,182 @@ function findProtectedDataRawWriteTargetWithState(
 
     updateCwdFromCdSegment(expandedSegment, state);
     recordVariableAssignments(expandedSegment, state.variables);
+  }
+
+  return undefined;
+}
+
+function findGroupedCommandWriteTarget(
+  command: string,
+  state: ShellScanState
+): string | undefined {
+  let quote: ShellQuote | undefined;
+  let index = 0;
+
+  while (index < command.length) {
+    const char = command[index];
+
+    if (quote) {
+      if (char === "\\" && quote.ansiC) {
+        index = readAnsiCEscape(command, index).nextIndex;
+        continue;
+      }
+      if (char === "\\" && quote.char === `"`) {
+        index += command[index + 1] === undefined ? 1 : 2;
+        continue;
+      }
+      if (char === quote.char) {
+        quote = undefined;
+      }
+      index += 1;
+      continue;
+    }
+
+    const quoteStart = readShellQuoteStart(command, index);
+    if (quoteStart) {
+      quote = quoteStart.quote;
+      index += quoteStart.length;
+      continue;
+    }
+
+    if (char === "\\") {
+      index += command[index + 1] === undefined ? 1 : 2;
+      continue;
+    }
+
+    if (char === "$" && command[index + 1] === "(") {
+      const substitution = readCommandSubstitution(command, index + 1);
+      if (!substitution) {
+        return undefined;
+      }
+      index = substitution.endIndex + 1;
+      continue;
+    }
+
+    if ((char === "<" || char === ">") && command[index + 1] === "(") {
+      const substitution = readCommandSubstitution(command, index + 1);
+      if (!substitution) {
+        return undefined;
+      }
+      index = substitution.endIndex + 1;
+      continue;
+    }
+
+    const group = readSimpleCommandGroup(command, index);
+    if (!group) {
+      index += 1;
+      continue;
+    }
+
+    const target = findProtectedDataRawWriteTargetWithState(group.body, {
+      variables: new Map(state.variables),
+      cwd: state.cwd,
+      cwdKnown: state.cwdKnown,
+      scanBudget: state.scanBudget
+    });
+    if (target) {
+      return target;
+    }
+    index = group.endIndex + 1;
+  }
+
+  return undefined;
+}
+
+function readSimpleCommandGroup(
+  command: string,
+  startIndex: number
+): { body: string; endIndex: number } | undefined {
+  const char = command[startIndex];
+  if (char === "(" && isShellGroupBoundary(command, startIndex - 1)) {
+    return readBalancedCommandGroup(command, startIndex, "(", ")");
+  }
+  if (
+    char === "{" &&
+    isShellGroupBoundary(command, startIndex - 1) &&
+    isShellGroupBoundary(command, startIndex + 1)
+  ) {
+    const group = readBalancedCommandGroup(command, startIndex, "{", "}");
+    return group ? { body: group.body.replace(/;?\s*$/, ""), endIndex: group.endIndex } : undefined;
+  }
+
+  return undefined;
+}
+
+function isShellGroupBoundary(command: string, index: number): boolean {
+  if (index < 0 || index >= command.length) {
+    return true;
+  }
+
+  return /\s|[;&|]/.test(command[index]);
+}
+
+function readBalancedCommandGroup(
+  command: string,
+  startIndex: number,
+  openChar: "(" | "{",
+  closeChar: ")" | "}"
+): { body: string; endIndex: number } | undefined {
+  let quote: ShellQuote | undefined;
+  let depth = 1;
+  let index = startIndex + 1;
+
+  while (index < command.length) {
+    const char = command[index];
+
+    if (quote) {
+      if (char === "\\" && quote.ansiC) {
+        index = readAnsiCEscape(command, index).nextIndex;
+        continue;
+      }
+      if (char === "\\" && quote.char === `"`) {
+        index += command[index + 1] === undefined ? 1 : 2;
+        continue;
+      }
+      if (char === quote.char) {
+        quote = undefined;
+      }
+      index += 1;
+      continue;
+    }
+
+    const quoteStart = readShellQuoteStart(command, index);
+    if (quoteStart) {
+      quote = quoteStart.quote;
+      index += quoteStart.length;
+      continue;
+    }
+
+    if (char === "\\") {
+      index += command[index + 1] === undefined ? 1 : 2;
+      continue;
+    }
+
+    if (char === "$" && command[index + 1] === "(") {
+      const substitution = readCommandSubstitution(command, index + 1);
+      if (!substitution) {
+        return undefined;
+      }
+      index = substitution.endIndex + 1;
+      continue;
+    }
+
+    if (char === openChar) {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+    if (char === closeChar) {
+      depth -= 1;
+      if (depth === 0) {
+        return {
+          body: command.slice(startIndex + 1, index).trim(),
+          endIndex: index
+        };
+      }
+    }
+
+    index += 1;
   }
 
   return undefined;
@@ -226,15 +423,18 @@ function isUnquotedOperatorToken(token: ShellToken, operators: ReadonlySet<strin
 
 function findMutationCommandTarget(
   segment: readonly ShellToken[],
-  variables: ReadonlyMap<string, string>,
-  context: PathEvaluationContext
+  state: ShellScanState
 ): string | undefined {
-  const wrapperUncertaintyTarget = findWrapperUncertaintyRawCandidate(segment, context);
-  if (wrapperUncertaintyTarget) {
-    return wrapperUncertaintyTarget;
+  const commandState = buildSegmentCommandScanState(segment, state);
+  const context = pathContextFromState(commandState);
+  if (commandState.uncertainWrapper) {
+    const wrapperUncertaintyTarget = findRawPathCandidate(segment, context);
+    if (wrapperUncertaintyTarget) {
+      return wrapperUncertaintyTarget;
+    }
   }
 
-  const commandIndex = findCommandTokenIndex(segment);
+  const { commandIndex } = commandState;
   if (commandIndex === undefined) {
     return undefined;
   }
@@ -242,13 +442,13 @@ function findMutationCommandTarget(
   const command = path.posix.basename(segment[commandIndex].value);
   const args = segment.slice(commandIndex + 1);
   if (command === "eval") {
-    const target = findEvalCommandTarget(args, variables, context);
+    const target = findEvalCommandTarget(args, commandState, context);
     if (target) {
       return target;
     }
   }
   if (isExecutableCodeStringCommand(command)) {
-    const target = findExecutableCodeStringRawMutationTarget(command, args, context);
+    const target = findExecutableCodeStringRawMutationTarget(command, args, commandState);
     if (target) {
       return target;
     }
@@ -331,8 +531,10 @@ function findMutationCommandTarget(
     const shellCommand = findShellCommandArgument(args);
     const target = shellCommand
       ? findProtectedDataRawWriteTargetWithState(shellCommand, {
-          variables: new Map(variables),
-          cwd: context.cwd
+          variables: new Map(commandState.variables),
+          cwd: commandState.cwd,
+          cwdKnown: commandState.cwdKnown,
+          scanBudget: commandState.scanBudget
         })
       : undefined;
     if (target) {
@@ -370,37 +572,149 @@ function findCommandTokenIndex(segment: readonly ShellToken[]): number | undefin
   return undefined;
 }
 
-function findWrapperUncertaintyRawCandidate(
+function buildSegmentCommandScanState(
   segment: readonly ShellToken[],
-  context: PathEvaluationContext
-): string | undefined {
-  const rawPathCandidate = findRawPathCandidate(segment, context);
-  if (!rawPathCandidate) {
-    return undefined;
-  }
+  state: ShellScanState
+): SegmentCommandScanState {
+  const commandState: SegmentCommandScanState = {
+    variables: new Map(state.variables),
+    cwd: state.cwd,
+    cwdKnown: state.cwdKnown,
+    scanBudget: state.scanBudget,
+    uncertainWrapper: false
+  };
 
   let index = 0;
   while (index < segment.length) {
     const token = segment[index];
     if (isAssignment(token)) {
+      recordVariableAssignment(token, commandState.variables);
       index += 1;
       continue;
     }
 
     const command = path.posix.basename(token.value);
     if (!WRAPPER_COMMANDS.has(command)) {
-      return undefined;
+      commandState.commandIndex = index;
+      return commandState;
     }
 
-    const parsedOptions = parseWrapperOptions(command, segment, index + 1);
-    if (parsedOptions.uncertain) {
-      return rawPathCandidate;
+    const parsedWrapper =
+      command === "env"
+        ? parseEnvWrapperForScan(segment, index + 1, commandState)
+        : parseGenericWrapperForScan(command, segment, index + 1);
+    commandState.uncertainWrapper =
+      commandState.uncertainWrapper || parsedWrapper.uncertain;
+    index = parsedWrapper.nextIndex;
+  }
+
+  return commandState;
+}
+
+function parseGenericWrapperForScan(
+  command: string,
+  segment: readonly ShellToken[],
+  startIndex: number
+): { nextIndex: number; uncertain: boolean } {
+  return parseWrapperOptions(command, segment, startIndex);
+}
+
+function parseEnvWrapperForScan(
+  segment: readonly ShellToken[],
+  startIndex: number,
+  state: SegmentCommandScanState
+): { nextIndex: number; uncertain: boolean } {
+  let index = startIndex;
+  let uncertain = false;
+
+  while (index < segment.length && segment[index].value.startsWith("-")) {
+    const option = segment[index].value;
+    if (option === "--") {
+      index += 1;
+      break;
     }
 
-    index = parsedOptions.nextIndex;
+    if (option === "-i" || option === "--ignore-environment") {
+      state.variables.clear();
+      index += 1;
+      continue;
+    }
+
+    const chdirTarget = envChdirOptionTarget(segment, index);
+    if (chdirTarget) {
+      applyCwdTargetToState(chdirTarget, state);
+      index = chdirTarget.nextIndex;
+      continue;
+    }
+
+    const unsetNextIndex = envUnsetOptionNextIndex(segment, index);
+    if (unsetNextIndex !== undefined) {
+      index = unsetNextIndex;
+      continue;
+    }
+
+    uncertain = true;
+    index += 1;
+  }
+
+  while (index < segment.length && isAssignment(segment[index])) {
+    recordVariableAssignment(segment[index], state.variables);
+    index += 1;
+  }
+
+  return { nextIndex: index, uncertain };
+}
+
+function envChdirOptionTarget(
+  segment: readonly ShellToken[],
+  index: number
+): { value: string; nextIndex: number } | undefined {
+  const option = segment[index].value;
+  if (option === "-C" || option === "--chdir") {
+    const target = segment[index + 1];
+    return target ? { value: target.value, nextIndex: index + 2 } : undefined;
+  }
+  if (option.startsWith("--chdir=")) {
+    return { value: option.slice("--chdir=".length), nextIndex: index + 1 };
+  }
+  if (option.startsWith("-C") && option.length > 2 && !option.startsWith("--")) {
+    return { value: option.slice(2), nextIndex: index + 1 };
   }
 
   return undefined;
+}
+
+function envUnsetOptionNextIndex(
+  segment: readonly ShellToken[],
+  index: number
+): number | undefined {
+  const option = segment[index].value;
+  if (option === "-u" || option === "--unset") {
+    return Math.min(index + 2, segment.length);
+  }
+  if (option.startsWith("--unset=")) {
+    return index + 1;
+  }
+  if (option.startsWith("-u") && option.length > 2 && !option.startsWith("--")) {
+    return index + 1;
+  }
+
+  return undefined;
+}
+
+function applyCwdTargetToState(
+  target: { value: string },
+  state: Pick<ShellScanState, "cwd" | "cwdKnown">
+): void {
+  if (!isSimpleLiteralPathValue(target.value)) {
+    state.cwd = undefined;
+    state.cwdKnown = false;
+    return;
+  }
+
+  const resolvedCwd = resolveShellPathWithKnowledge(state.cwd, state.cwdKnown, target.value);
+  state.cwd = resolvedCwd.cwd;
+  state.cwdKnown = resolvedCwd.cwdKnown;
 }
 
 function parseWrapperOptions(
@@ -545,8 +859,26 @@ function isReadOnlySafeRawPathCommand(
   if (command === "wget") {
     return findWgetOutputTarget(args, context) === undefined;
   }
+  if (command === "cd") {
+    return true;
+  }
+  if (command === "awk") {
+    return isReadOnlyAwkCommand(args);
+  }
+  if (command === "rsync") {
+    return isCopyOutOfRawCommand(args, context);
+  }
 
   return command === "cp" && isCopyOutOfRawCommand(args, context);
+}
+
+function isReadOnlyAwkCommand(args: readonly ShellToken[]): boolean {
+  return !args.some((arg) => {
+    if (!arg.fullyQuoted && (arg.value === ">" || arg.value === ">>")) {
+      return true;
+    }
+    return /(^|[^A-Za-z_])(?:system|close)\s*\(|>{1,2}/.test(arg.value);
+  });
 }
 
 function isCopyOutOfRawCommand(
@@ -634,6 +966,7 @@ function findCurlOutputTarget(
   args: readonly ShellToken[],
   context: PathEvaluationContext
 ): string | undefined {
+  let usesRemoteNameOutput = false;
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index].value;
     if (arg === "-o" || arg === "--output") {
@@ -651,13 +984,25 @@ function findCurlOutputTarget(
       continue;
     }
 
+    if (isCurlRemoteNameOption(arg)) {
+      usesRemoteNameOutput = true;
+    }
+
     const shortOptionTarget = findCurlShortOutputTarget(args, index, context);
     if (shortOptionTarget) {
       return shortOptionTarget;
     }
   }
 
-  return undefined;
+  return usesRemoteNameOutput ? protectedCurrentWorkingDirectoryTarget(context) : undefined;
+}
+
+function isCurlRemoteNameOption(arg: string): boolean {
+  return (
+    arg === "-O" ||
+    arg === "--remote-name" ||
+    (!arg.startsWith("--") && arg.startsWith("-") && arg.slice(1).includes("O"))
+  );
 }
 
 function findCurlShortOutputTarget(
@@ -722,12 +1067,20 @@ function findGitCloneTarget(
     .slice(cloneIndex + 1)
     .filter((arg) => !arg.value.startsWith("-"));
   if (positionalArgs.length < 2) {
-    return undefined;
+    return positionalArgs.length === 1 ? protectedCurrentWorkingDirectoryTarget(context) : undefined;
   }
 
   const destination = positionalArgs.at(-1);
   return destination && isProtectedDataRawCandidate(destination, context)
     ? destination.value
+    : undefined;
+}
+
+function protectedCurrentWorkingDirectoryTarget(
+  context: PathEvaluationContext
+): string | undefined {
+  return context.cwdKnown && context.cwd && isProtectedDataRawPathVariant(context.cwd)
+    ? context.cwd
     : undefined;
 }
 
@@ -748,7 +1101,7 @@ function findTarExtractionTarget(
     return targetDirectory.value;
   }
 
-  return undefined;
+  return targetDirectory ? undefined : protectedCurrentWorkingDirectoryTarget(context);
 }
 
 function isTarExtractCommand(args: readonly ShellToken[]): boolean {
@@ -780,9 +1133,12 @@ function findWgetOutputTarget(
   args: readonly ShellToken[],
   context: PathEvaluationContext
 ): string | undefined {
+  let hasExplicitOutputTarget = false;
+  let hasExplicitDirectoryPrefix = false;
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg.value === "-O" || arg.value === "--output-document") {
+      hasExplicitOutputTarget = true;
       const target = args[index + 1];
       if (target && isProtectedDataRawCandidate(target, context)) {
         return target.value;
@@ -790,6 +1146,7 @@ function findWgetOutputTarget(
       continue;
     }
     if (arg.value.startsWith("--output-document=")) {
+      hasExplicitOutputTarget = true;
       const target = pathCandidateFromToken(
         arg,
         arg.value.slice("--output-document=".length)
@@ -800,11 +1157,16 @@ function findWgetOutputTarget(
       continue;
     }
     if (arg.value.startsWith("-O") && !arg.value.startsWith("--") && arg.value.length > 2) {
+      hasExplicitOutputTarget = true;
       const target = pathCandidateFromToken(arg, arg.value.slice("-O".length));
       if (isProtectedDataRawCandidate(target, context)) {
         return target.value;
       }
       continue;
+    }
+
+    if (isWgetDirectoryPrefixOption(arg.value)) {
+      hasExplicitDirectoryPrefix = true;
     }
 
     const targetDirectory = findWgetDirectoryPrefixTarget(args, index, context);
@@ -813,7 +1175,22 @@ function findWgetOutputTarget(
     }
   }
 
-  return undefined;
+  return !hasExplicitOutputTarget && !hasExplicitDirectoryPrefix && hasPositionalArgument(args)
+    ? protectedCurrentWorkingDirectoryTarget(context)
+    : undefined;
+}
+
+function isWgetDirectoryPrefixOption(arg: string): boolean {
+  return (
+    arg === "-P" ||
+    arg === "--directory-prefix" ||
+    arg.startsWith("--directory-prefix=") ||
+    (arg.startsWith("-P") && !arg.startsWith("--") && arg.length > 2)
+  );
+}
+
+function hasPositionalArgument(args: readonly ShellToken[]): boolean {
+  return args.some((arg) => !arg.value.startsWith("-"));
 }
 
 function findWgetDirectoryPrefixTarget(
@@ -885,14 +1262,16 @@ function findOptionValueAt(
 
 function findEvalCommandTarget(
   args: readonly ShellToken[],
-  variables: ReadonlyMap<string, string>,
+  state: ShellScanState,
   context: PathEvaluationContext
 ): string | undefined {
   const command = args.map((arg) => arg.value).join(" ").trim();
   return command
     ? findProtectedDataRawWriteTargetWithState(command, {
-        variables: new Map(variables),
-        cwd: context.cwd
+        variables: new Map(state.variables),
+        cwd: context.cwd,
+        cwdKnown: context.cwdKnown,
+        scanBudget: state.scanBudget
       })
     : undefined;
 }
@@ -916,9 +1295,10 @@ function isExecutableCodeStringCommand(command: string): boolean {
 function findExecutableCodeStringRawMutationTarget(
   command: string,
   args: readonly ShellToken[],
-  context: PathEvaluationContext
+  state: ShellScanState
 ): string | undefined {
-  const denoEvalTarget = findDenoEvalRawMutationTarget(command, args, context);
+  const context = pathContextFromState(state);
+  const denoEvalTarget = findDenoEvalRawMutationTarget(command, args, state);
   if (denoEvalTarget) {
     return denoEvalTarget;
   }
@@ -929,7 +1309,11 @@ function findExecutableCodeStringRawMutationTarget(
       continue;
     }
 
-    const target = findExecutableCodeRawMutationTargetInText(codeString, context);
+    const target = findExecutableCodeRawMutationTargetInText(
+      codeString,
+      context,
+      state.scanBudget
+    );
     if (target) {
       return target;
     }
@@ -941,14 +1325,20 @@ function findExecutableCodeStringRawMutationTarget(
 function findDenoEvalRawMutationTarget(
   command: string,
   args: readonly ShellToken[],
-  context: PathEvaluationContext
+  state: ShellScanState
 ): string | undefined {
   if (command.toLowerCase() !== "deno" || args[0]?.value !== "eval") {
     return undefined;
   }
 
   const codeString = args.find((arg, index) => index > 0 && !arg.value.startsWith("-"))?.value;
-  return codeString ? findExecutableCodeRawMutationTargetInText(codeString, context) : undefined;
+  return codeString
+    ? findExecutableCodeRawMutationTargetInText(
+        codeString,
+        pathContextFromState(state),
+        state.scanBudget
+      )
+    : undefined;
 }
 
 function findExecutableCodeStringAt(
@@ -1082,7 +1472,8 @@ function findExecutableStdinRawWriteTarget(
   }
 
   const expandedSegment = expandSegmentParameterReferences(segment, state.variables);
-  const commandIndex = findCommandTokenIndex(expandedSegment);
+  const commandState = buildSegmentCommandScanState(expandedSegment, state);
+  const { commandIndex } = commandState;
   if (commandIndex === undefined) {
     return undefined;
   }
@@ -1091,8 +1482,10 @@ function findExecutableStdinRawWriteTarget(
   const args = expandedSegment.slice(commandIndex + 1);
   if (SHELL_COMMANDS.has(command)) {
     return findProtectedDataRawWriteTargetWithState(body, {
-      variables: new Map(state.variables),
-      cwd: state.cwd
+      variables: new Map(commandState.variables),
+      cwd: commandState.cwd,
+      cwdKnown: commandState.cwdKnown,
+      scanBudget: commandState.scanBudget
     });
   }
 
@@ -1100,7 +1493,11 @@ function findExecutableStdinRawWriteTarget(
     return undefined;
   }
 
-  return findExecutableCodeRawMutationTargetInText(body, { cwd: state.cwd });
+  return findExecutableCodeRawMutationTargetInText(
+    body,
+    pathContextFromState(commandState),
+    commandState.scanBudget
+  );
 }
 
 function receivesExecutableCodeFromStdin(args: readonly ShellToken[]): boolean {
@@ -1109,7 +1506,8 @@ function receivesExecutableCodeFromStdin(args: readonly ShellToken[]): boolean {
 }
 
 function updateCwdFromCdSegment(segment: readonly ShellToken[], state: ShellScanState): void {
-  const commandIndex = findCommandTokenIndex(segment);
+  const commandState = buildSegmentCommandScanState(segment, state);
+  const { commandIndex } = commandState;
   if (commandIndex === undefined) {
     return;
   }
@@ -1121,32 +1519,72 @@ function updateCwdFromCdSegment(segment: readonly ShellToken[], state: ShellScan
 
   const target = segment.slice(commandIndex + 1).find((arg) => !arg.value.startsWith("-"));
   if (!target || target.value === "-" || !isSimpleLiteralCdTarget(target)) {
+    state.cwd = undefined;
+    state.cwdKnown = false;
     return;
   }
 
-  state.cwd = resolveShellPath(state.cwd, target.value);
+  applyCwdTargetToState(target, state);
 }
 
 function isSimpleLiteralCdTarget(target: ShellToken): boolean {
-  return !/[`$*?\[\]{}]/.test(target.value);
+  return isSimpleLiteralPathValue(target.value);
 }
 
-function resolveShellPath(cwd: string | undefined, target: string): string {
+function isSimpleLiteralPathValue(value: string): boolean {
+  return !/[`$*?\[\]{}]/.test(value);
+}
+
+function resolveShellPathWithKnowledge(
+  cwd: string | undefined,
+  cwdKnown: boolean,
+  target: string
+): { cwd?: string; cwdKnown: boolean } {
   if (path.isAbsolute(target) || path.posix.isAbsolute(target)) {
-    return path.resolve(target);
+    return { cwd: path.resolve(target), cwdKnown: true };
   }
-  return path.resolve(cwd ?? process.cwd(), target);
+  if (!cwdKnown || !cwd) {
+    return { cwd: undefined, cwdKnown: false };
+  }
+
+  return { cwd: path.resolve(cwd, target), cwdKnown: true };
 }
 
-function normalizeInitialCwd(workDir: string | undefined): string | undefined {
-  return workDir ? path.resolve(workDir) : undefined;
+function normalizeInitialCwd(workDir: string | undefined): string {
+  return path.resolve(workDir ?? process.cwd());
+}
+
+function pathContextFromState(state: Pick<ShellScanState, "cwd" | "cwdKnown">): PathEvaluationContext {
+  return {
+    cwd: state.cwd,
+    cwdKnown: state.cwdKnown
+  };
+}
+
+function makeShellScanBudget(): ShellScanBudget {
+  return {
+    remainingExecutableCodeChars: MAX_EXECUTABLE_CODE_SCAN_CHARS,
+    remainingExecutableRawTargets: MAX_EXECUTABLE_RAW_TARGETS
+  };
 }
 
 function findExecutableCodeRawMutationTargetInText(
   value: string,
-  context: PathEvaluationContext
+  context: PathEvaluationContext,
+  scanBudget: ShellScanBudget
 ): string | undefined {
-  for (const target of findProtectedRawPathsInText(value, context)) {
+  if (!reserveExecutableCodeScanBudget(value, scanBudget)) {
+    return hasProtectedRawPathText(value) && hasExecutableCodeWriteIntentMarker(value)
+      ? "data/raw"
+      : undefined;
+  }
+
+  const scanResult = findProtectedRawPathsInText(value, context, scanBudget);
+  if (scanResult.exceeded && hasExecutableCodeWriteIntentMarker(value)) {
+    return scanResult.targets[0] ?? "data/raw";
+  }
+
+  for (const target of scanResult.targets) {
     if (hasExecutableCodeWriteIntentForRawPath(value, target)) {
       return target;
     }
@@ -1157,27 +1595,60 @@ function findExecutableCodeRawMutationTargetInText(
 
 function findProtectedRawPathsInText(
   value: string,
-  context: PathEvaluationContext
-): string[] {
+  context: PathEvaluationContext,
+  scanBudget: ShellScanBudget
+): { targets: string[]; exceeded: boolean } {
   const targets: string[] = [];
-  const rawPathPattern = /(?:file:\/\/)?[A-Za-z0-9_./@%:+-]*data\/raw(?:\/[A-Za-z0-9_./@%:+-]*)?/g;
-  for (const match of value.matchAll(rawPathPattern)) {
+  const rawPathPattern = /(?:file:\/\/)?[A-Za-z0-9_./@%:+-]*data\/raw(?:\/[A-Za-z0-9_./@%:+-]*)?/gi;
+  let match: RegExpExecArray | null;
+  while ((match = rawPathPattern.exec(value)) !== null) {
+    if (scanBudget.remainingExecutableRawTargets <= 0) {
+      return { targets, exceeded: true };
+    }
+
     const candidate = match[0];
     if (isProtectedDataRawPath(candidate, context)) {
       targets.push(candidate);
+      scanBudget.remainingExecutableRawTargets -= 1;
       continue;
     }
 
-    const rawPathIndex = candidate.indexOf("data/raw");
+    const rawPathIndex = candidate.toLowerCase().indexOf("data/raw");
     if (rawPathIndex !== -1) {
       const relativeCandidate = candidate.slice(rawPathIndex);
       if (isProtectedDataRawPath(relativeCandidate, context)) {
         targets.push(relativeCandidate);
+        scanBudget.remainingExecutableRawTargets -= 1;
       }
     }
   }
 
-  return targets;
+  return { targets, exceeded: false };
+}
+
+function reserveExecutableCodeScanBudget(
+  value: string,
+  scanBudget: ShellScanBudget
+): boolean {
+  if (value.length > scanBudget.remainingExecutableCodeChars) {
+    scanBudget.remainingExecutableCodeChars = 0;
+    return false;
+  }
+
+  scanBudget.remainingExecutableCodeChars -= value.length;
+  return true;
+}
+
+function hasProtectedRawPathText(value: string): boolean {
+  return value.toLowerCase().includes("data/raw");
+}
+
+function hasExecutableCodeWriteIntentMarker(value: string): boolean {
+  return (
+    /\b(?:open|writeFile|writeFileSync|appendFile|appendFileSync|createWriteStream|unlink|unlinkSync|rm|rmSync|remove|removeSync|rename|renameSync|mkdir|mkdirSync|rmdir|rmdirSync|truncate|truncateSync|writeLines|write\.csv|write\.table|saveRDS|save)\s*\(/i.test(
+      value
+    ) || /\.write_(?:text|bytes)\s*\(/i.test(value)
+  );
 }
 
 function hasExecutableCodeWriteIntentForRawPath(value: string, target: string): boolean {
@@ -1188,6 +1659,7 @@ function hasExecutableCodeWriteIntentForRawPath(value: string, target: string): 
     new RegExp(`\\bopen\\s*\\(${codeBeforeRawCloseParen},\\s*["'][^"']*[wax+][^"']*["']`, "i"),
     new RegExp(`\\b(?:writeFile|writeFileSync|appendFile|appendFileSync|createWriteStream)\\s*\\(${codeBeforeRawCloseParen}`, "i"),
     new RegExp(`\\b(?:unlink|unlinkSync|rm|rmSync|remove|removeSync|rename|renameSync|mkdir|mkdirSync|rmdir|rmdirSync|truncate|truncateSync)\\s*\\(${codeBeforeRawCloseParen}`, "i"),
+    new RegExp(`\\b(?:writeLines|write\\.csv|write\\.table|saveRDS|save)\\s*\\([\\s\\S]{0,1024}${escapedTarget}`, "i"),
     new RegExp(`\\bPath\\s*\\(${codeBeforeRawCloseParen}\\)\\.write_(?:text|bytes)\\s*\\(`, "i"),
     new RegExp(`${escapedTarget}[^\\n;)]*\\.write_(?:text|bytes)\\s*\\(`, "i")
   ].some((pattern) => pattern.test(value));
@@ -1302,7 +1774,7 @@ function isProtectedDataRawCandidate(
 
 function isProtectedDataRawPath(
   candidate: string,
-  context: PathEvaluationContext = {}
+  context: PathEvaluationContext = { cwdKnown: false }
 ): boolean {
   return candidatePathVariants(candidate, context).some((variant) =>
     isProtectedDataRawPathVariant(variant)
@@ -1328,6 +1800,10 @@ function candidatePathVariants(
   const localCandidate = normalizeLocalPathCandidate(candidate);
   if (!localCandidate) {
     return [];
+  }
+
+  if (context.cwdKnown && context.cwd && isRelativeLocalPath(localCandidate)) {
+    return [path.resolve(context.cwd, localCandidate)];
   }
 
   const variants = [localCandidate];
@@ -1361,8 +1837,13 @@ function findAdjacentSegmentIndex(
   first: string,
   second: string
 ): number {
+  const normalizedFirst = first.toLowerCase();
+  const normalizedSecond = second.toLowerCase();
   for (let index = 0; index < segments.length - 1; index += 1) {
-    if (segments[index] === first && segments[index + 1] === second) {
+    if (
+      segments[index].toLowerCase() === normalizedFirst &&
+      segments[index + 1].toLowerCase() === normalizedSecond
+    ) {
       return index;
     }
   }
@@ -1480,7 +1961,7 @@ function shellPathPatternCanMatchProtectedRaw(pattern: string): boolean {
 
 function shellSegmentPatternCanMatchLiteral(pattern: string, literal: string): boolean {
   const regex = globSegmentPatternToRegex(pattern);
-  return regex ? regex.test(literal) : pattern === literal;
+  return regex ? regex.test(literal) : pattern.toLowerCase() === literal.toLowerCase();
 }
 
 function globSegmentPatternToRegex(pattern: string): RegExp | undefined {
@@ -1500,9 +1981,9 @@ function globSegmentPatternToRegex(pattern: string): RegExp | undefined {
       continue;
     }
     if (char === "[") {
-      const closeIndex = pattern.indexOf("]", index + 1);
+      const closeIndex = findGlobBracketExpressionEnd(pattern, index);
       if (closeIndex !== -1) {
-        source += pattern.slice(index, closeIndex + 1);
+        source += globBracketExpressionToRegexSource(pattern.slice(index, closeIndex + 1));
         index = closeIndex;
         changed = true;
         continue;
@@ -1511,7 +1992,35 @@ function globSegmentPatternToRegex(pattern: string): RegExp | undefined {
     source += escapeRegExp(char);
   }
 
-  return changed ? new RegExp(`^${source}$`) : undefined;
+  return changed ? new RegExp(`^${source}$`, "i") : undefined;
+}
+
+function findGlobBracketExpressionEnd(pattern: string, openIndex: number): number {
+  if (pattern.startsWith("[[:", openIndex)) {
+    const posixClassEnd = pattern.indexOf(":]]", openIndex + 3);
+    return posixClassEnd === -1 ? -1 : posixClassEnd + 2;
+  }
+
+  return pattern.indexOf("]", openIndex + 1);
+}
+
+function globBracketExpressionToRegexSource(expression: string): string {
+  const posixClass = expression.match(/^\[\[:([A-Za-z]+):\]\]$/);
+  if (!posixClass) {
+    return expression;
+  }
+
+  const className = posixClass[1].toLowerCase();
+  const translatedClasses: Record<string, string> = {
+    alnum: "[A-Za-z0-9]",
+    alpha: "[A-Za-z]",
+    digit: "[0-9]",
+    lower: "[a-z]",
+    upper: "[A-Z]",
+    xdigit: "[A-Fa-f0-9]"
+  };
+
+  return translatedClasses[className] ?? ".";
 }
 
 function escapeRegExp(value: string): string {
@@ -1821,7 +2330,9 @@ function findCommandSubstitutionWriteTarget(
 
       const target = findProtectedDataRawWriteTargetWithState(substitution.content, {
         variables: new Map(state.variables),
-        cwd: state.cwd
+        cwd: state.cwd,
+        cwdKnown: state.cwdKnown,
+        scanBudget: state.scanBudget
       });
       if (target) {
         return target;
@@ -1838,7 +2349,9 @@ function findCommandSubstitutionWriteTarget(
 
       const target = findProtectedDataRawWriteTargetWithState(substitution.content, {
         variables: new Map(state.variables),
-        cwd: state.cwd
+        cwd: state.cwd,
+        cwdKnown: state.cwdKnown,
+        scanBudget: state.scanBudget
       });
       if (target) {
         return target;
@@ -1855,7 +2368,9 @@ function findCommandSubstitutionWriteTarget(
 
       const target = findProtectedDataRawWriteTargetWithState(substitution.content, {
         variables: new Map(state.variables),
-        cwd: state.cwd
+        cwd: state.cwd,
+        cwdKnown: state.cwdKnown,
+        scanBudget: state.scanBudget
       });
       if (target) {
         return target;

--- a/packages/core/src/tools/data-raw-write-rule.ts
+++ b/packages/core/src/tools/data-raw-write-rule.ts
@@ -21,7 +21,17 @@ const ANY_RAW_PATH_MUTATION_COMMANDS = new Set([
 const DESTINATION_RAW_PATH_COMMANDS = new Set(["cp", "install", "ln"]);
 const ANY_ENDPOINT_RAW_PATH_COMMANDS = new Set(["mv"]);
 const WRAPPER_COMMANDS = new Set(["command", "doas", "env", "nice", "nohup", "sudo", "time"]);
+const WRAPPER_OPTIONS_WITH_OPERANDS = new Map<string, ReadonlySet<string>>([
+  ["env", new Set(["-u", "--unset"])],
+  ["nice", new Set(["-n", "--adjustment"])]
+]);
 const SHELL_COMMANDS = new Set(["bash", "sh", "zsh"]);
+
+type ShellToken = {
+  value: string;
+  fromOperator: boolean;
+  quoted: boolean;
+};
 
 export const DATA_RAW_WRITE_DENY_RULE: PolicyRule = {
   ruleId: DATA_RAW_WRITE_DENY_RULE_ID,
@@ -71,6 +81,11 @@ export function extractBashCommand(input: unknown): string | undefined {
 }
 
 export function findProtectedDataRawWriteTarget(command: string): string | undefined {
+  const substitutionTarget = findCommandSubstitutionWriteTarget(command);
+  if (substitutionTarget) {
+    return substitutionTarget;
+  }
+
   const tokens = tokenizeShellCommand(command);
   const redirectTarget = findRedirectWriteTarget(tokens);
   if (redirectTarget) {
@@ -95,14 +110,14 @@ export function makeDataRawPolicyGateContext() {
 
 export type DataRawWritePolicyCall = PolicyGateToolCall;
 
-function findRedirectWriteTarget(tokens: readonly string[]): string | undefined {
+function findRedirectWriteTarget(tokens: readonly ShellToken[]): string | undefined {
   for (let index = 0; index < tokens.length; index += 1) {
     const token = tokens[index];
-    if (!REDIRECT_WRITE_OPERATORS.has(token)) {
+    if (!isUnquotedOperatorToken(token, REDIRECT_WRITE_OPERATORS)) {
       continue;
     }
 
-    const target = tokens[index + 1];
+    const target = tokens[index + 1]?.value;
     if (target && isProtectedDataRawPath(target)) {
       return target;
     }
@@ -111,12 +126,12 @@ function findRedirectWriteTarget(tokens: readonly string[]): string | undefined 
   return undefined;
 }
 
-function splitCommandSegments(tokens: readonly string[]): string[][] {
-  const segments: string[][] = [];
-  let current: string[] = [];
+function splitCommandSegments(tokens: readonly ShellToken[]): ShellToken[][] {
+  const segments: ShellToken[][] = [];
+  let current: ShellToken[] = [];
 
   for (const token of tokens) {
-    if (SEGMENT_SEPARATORS.has(token)) {
+    if (isUnquotedOperatorToken(token, SEGMENT_SEPARATORS)) {
       if (current.length > 0) {
         segments.push(current);
         current = [];
@@ -133,31 +148,39 @@ function splitCommandSegments(tokens: readonly string[]): string[][] {
   return segments;
 }
 
-function findMutationCommandTarget(segment: readonly string[]): string | undefined {
+function isUnquotedOperatorToken(token: ShellToken, operators: ReadonlySet<string>): boolean {
+  return token.fromOperator && !token.quoted && operators.has(token.value);
+}
+
+function findMutationCommandTarget(segment: readonly ShellToken[]): string | undefined {
   const commandIndex = findCommandTokenIndex(segment);
   if (commandIndex === undefined) {
     return undefined;
   }
 
-  const command = path.posix.basename(segment[commandIndex]);
+  const command = path.posix.basename(segment[commandIndex].value);
   const args = segment.slice(commandIndex + 1);
   if (ANY_RAW_PATH_MUTATION_COMMANDS.has(command)) {
-    return args.find(isProtectedDataRawPath);
+    return findRawPathArgument(args);
   }
   if (DESTINATION_RAW_PATH_COMMANDS.has(command)) {
     return findDestinationRawPathTarget(args);
   }
   if (ANY_ENDPOINT_RAW_PATH_COMMANDS.has(command)) {
-    return args.find(isProtectedDataRawPath);
+    return findRawPathArgument(args);
   }
   if (command === "dd") {
     return findDdOutputTarget(args);
   }
   if (command === "tee") {
-    return args.find((arg) => !arg.startsWith("-") && isProtectedDataRawPath(arg));
+    return args.find((arg) => !arg.value.startsWith("-") && isProtectedDataRawPath(arg.value))
+      ?.value;
   }
-  if (command === "sed" && args.some((arg) => arg === "-i" || arg.startsWith("-i"))) {
-    return args.find(isProtectedDataRawPath);
+  if (command === "sed" && args.some((arg) => arg.value === "-i" || arg.value.startsWith("-i"))) {
+    return findRawPathArgument(args);
+  }
+  if (command === "curl") {
+    return findCurlOutputTarget(args);
   }
   if (SHELL_COMMANDS.has(command)) {
     const shellCommand = findShellCommandArgument(args);
@@ -167,7 +190,7 @@ function findMutationCommandTarget(segment: readonly string[]): string | undefin
   return undefined;
 }
 
-function findCommandTokenIndex(segment: readonly string[]): number | undefined {
+function findCommandTokenIndex(segment: readonly ShellToken[]): number | undefined {
   let index = 0;
   while (index < segment.length) {
     const token = segment[index];
@@ -176,11 +199,15 @@ function findCommandTokenIndex(segment: readonly string[]): number | undefined {
       continue;
     }
 
-    const command = path.posix.basename(token);
+    const command = path.posix.basename(token.value);
     if (WRAPPER_COMMANDS.has(command)) {
       index += 1;
-      while (index < segment.length && segment[index].startsWith("-")) {
+      while (index < segment.length && segment[index].value.startsWith("-")) {
+        const option = segment[index].value;
         index += 1;
+        if (wrapperOptionConsumesOperand(command, option) && index < segment.length) {
+          index += 1;
+        }
       }
       continue;
     }
@@ -191,12 +218,20 @@ function findCommandTokenIndex(segment: readonly string[]): number | undefined {
   return undefined;
 }
 
-function lastNonOptionArgument(args: readonly string[]): string | undefined {
-  const target = args.filter((arg) => !arg.startsWith("-")).at(-1);
+function wrapperOptionConsumesOperand(command: string, option: string): boolean {
+  return WRAPPER_OPTIONS_WITH_OPERANDS.get(command)?.has(option) ?? false;
+}
+
+function findRawPathArgument(args: readonly ShellToken[]): string | undefined {
+  return args.find((arg) => isProtectedDataRawPath(arg.value))?.value;
+}
+
+function lastNonOptionArgument(args: readonly ShellToken[]): string | undefined {
+  const target = args.filter((arg) => !arg.value.startsWith("-")).at(-1)?.value;
   return target && isProtectedDataRawPath(target) ? target : undefined;
 }
 
-function findDestinationRawPathTarget(args: readonly string[]): string | undefined {
+function findDestinationRawPathTarget(args: readonly ShellToken[]): string | undefined {
   const targetDirectory = findTargetDirectoryArgument(args);
   if (targetDirectory !== undefined) {
     return isProtectedDataRawPath(targetDirectory) ? targetDirectory : undefined;
@@ -205,11 +240,11 @@ function findDestinationRawPathTarget(args: readonly string[]): string | undefin
   return lastNonOptionArgument(args);
 }
 
-function findTargetDirectoryArgument(args: readonly string[]): string | undefined {
+function findTargetDirectoryArgument(args: readonly ShellToken[]): string | undefined {
   for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
+    const arg = args[index].value;
     if (arg === "-t" || arg === "--target-directory") {
-      return args[index + 1] ?? "";
+      return args[index + 1]?.value ?? "";
     }
     if (arg.startsWith("--target-directory=")) {
       return arg.slice("--target-directory=".length);
@@ -222,13 +257,13 @@ function findTargetDirectoryArgument(args: readonly string[]): string | undefine
   return undefined;
 }
 
-function findDdOutputTarget(args: readonly string[]): string | undefined {
+function findDdOutputTarget(args: readonly ShellToken[]): string | undefined {
   for (const arg of args) {
-    if (!arg.startsWith("of=")) {
+    if (!arg.value.startsWith("of=")) {
       continue;
     }
 
-    const target = arg.slice("of=".length);
+    const target = arg.value.slice("of=".length);
     if (isProtectedDataRawPath(target)) {
       return target;
     }
@@ -237,25 +272,72 @@ function findDdOutputTarget(args: readonly string[]): string | undefined {
   return undefined;
 }
 
-function findShellCommandArgument(args: readonly string[]): string | undefined {
+function findCurlOutputTarget(args: readonly ShellToken[]): string | undefined {
   for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (arg === "--") {
+    const arg = args[index].value;
+    if (arg === "-o" || arg === "--output") {
+      const target = args[index + 1]?.value;
+      if (target && isProtectedDataRawPath(target)) {
+        return target;
+      }
       continue;
     }
-    if (arg === "-c") {
-      return args[index + 1];
+    if (arg.startsWith("--output=")) {
+      const target = arg.slice("--output=".length);
+      if (isProtectedDataRawPath(target)) {
+        return target;
+      }
+      continue;
     }
-    if (arg.startsWith("-") && !arg.startsWith("--") && arg.includes("c")) {
-      return args[index + 1];
+
+    const shortOptionTarget = findCurlShortOutputTarget(args, index);
+    if (shortOptionTarget) {
+      return shortOptionTarget;
     }
   }
 
   return undefined;
 }
 
-function isAssignment(token: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
+function findCurlShortOutputTarget(
+  args: readonly ShellToken[],
+  index: number
+): string | undefined {
+  const arg = args[index].value;
+  if (!arg.startsWith("-") || arg.startsWith("--") || arg.length < 3) {
+    return undefined;
+  }
+
+  const optionCluster = arg.slice(1);
+  const outputOptionIndex = optionCluster.indexOf("o");
+  if (outputOptionIndex === -1) {
+    return undefined;
+  }
+
+  const attachedTarget = optionCluster.slice(outputOptionIndex + 1);
+  const target = attachedTarget.length > 0 ? attachedTarget : args[index + 1]?.value;
+  return target && isProtectedDataRawPath(target) ? target : undefined;
+}
+
+function findShellCommandArgument(args: readonly ShellToken[]): string | undefined {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index].value;
+    if (arg === "--") {
+      continue;
+    }
+    if (arg === "-c") {
+      return args[index + 1]?.value;
+    }
+    if (arg.startsWith("-") && !arg.startsWith("--") && arg.includes("c")) {
+      return args[index + 1]?.value;
+    }
+  }
+
+  return undefined;
+}
+
+function isAssignment(token: ShellToken): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token.value);
 }
 
 function isProtectedDataRawPath(candidate: string): boolean {
@@ -269,16 +351,18 @@ function isProtectedDataRawPath(candidate: string): boolean {
   );
 }
 
-function tokenizeShellCommand(command: string): string[] {
-  const tokens: string[] = [];
+function tokenizeShellCommand(command: string): ShellToken[] {
+  const tokens: ShellToken[] = [];
   let current = "";
+  let currentQuoted = false;
   let quote: "'" | '"' | undefined;
   let index = 0;
 
   const flush = () => {
     if (current.length > 0) {
-      tokens.push(current);
+      tokens.push({ value: current, fromOperator: false, quoted: currentQuoted });
       current = "";
+      currentQuoted = false;
     }
   };
 
@@ -306,13 +390,14 @@ function tokenizeShellCommand(command: string): string[] {
 
     if (char === "'" || char === `"`) {
       quote = char;
+      currentQuoted = true;
       index += 1;
       continue;
     }
 
     if (char === "\n" || char === "\r") {
       flush();
-      tokens.push(";");
+      tokens.push({ value: ";", fromOperator: true, quoted: false });
       index += 1;
       continue;
     }
@@ -326,7 +411,7 @@ function tokenizeShellCommand(command: string): string[] {
     const operator = readShellOperator(command, index);
     if (operator) {
       flush();
-      tokens.push(operator);
+      tokens.push({ value: operator, fromOperator: true, quoted: false });
       index += operator.length;
       continue;
     }
@@ -346,6 +431,157 @@ function tokenizeShellCommand(command: string): string[] {
 
   flush();
   return tokens;
+}
+
+function findCommandSubstitutionWriteTarget(command: string): string | undefined {
+  let quote: "'" | '"' | undefined;
+  let index = 0;
+
+  while (index < command.length) {
+    const char = command[index];
+
+    if (char === "\\") {
+      index += 2;
+      continue;
+    }
+
+    if (quote === "'") {
+      if (char === "'") {
+        quote = undefined;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (char === "'" && !quote) {
+      quote = "'";
+      index += 1;
+      continue;
+    }
+
+    if (char === `"`) {
+      quote = quote === `"` ? undefined : `"`;
+      index += 1;
+      continue;
+    }
+
+    if (char === "$" && command[index + 1] === "(") {
+      const substitution = readCommandSubstitution(command, index + 1);
+      if (!substitution) {
+        return undefined;
+      }
+
+      const target = findProtectedDataRawWriteTarget(substitution.content);
+      if (target) {
+        return target;
+      }
+      index = substitution.endIndex + 1;
+      continue;
+    }
+
+    if (char === "`") {
+      const substitution = readBacktickCommandSubstitution(command, index);
+      if (!substitution) {
+        return undefined;
+      }
+
+      const target = findProtectedDataRawWriteTarget(substitution.content);
+      if (target) {
+        return target;
+      }
+      index = substitution.endIndex + 1;
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return undefined;
+}
+
+function readCommandSubstitution(
+  command: string,
+  openParenIndex: number
+): { content: string; endIndex: number } | undefined {
+  let quote: "'" | '"' | undefined;
+  let depth = 1;
+  let index = openParenIndex + 1;
+
+  while (index < command.length) {
+    const char = command[index];
+
+    if (char === "\\") {
+      index += 2;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (char === "'" || char === `"`) {
+      quote = char;
+      index += 1;
+      continue;
+    }
+
+    if (char === "(") {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+
+    if (char === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return {
+          content: command.slice(openParenIndex + 1, index),
+          endIndex: index
+        };
+      }
+    }
+
+    index += 1;
+  }
+
+  return undefined;
+}
+
+function readBacktickCommandSubstitution(
+  command: string,
+  openBacktickIndex: number
+): { content: string; endIndex: number } | undefined {
+  let content = "";
+  let index = openBacktickIndex + 1;
+
+  while (index < command.length) {
+    const char = command[index];
+
+    if (char === "\\") {
+      const next = command[index + 1];
+      if (next !== undefined) {
+        content += `${char}${next}`;
+        index += 2;
+        continue;
+      }
+    }
+
+    if (char === "`") {
+      return {
+        content,
+        endIndex: index
+      };
+    }
+
+    content += char;
+    index += 1;
+  }
+
+  return undefined;
 }
 
 function readShellOperator(command: string, index: number): string | undefined {

--- a/packages/core/src/tools/data-raw-write-rule.ts
+++ b/packages/core/src/tools/data-raw-write-rule.ts
@@ -7,8 +7,8 @@ export const DATA_RAW_WRITE_RULE_REF =
   "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md" as const;
 
 const BASH_TOOL_IDS = new Set(["bash"]);
-const REDIRECT_WRITE_OPERATORS = new Set([">", ">>", ">|", "1>", "1>>", "2>", "2>>", "&>", "&>>"]);
-const SEGMENT_SEPARATORS = new Set([";", "&&", "||", "|"]);
+const REDIRECT_WRITE_OPERATORS = new Set([">", ">>", ">|", "1>", "1>>", "2>", "2>>", "&>", "&>>", ">&"]);
+const SEGMENT_SEPARATORS = new Set([";", "&&", "||", "|", "&"]);
 const ANY_RAW_PATH_MUTATION_COMMANDS = new Set([
   "chmod",
   "chown",
@@ -18,19 +18,38 @@ const ANY_RAW_PATH_MUTATION_COMMANDS = new Set([
   "touch",
   "truncate"
 ]);
-const DESTINATION_RAW_PATH_COMMANDS = new Set(["cp", "install", "ln"]);
+const DESTINATION_RAW_PATH_COMMANDS = new Set(["cp", "install", "ln", "rsync"]);
 const ANY_ENDPOINT_RAW_PATH_COMMANDS = new Set(["mv"]);
+const READ_ONLY_RAW_PATH_COMMANDS = new Set(["cat", "grep", "head", "ls", "tail", "wc"]);
 const WRAPPER_COMMANDS = new Set(["command", "doas", "env", "nice", "nohup", "sudo", "time"]);
 const WRAPPER_OPTIONS_WITH_OPERANDS = new Map<string, ReadonlySet<string>>([
-  ["env", new Set(["-u", "--unset"])],
-  ["nice", new Set(["-n", "--adjustment"])]
+  ["doas", new Set(["-u"])],
+  ["env", new Set(["-C", "--chdir", "-u", "--unset"])],
+  ["nice", new Set(["-n", "--adjustment"])],
+  ["sudo", new Set(["-u", "--user"])],
+  ["time", new Set(["-f", "--format"])]
 ]);
 const SHELL_COMMANDS = new Set(["bash", "sh", "zsh"]);
+const FIND_MUTATION_ACTIONS = new Set(["-delete", "-exec", "-execdir", "-ok", "-okdir"]);
 
 type ShellToken = {
   value: string;
   fromOperator: boolean;
   quoted: boolean;
+  fullyQuoted: boolean;
+  expandsParameters: boolean;
+};
+
+type ShellQuote = {
+  char: "'" | '"';
+  ansiC: boolean;
+  expandsParameters: boolean;
+};
+
+type PathCandidate = {
+  value: string;
+  quoted: boolean;
+  fullyQuoted: boolean;
 };
 
 export const DATA_RAW_WRITE_DENY_RULE: PolicyRule = {
@@ -80,23 +99,31 @@ export function extractBashCommand(input: unknown): string | undefined {
   return undefined;
 }
 
-export function findProtectedDataRawWriteTarget(command: string): string | undefined {
-  const substitutionTarget = findCommandSubstitutionWriteTarget(command);
+export function findProtectedDataRawWriteTarget(
+  command: string,
+  initialVariables: ReadonlyMap<string, string> = new Map()
+): string | undefined {
+  const substitutionTarget = findCommandSubstitutionWriteTarget(command, initialVariables);
   if (substitutionTarget) {
     return substitutionTarget;
   }
 
   const tokens = tokenizeShellCommand(command);
-  const redirectTarget = findRedirectWriteTarget(tokens);
-  if (redirectTarget) {
-    return redirectTarget;
-  }
+  const variables = new Map(initialVariables);
 
   for (const segment of splitCommandSegments(tokens)) {
-    const mutationTarget = findMutationCommandTarget(segment);
+    const expandedSegment = expandSegmentParameterReferences(segment, variables);
+    const redirectTarget = findRedirectWriteTarget(expandedSegment);
+    if (redirectTarget) {
+      return redirectTarget;
+    }
+
+    const mutationTarget = findMutationCommandTarget(expandedSegment, variables);
     if (mutationTarget) {
       return mutationTarget;
     }
+
+    recordVariableAssignments(segment, variables);
   }
 
   return undefined;
@@ -117,9 +144,9 @@ function findRedirectWriteTarget(tokens: readonly ShellToken[]): string | undefi
       continue;
     }
 
-    const target = tokens[index + 1]?.value;
-    if (target && isProtectedDataRawPath(target)) {
-      return target;
+    const target = tokens[index + 1];
+    if (target && isProtectedDataRawCandidate(target)) {
+      return target.value;
     }
   }
 
@@ -152,7 +179,15 @@ function isUnquotedOperatorToken(token: ShellToken, operators: ReadonlySet<strin
   return token.fromOperator && !token.quoted && operators.has(token.value);
 }
 
-function findMutationCommandTarget(segment: readonly ShellToken[]): string | undefined {
+function findMutationCommandTarget(
+  segment: readonly ShellToken[],
+  variables: ReadonlyMap<string, string>
+): string | undefined {
+  const wrapperUncertaintyTarget = findWrapperUncertaintyRawCandidate(segment);
+  if (wrapperUncertaintyTarget) {
+    return wrapperUncertaintyTarget;
+  }
+
   const commandIndex = findCommandTokenIndex(segment);
   if (commandIndex === undefined) {
     return undefined;
@@ -160,34 +195,105 @@ function findMutationCommandTarget(segment: readonly ShellToken[]): string | und
 
   const command = path.posix.basename(segment[commandIndex].value);
   const args = segment.slice(commandIndex + 1);
+  if (command === "eval") {
+    const target = findEvalCommandTarget(args, variables);
+    if (target) {
+      return target;
+    }
+  }
+  if (isExecutableCodeStringCommand(command)) {
+    const target = findExecutableCodeStringRawTarget(command, args);
+    if (target) {
+      return target;
+    }
+  }
   if (ANY_RAW_PATH_MUTATION_COMMANDS.has(command)) {
-    return findRawPathArgument(args);
+    const target = findRawPathArgument(args);
+    if (target) {
+      return target;
+    }
   }
   if (DESTINATION_RAW_PATH_COMMANDS.has(command)) {
-    return findDestinationRawPathTarget(args);
+    const target = findDestinationRawPathTarget(args);
+    if (target) {
+      return target;
+    }
   }
   if (ANY_ENDPOINT_RAW_PATH_COMMANDS.has(command)) {
-    return findRawPathArgument(args);
+    const target = findRawPathArgument(args);
+    if (target) {
+      return target;
+    }
   }
   if (command === "dd") {
-    return findDdOutputTarget(args);
+    const target = findDdOutputTarget(args);
+    if (target) {
+      return target;
+    }
   }
   if (command === "tee") {
-    return args.find((arg) => !arg.value.startsWith("-") && isProtectedDataRawPath(arg.value))
+    const target = args.find((arg) => !arg.value.startsWith("-") && isProtectedDataRawCandidate(arg))
       ?.value;
+    if (target) {
+      return target;
+    }
   }
-  if (command === "sed" && args.some((arg) => arg.value === "-i" || arg.value.startsWith("-i"))) {
-    return findRawPathArgument(args);
+  if (command === "sed" && args.some(isSedInPlaceOption)) {
+    const target = findRawPathArgument(args);
+    if (target) {
+      return target;
+    }
   }
   if (command === "curl") {
-    return findCurlOutputTarget(args);
+    const target = findCurlOutputTarget(args);
+    if (target) {
+      return target;
+    }
+  }
+  if (command === "find") {
+    const target = findFindMutationTarget(args);
+    if (target) {
+      return target;
+    }
+  }
+  if (command === "git") {
+    const target = findGitCloneTarget(args);
+    if (target) {
+      return target;
+    }
+  }
+  if (command === "tar") {
+    const target = findTarExtractionTarget(args);
+    if (target) {
+      return target;
+    }
+  }
+  if (command === "unzip") {
+    const target = findUnzipExtractionTarget(args);
+    if (target) {
+      return target;
+    }
+  }
+  if (command === "wget") {
+    const target = findWgetOutputTarget(args);
+    if (target) {
+      return target;
+    }
   }
   if (SHELL_COMMANDS.has(command)) {
     const shellCommand = findShellCommandArgument(args);
-    return shellCommand ? findProtectedDataRawWriteTarget(shellCommand) : undefined;
+    const target = shellCommand ? findProtectedDataRawWriteTarget(shellCommand, variables) : undefined;
+    if (target) {
+      return target;
+    }
   }
 
-  return undefined;
+  const rawPathCandidate = findRawPathCandidate(segment);
+  if (!rawPathCandidate || isReadOnlySafeRawPathCommand(command, args)) {
+    return undefined;
+  }
+
+  return rawPathCandidate;
 }
 
 function findCommandTokenIndex(segment: readonly ShellToken[]): number | undefined {
@@ -201,14 +307,8 @@ function findCommandTokenIndex(segment: readonly ShellToken[]): number | undefin
 
     const command = path.posix.basename(token.value);
     if (WRAPPER_COMMANDS.has(command)) {
-      index += 1;
-      while (index < segment.length && segment[index].value.startsWith("-")) {
-        const option = segment[index].value;
-        index += 1;
-        if (wrapperOptionConsumesOperand(command, option) && index < segment.length) {
-          index += 1;
-        }
-      }
+      const parsedOptions = parseWrapperOptions(command, segment, index + 1);
+      index = parsedOptions.nextIndex;
       continue;
     }
 
@@ -218,39 +318,202 @@ function findCommandTokenIndex(segment: readonly ShellToken[]): number | undefin
   return undefined;
 }
 
-function wrapperOptionConsumesOperand(command: string, option: string): boolean {
-  return WRAPPER_OPTIONS_WITH_OPERANDS.get(command)?.has(option) ?? false;
+function findWrapperUncertaintyRawCandidate(segment: readonly ShellToken[]): string | undefined {
+  const rawPathCandidate = findRawPathCandidate(segment);
+  if (!rawPathCandidate) {
+    return undefined;
+  }
+
+  let index = 0;
+  while (index < segment.length) {
+    const token = segment[index];
+    if (isAssignment(token)) {
+      index += 1;
+      continue;
+    }
+
+    const command = path.posix.basename(token.value);
+    if (!WRAPPER_COMMANDS.has(command)) {
+      return undefined;
+    }
+
+    const parsedOptions = parseWrapperOptions(command, segment, index + 1);
+    if (parsedOptions.uncertain) {
+      return rawPathCandidate;
+    }
+
+    index = parsedOptions.nextIndex;
+  }
+
+  return undefined;
+}
+
+function parseWrapperOptions(
+  command: string,
+  segment: readonly ShellToken[],
+  startIndex: number
+): { nextIndex: number; uncertain: boolean } {
+  let index = startIndex;
+  while (index < segment.length && segment[index].value.startsWith("-")) {
+    const option = segment[index].value;
+    if (option === "--") {
+      return { nextIndex: index + 1, uncertain: false };
+    }
+
+    const operandMode = wrapperOptionOperandMode(command, option);
+    if (!operandMode) {
+      return { nextIndex: index + 1, uncertain: true };
+    }
+
+    index += 1;
+    if (operandMode === "separate") {
+      if (index >= segment.length) {
+        return { nextIndex: index, uncertain: true };
+      }
+      index += 1;
+    }
+  }
+
+  return { nextIndex: index, uncertain: false };
+}
+
+function wrapperOptionOperandMode(
+  command: string,
+  option: string
+): "inline" | "separate" | undefined {
+  const optionsWithOperands = WRAPPER_OPTIONS_WITH_OPERANDS.get(command);
+  if (!optionsWithOperands) {
+    return undefined;
+  }
+
+  if (optionsWithOperands.has(option)) {
+    return "separate";
+  }
+
+  if (option.startsWith("--")) {
+    const assignmentIndex = option.indexOf("=");
+    if (assignmentIndex > 2 && optionsWithOperands.has(option.slice(0, assignmentIndex))) {
+      return "inline";
+    }
+    return undefined;
+  }
+
+  const shortOption = option.slice(0, 2);
+  return optionsWithOperands.has(shortOption) && option.length > shortOption.length
+    ? "inline"
+    : undefined;
 }
 
 function findRawPathArgument(args: readonly ShellToken[]): string | undefined {
-  return args.find((arg) => isProtectedDataRawPath(arg.value))?.value;
+  return args.find(isProtectedDataRawCandidate)?.value;
+}
+
+function findRawPathCandidate(tokens: readonly ShellToken[]): string | undefined {
+  for (const token of tokens) {
+    const candidate = findProtectedRawPathCandidate(token);
+    if (candidate) {
+      return candidate.value;
+    }
+  }
+
+  return undefined;
+}
+
+function findProtectedRawPathCandidate(token: ShellToken): PathCandidate | undefined {
+  const wholeTokenCandidate = pathCandidateFromToken(token);
+  if (isProtectedDataRawCandidate(wholeTokenCandidate)) {
+    return wholeTokenCandidate;
+  }
+
+  if (!token.value.startsWith("-")) {
+    return undefined;
+  }
+
+  if (token.value.startsWith("--")) {
+    const assignmentIndex = token.value.indexOf("=");
+    if (assignmentIndex > 2 && assignmentIndex < token.value.length - 1) {
+      const assignmentCandidate = pathCandidateFromToken(
+        token,
+        token.value.slice(assignmentIndex + 1)
+      );
+      return isProtectedDataRawCandidate(assignmentCandidate) ? assignmentCandidate : undefined;
+    }
+
+    return undefined;
+  }
+
+  return findAttachedShortOptionRawPathCandidate(token);
+}
+
+function findAttachedShortOptionRawPathCandidate(token: ShellToken): PathCandidate | undefined {
+  for (let valueStart = 2; valueStart < token.value.length; valueStart += 1) {
+    const candidate = pathCandidateFromToken(token, token.value.slice(valueStart));
+    if (isProtectedDataRawCandidate(candidate)) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+function isReadOnlySafeRawPathCommand(
+  command: string,
+  args: readonly ShellToken[]
+): boolean {
+  if (READ_ONLY_RAW_PATH_COMMANDS.has(command)) {
+    return true;
+  }
+  if (command === "find") {
+    return !hasFindMutationAction(args);
+  }
+  if (command === "sed") {
+    return !args.some(isSedInPlaceOption);
+  }
+
+  return command === "cp" && isCopyOutOfRawCommand(args);
+}
+
+function isCopyOutOfRawCommand(args: readonly ShellToken[]): boolean {
+  const targetDirectory = findTargetDirectoryArgument(args);
+  if (targetDirectory !== undefined) {
+    return !isProtectedDataRawCandidate(targetDirectory) && args.some(isProtectedDataRawCandidate);
+  }
+
+  const positionalArgs = args.filter((arg) => !arg.value.startsWith("-"));
+  const destination = positionalArgs.at(-1);
+  if (!destination || isProtectedDataRawCandidate(destination)) {
+    return false;
+  }
+
+  return positionalArgs.slice(0, -1).some(isProtectedDataRawCandidate);
 }
 
 function lastNonOptionArgument(args: readonly ShellToken[]): string | undefined {
-  const target = args.filter((arg) => !arg.value.startsWith("-")).at(-1)?.value;
-  return target && isProtectedDataRawPath(target) ? target : undefined;
+  const target = args.filter((arg) => !arg.value.startsWith("-")).at(-1);
+  return target && isProtectedDataRawCandidate(target) ? target.value : undefined;
 }
 
 function findDestinationRawPathTarget(args: readonly ShellToken[]): string | undefined {
   const targetDirectory = findTargetDirectoryArgument(args);
   if (targetDirectory !== undefined) {
-    return isProtectedDataRawPath(targetDirectory) ? targetDirectory : undefined;
+    return isProtectedDataRawCandidate(targetDirectory) ? targetDirectory.value : undefined;
   }
 
   return lastNonOptionArgument(args);
 }
 
-function findTargetDirectoryArgument(args: readonly ShellToken[]): string | undefined {
+function findTargetDirectoryArgument(args: readonly ShellToken[]): PathCandidate | undefined {
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index].value;
     if (arg === "-t" || arg === "--target-directory") {
-      return args[index + 1]?.value ?? "";
+      const target = args[index + 1];
+      return target ? pathCandidateFromToken(target) : { value: "", quoted: false, fullyQuoted: false };
     }
     if (arg.startsWith("--target-directory=")) {
-      return arg.slice("--target-directory=".length);
+      return pathCandidateFromToken(args[index], arg.slice("--target-directory=".length));
     }
     if (arg.startsWith("-t") && !arg.startsWith("--") && arg.length > 2) {
-      return arg.slice(2);
+      return pathCandidateFromToken(args[index], arg.slice(2));
     }
   }
 
@@ -263,9 +526,9 @@ function findDdOutputTarget(args: readonly ShellToken[]): string | undefined {
       continue;
     }
 
-    const target = arg.value.slice("of=".length);
-    if (isProtectedDataRawPath(target)) {
-      return target;
+    const target = pathCandidateFromToken(arg, arg.value.slice("of=".length));
+    if (isProtectedDataRawCandidate(target)) {
+      return target.value;
     }
   }
 
@@ -276,16 +539,16 @@ function findCurlOutputTarget(args: readonly ShellToken[]): string | undefined {
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index].value;
     if (arg === "-o" || arg === "--output") {
-      const target = args[index + 1]?.value;
-      if (target && isProtectedDataRawPath(target)) {
-        return target;
+      const target = args[index + 1];
+      if (target && isProtectedDataRawCandidate(target)) {
+        return target.value;
       }
       continue;
     }
     if (arg.startsWith("--output=")) {
-      const target = arg.slice("--output=".length);
-      if (isProtectedDataRawPath(target)) {
-        return target;
+      const target = pathCandidateFromToken(args[index], arg.slice("--output=".length));
+      if (isProtectedDataRawCandidate(target)) {
+        return target.value;
       }
       continue;
     }
@@ -315,8 +578,290 @@ function findCurlShortOutputTarget(
   }
 
   const attachedTarget = optionCluster.slice(outputOptionIndex + 1);
-  const target = attachedTarget.length > 0 ? attachedTarget : args[index + 1]?.value;
-  return target && isProtectedDataRawPath(target) ? target : undefined;
+  const target =
+    attachedTarget.length > 0
+      ? pathCandidateFromToken(args[index], attachedTarget)
+      : args[index + 1];
+  return target && isProtectedDataRawCandidate(target) ? target.value : undefined;
+}
+
+function isSedInPlaceOption(arg: ShellToken): boolean {
+  return (
+    arg.value === "-i" ||
+    arg.value.startsWith("-i") ||
+    (arg.value.startsWith("-") && !arg.value.startsWith("--") && arg.value.slice(1).includes("i")) ||
+    arg.value === "--in-place" ||
+    arg.value.startsWith("--in-place=")
+  );
+}
+
+function findFindMutationTarget(args: readonly ShellToken[]): string | undefined {
+  if (!hasFindMutationAction(args)) {
+    return undefined;
+  }
+
+  return findRawPathArgument(args);
+}
+
+function hasFindMutationAction(args: readonly ShellToken[]): boolean {
+  return args.some((arg) => FIND_MUTATION_ACTIONS.has(arg.value));
+}
+
+function findGitCloneTarget(args: readonly ShellToken[]): string | undefined {
+  const cloneIndex = args.findIndex((arg) => arg.value === "clone");
+  if (cloneIndex === -1) {
+    return undefined;
+  }
+
+  const positionalArgs = args
+    .slice(cloneIndex + 1)
+    .filter((arg) => !arg.value.startsWith("-"));
+  if (positionalArgs.length < 2) {
+    return undefined;
+  }
+
+  const destination = positionalArgs.at(-1);
+  return destination && isProtectedDataRawCandidate(destination) ? destination.value : undefined;
+}
+
+function findTarExtractionTarget(args: readonly ShellToken[]): string | undefined {
+  if (!isTarExtractCommand(args)) {
+    return undefined;
+  }
+
+  const targetDirectory = findOptionValue(args, {
+    separate: new Set(["-C", "--directory"]),
+    longAssignments: ["--directory="],
+    shortAttached: "-C"
+  });
+  if (targetDirectory && isProtectedDataRawCandidate(targetDirectory)) {
+    return targetDirectory.value;
+  }
+
+  return undefined;
+}
+
+function isTarExtractCommand(args: readonly ShellToken[]): boolean {
+  return args.some((arg, index) => {
+    if (arg.value === "--extract") {
+      return true;
+    }
+    if (arg.value.startsWith("-") && !arg.value.startsWith("--")) {
+      return arg.value.includes("x");
+    }
+    return index === 0 && /^[A-Za-z]+$/.test(arg.value) && arg.value.includes("x");
+  });
+}
+
+function findUnzipExtractionTarget(args: readonly ShellToken[]): string | undefined {
+  const targetDirectory = findOptionValue(args, {
+    separate: new Set(["-d"]),
+    shortAttached: "-d"
+  });
+  return targetDirectory && isProtectedDataRawCandidate(targetDirectory)
+    ? targetDirectory.value
+    : undefined;
+}
+
+function findWgetOutputTarget(args: readonly ShellToken[]): string | undefined {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg.value === "-O" || arg.value === "--output-document") {
+      const target = args[index + 1];
+      if (target && isProtectedDataRawCandidate(target)) {
+        return target.value;
+      }
+      continue;
+    }
+    if (arg.value.startsWith("--output-document=")) {
+      const target = pathCandidateFromToken(
+        arg,
+        arg.value.slice("--output-document=".length)
+      );
+      if (isProtectedDataRawCandidate(target)) {
+        return target.value;
+      }
+      continue;
+    }
+    if (arg.value.startsWith("-O") && !arg.value.startsWith("--") && arg.value.length > 2) {
+      const target = pathCandidateFromToken(arg, arg.value.slice("-O".length));
+      if (isProtectedDataRawCandidate(target)) {
+        return target.value;
+      }
+      continue;
+    }
+
+    const targetDirectory = findWgetDirectoryPrefixTarget(args, index);
+    if (targetDirectory) {
+      return targetDirectory;
+    }
+  }
+
+  return undefined;
+}
+
+function findWgetDirectoryPrefixTarget(
+  args: readonly ShellToken[],
+  index: number
+): string | undefined {
+  const target = findOptionValueAt(args, index, {
+    separate: new Set(["-P", "--directory-prefix"]),
+    longAssignments: ["--directory-prefix="],
+    shortAttached: "-P"
+  });
+  return target && isProtectedDataRawCandidate(target) ? target.value : undefined;
+}
+
+function findOptionValue(
+  args: readonly ShellToken[],
+  options: {
+    separate?: ReadonlySet<string>;
+    longAssignments?: readonly string[];
+    shortAttached?: string;
+  }
+): PathCandidate | undefined {
+  for (let index = 0; index < args.length; index += 1) {
+    const target = findOptionValueAt(args, index, options);
+    if (target !== undefined) {
+      return target;
+    }
+  }
+
+  return undefined;
+}
+
+function findOptionValueAt(
+  args: readonly ShellToken[],
+  index: number,
+  options: {
+    separate?: ReadonlySet<string>;
+    longAssignments?: readonly string[];
+    shortAttached?: string;
+  }
+): PathCandidate | undefined {
+  const arg = args[index];
+  if (!arg) {
+    return undefined;
+  }
+
+  if (options.separate?.has(arg.value)) {
+    return args[index + 1] ? pathCandidateFromToken(args[index + 1]) : undefined;
+  }
+
+  for (const assignmentPrefix of options.longAssignments ?? []) {
+    if (arg.value.startsWith(assignmentPrefix)) {
+      return pathCandidateFromToken(arg, arg.value.slice(assignmentPrefix.length));
+    }
+  }
+
+  if (
+    options.shortAttached &&
+    arg.value.startsWith(options.shortAttached) &&
+    !arg.value.startsWith("--") &&
+    arg.value.length > options.shortAttached.length
+  ) {
+    return pathCandidateFromToken(arg, arg.value.slice(options.shortAttached.length));
+  }
+
+  return undefined;
+}
+
+function findEvalCommandTarget(
+  args: readonly ShellToken[],
+  variables: ReadonlyMap<string, string>
+): string | undefined {
+  const command = args.map((arg) => arg.value).join(" ").trim();
+  return command ? findProtectedDataRawWriteTarget(command, variables) : undefined;
+}
+
+function isExecutableCodeStringCommand(command: string): boolean {
+  const normalized = command.toLowerCase();
+  return (
+    normalized === "bun" ||
+    normalized === "deno" ||
+    normalized === "node" ||
+    normalized === "perl" ||
+    normalized === "php" ||
+    normalized === "r" ||
+    normalized === "rscript" ||
+    normalized === "ruby" ||
+    normalized === "python" ||
+    /^python\d+(?:\.\d+)?$/.test(normalized)
+  );
+}
+
+function findExecutableCodeStringRawTarget(
+  command: string,
+  args: readonly ShellToken[]
+): string | undefined {
+  const denoEvalTarget = findDenoEvalRawTarget(command, args);
+  if (denoEvalTarget) {
+    return denoEvalTarget;
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const codeString = findExecutableCodeStringAt(args, index);
+    if (!codeString) {
+      continue;
+    }
+
+    const target = findProtectedRawPathInText(codeString);
+    if (target) {
+      return target;
+    }
+  }
+
+  return undefined;
+}
+
+function findDenoEvalRawTarget(command: string, args: readonly ShellToken[]): string | undefined {
+  if (command.toLowerCase() !== "deno" || args[0]?.value !== "eval") {
+    return undefined;
+  }
+
+  const codeString = args.find((arg, index) => index > 0 && !arg.value.startsWith("-"))?.value;
+  return codeString ? findProtectedRawPathInText(codeString) : undefined;
+}
+
+function findExecutableCodeStringAt(
+  args: readonly ShellToken[],
+  index: number
+): string | undefined {
+  const arg = args[index];
+  if (!arg) {
+    return undefined;
+  }
+
+  if (arg.value === "-c" || arg.value === "-e" || arg.value === "-E" || arg.value === "-p") {
+    return args[index + 1]?.value;
+  }
+  if (arg.value === "--eval" || arg.value === "--print") {
+    return args[index + 1]?.value;
+  }
+  if (arg.value.startsWith("--eval=")) {
+    return arg.value.slice("--eval=".length);
+  }
+  if (arg.value.startsWith("--print=")) {
+    return arg.value.slice("--print=".length);
+  }
+  if (
+    !arg.value.startsWith("--") &&
+    (arg.value.startsWith("-c") ||
+      arg.value.startsWith("-e") ||
+      arg.value.startsWith("-E") ||
+      arg.value.startsWith("-p")) &&
+    arg.value.length > 2
+  ) {
+    return arg.value.slice(2);
+  }
+  if (!arg.value.startsWith("--") && arg.value.startsWith("-r") && arg.value.length > 2) {
+    return arg.value.slice(2);
+  }
+  if (arg.value === "-r") {
+    return args[index + 1]?.value;
+  }
+
+  return undefined;
 }
 
 function findShellCommandArgument(args: readonly ShellToken[]): string | undefined {
@@ -336,13 +881,131 @@ function findShellCommandArgument(args: readonly ShellToken[]): string | undefin
   return undefined;
 }
 
+function expandSegmentParameterReferences(
+  segment: readonly ShellToken[],
+  variables: ReadonlyMap<string, string>
+): ShellToken[] {
+  if (variables.size === 0) {
+    return [...segment];
+  }
+
+  return segment.map((token) => expandTokenParameterReferences(token, variables));
+}
+
+function expandTokenParameterReferences(
+  token: ShellToken,
+  variables: ReadonlyMap<string, string>
+): ShellToken {
+  if (!token.expandsParameters || !token.value.includes("$")) {
+    return token;
+  }
+
+  const expandedValue = token.value.replace(
+    /\$(?:{([A-Za-z_][A-Za-z0-9_]*)}|([A-Za-z_][A-Za-z0-9_]*))/g,
+    (match, bracedName: string | undefined, bareName: string | undefined) => {
+      const variableName = bracedName ?? bareName;
+      const value = variableName ? variables.get(variableName) : undefined;
+      return value ?? match;
+    }
+  );
+
+  return expandedValue === token.value ? token : { ...token, value: expandedValue };
+}
+
+function recordVariableAssignments(
+  segment: readonly ShellToken[],
+  variables: Map<string, string>
+): void {
+  const commandIndex = findCommandTokenIndex(segment);
+  if (commandIndex === undefined) {
+    for (const token of segment) {
+      recordVariableAssignment(token, variables);
+    }
+    return;
+  }
+
+  const command = path.posix.basename(segment[commandIndex].value);
+  if (command !== "export") {
+    return;
+  }
+
+  for (const arg of segment.slice(commandIndex + 1)) {
+    if (arg.value.startsWith("-")) {
+      continue;
+    }
+    recordVariableAssignment(arg, variables);
+  }
+}
+
+function recordVariableAssignment(token: ShellToken, variables: Map<string, string>): void {
+  const assignment = token.value.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+  if (!assignment) {
+    return;
+  }
+
+  const [, name, value] = assignment;
+  if (!isSimpleLiteralVariableValue(value)) {
+    variables.delete(name);
+    return;
+  }
+
+  variables.set(name, value);
+}
+
 function isAssignment(token: ShellToken): boolean {
   return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token.value);
+}
+
+function isSimpleLiteralVariableValue(value: string): boolean {
+  return !/[`$]/.test(value);
+}
+
+function pathCandidateFromToken(token: ShellToken, value = token.value): PathCandidate {
+  return {
+    value,
+    quoted: token.quoted,
+    fullyQuoted: token.fullyQuoted
+  };
+}
+
+function isProtectedDataRawCandidate(candidate: PathCandidate): boolean {
+  if (isProtectedDataRawPath(candidate.value)) {
+    return true;
+  }
+  return (
+    !candidate.fullyQuoted &&
+    expandShellBraceAlternatives(candidate.value).some((expanded) =>
+      isProtectedDataRawPath(expanded)
+    )
+  );
+}
+
+function findProtectedRawPathInText(value: string): string | undefined {
+  const rawPathPattern = /(?:file:\/\/)?[A-Za-z0-9_./@%:+-]*data\/raw(?:\/[A-Za-z0-9_./@%:+-]*)?/g;
+  for (const match of value.matchAll(rawPathPattern)) {
+    const candidate = match[0];
+    if (isProtectedDataRawPath(candidate)) {
+      return candidate;
+    }
+
+    const rawPathIndex = candidate.indexOf("data/raw");
+    if (rawPathIndex !== -1) {
+      const relativeCandidate = candidate.slice(rawPathIndex);
+      if (isProtectedDataRawPath(relativeCandidate)) {
+        return relativeCandidate;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 function isProtectedDataRawPath(candidate: string): boolean {
   const normalized = path.posix.normalize(candidate.replace(/^file:\/\//, ""));
   const withoutDotPrefix = normalized.replace(/^\.\/+/, "");
+  if (isGovernedTaskWorkspacePath(withoutDotPrefix)) {
+    return false;
+  }
   return (
     withoutDotPrefix === "data/raw" ||
     withoutDotPrefix.startsWith("data/raw/") ||
@@ -351,18 +1014,134 @@ function isProtectedDataRawPath(candidate: string): boolean {
   );
 }
 
+function isGovernedTaskWorkspacePath(candidate: string): boolean {
+  const withoutLeadingSlash = candidate.replace(/^\/+/, "");
+  return withoutLeadingSlash.startsWith("workspace/tasks/");
+}
+
+function expandShellBraceAlternatives(candidate: string): string[] {
+  if (!candidate.includes("{")) {
+    return [];
+  }
+
+  let expanded = [candidate];
+  for (let pass = 0; pass < 4; pass += 1) {
+    const next: string[] = [];
+    let changed = false;
+
+    for (const value of expanded) {
+      const expansion = expandFirstBraceExpression(value);
+      if (!expansion) {
+        next.push(value);
+        continue;
+      }
+
+      changed = true;
+      next.push(...expansion);
+      if (next.length > 64) {
+        return ["data/raw"];
+      }
+    }
+
+    expanded = next;
+    if (!changed) {
+      break;
+    }
+  }
+
+  if (expanded.some((value) => value.includes("{"))) {
+    return ["data/raw"];
+  }
+
+  return expanded.filter((value) => value !== candidate);
+}
+
+function expandFirstBraceExpression(candidate: string): string[] | undefined {
+  const openIndex = candidate.indexOf("{");
+  if (openIndex === -1) {
+    return undefined;
+  }
+
+  let depth = 0;
+  for (let index = openIndex; index < candidate.length; index += 1) {
+    const char = candidate[index];
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+    if (char !== "}") {
+      continue;
+    }
+
+    depth -= 1;
+    if (depth !== 0) {
+      continue;
+    }
+
+    const body = candidate.slice(openIndex + 1, index);
+    const alternatives = splitBraceAlternatives(body);
+    if (alternatives.length < 2) {
+      return undefined;
+    }
+
+    const prefix = candidate.slice(0, openIndex);
+    const suffix = candidate.slice(index + 1);
+    return alternatives.map((alternative) => `${prefix}${alternative}${suffix}`);
+  }
+
+  return undefined;
+}
+
+function splitBraceAlternatives(body: string): string[] {
+  const alternatives: string[] = [];
+  let current = "";
+  let depth = 0;
+
+  for (const char of body) {
+    if (char === "{") {
+      depth += 1;
+      current += char;
+      continue;
+    }
+    if (char === "}") {
+      depth = Math.max(0, depth - 1);
+      current += char;
+      continue;
+    }
+    if (char === "," && depth === 0) {
+      alternatives.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+
+  alternatives.push(current);
+  return alternatives;
+}
+
 function tokenizeShellCommand(command: string): ShellToken[] {
   const tokens: ShellToken[] = [];
   let current = "";
   let currentQuoted = false;
-  let quote: "'" | '"' | undefined;
+  let currentHasUnquotedContent = false;
+  let currentExpandsParameters = false;
+  let quote: ShellQuote | undefined;
   let index = 0;
 
   const flush = () => {
     if (current.length > 0) {
-      tokens.push({ value: current, fromOperator: false, quoted: currentQuoted });
+      tokens.push({
+        value: current,
+        fromOperator: false,
+        quoted: currentQuoted,
+        fullyQuoted: currentQuoted && !currentHasUnquotedContent,
+        expandsParameters: currentExpandsParameters
+      });
       current = "";
       currentQuoted = false;
+      currentHasUnquotedContent = false;
+      currentExpandsParameters = false;
     }
   };
 
@@ -370,34 +1149,50 @@ function tokenizeShellCommand(command: string): ShellToken[] {
     const char = command[index];
 
     if (quote) {
-      if (char === "\\") {
+      if (char === "\\" && quote.ansiC) {
+        const escape = readAnsiCEscape(command, index);
+        current += escape.value;
+        index = escape.nextIndex;
+        continue;
+      }
+      if (char === "\\" && quote.char === `"`) {
         const next = command[index + 1];
         if (next !== undefined) {
           current += next;
+          currentExpandsParameters =
+            currentExpandsParameters || (quote.expandsParameters && next !== "$");
           index += 2;
           continue;
         }
       }
-      if (char === quote) {
+      if (char === quote.char) {
         quote = undefined;
         index += 1;
         continue;
       }
       current += char;
+      currentExpandsParameters = currentExpandsParameters || quote.expandsParameters;
       index += 1;
       continue;
     }
 
-    if (char === "'" || char === `"`) {
-      quote = char;
+    const quoteStart = readShellQuoteStart(command, index);
+    if (quoteStart) {
+      quote = quoteStart.quote;
       currentQuoted = true;
-      index += 1;
+      index += quoteStart.length;
       continue;
     }
 
     if (char === "\n" || char === "\r") {
       flush();
-      tokens.push({ value: ";", fromOperator: true, quoted: false });
+      tokens.push({
+        value: ";",
+        fromOperator: true,
+        quoted: false,
+        fullyQuoted: false,
+        expandsParameters: false
+      });
       index += 1;
       continue;
     }
@@ -411,7 +1206,13 @@ function tokenizeShellCommand(command: string): ShellToken[] {
     const operator = readShellOperator(command, index);
     if (operator) {
       flush();
-      tokens.push({ value: operator, fromOperator: true, quoted: false });
+      tokens.push({
+        value: operator,
+        fromOperator: true,
+        quoted: false,
+        fullyQuoted: false,
+        expandsParameters: false
+      });
       index += operator.length;
       continue;
     }
@@ -420,12 +1221,16 @@ function tokenizeShellCommand(command: string): ShellToken[] {
       const next = command[index + 1];
       if (next !== undefined) {
         current += next;
+        currentHasUnquotedContent = true;
+        currentExpandsParameters = currentExpandsParameters || next !== "$";
         index += 2;
         continue;
       }
     }
 
     current += char;
+    currentHasUnquotedContent = true;
+    currentExpandsParameters = true;
     index += 1;
   }
 
@@ -433,35 +1238,57 @@ function tokenizeShellCommand(command: string): ShellToken[] {
   return tokens;
 }
 
-function findCommandSubstitutionWriteTarget(command: string): string | undefined {
-  let quote: "'" | '"' | undefined;
+function findCommandSubstitutionWriteTarget(
+  command: string,
+  variables: ReadonlyMap<string, string> = new Map()
+): string | undefined {
+  let quote: ShellQuote | undefined;
   let index = 0;
 
   while (index < command.length) {
     const char = command[index];
 
-    if (char === "\\") {
-      index += 2;
-      continue;
-    }
-
-    if (quote === "'") {
-      if (char === "'") {
+    if (quote?.char === "'") {
+      if (char === "\\" && quote.ansiC) {
+        index = readAnsiCEscape(command, index).nextIndex;
+        continue;
+      }
+      if (char === quote.char) {
         quote = undefined;
       }
       index += 1;
       continue;
     }
 
-    if (char === "'" && !quote) {
-      quote = "'";
-      index += 1;
+    if (quote?.char === `"`) {
+      if (char === "\\") {
+        index += command[index + 1] === undefined ? 1 : 2;
+        continue;
+      }
+      if (char === `"`) {
+        quote = undefined;
+        index += 1;
+        continue;
+      }
+      if (
+        !(char === "$" && command[index + 1] === "(") &&
+        !((char === "<" || char === ">") && command[index + 1] === "(") &&
+        char !== "`"
+      ) {
+        index += 1;
+        continue;
+      }
+    }
+
+    const quoteStart = quote ? undefined : readShellQuoteStart(command, index);
+    if (quoteStart) {
+      quote = quoteStart.quote;
+      index += quoteStart.length;
       continue;
     }
 
-    if (char === `"`) {
-      quote = quote === `"` ? undefined : `"`;
-      index += 1;
+    if (char === "\\") {
+      index += command[index + 1] === undefined ? 1 : 2;
       continue;
     }
 
@@ -471,7 +1298,21 @@ function findCommandSubstitutionWriteTarget(command: string): string | undefined
         return undefined;
       }
 
-      const target = findProtectedDataRawWriteTarget(substitution.content);
+      const target = findProtectedDataRawWriteTarget(substitution.content, variables);
+      if (target) {
+        return target;
+      }
+      index = substitution.endIndex + 1;
+      continue;
+    }
+
+    if ((char === "<" || char === ">") && command[index + 1] === "(") {
+      const substitution = readCommandSubstitution(command, index + 1);
+      if (!substitution) {
+        return undefined;
+      }
+
+      const target = findProtectedDataRawWriteTarget(substitution.content, variables);
       if (target) {
         return target;
       }
@@ -485,7 +1326,7 @@ function findCommandSubstitutionWriteTarget(command: string): string | undefined
         return undefined;
       }
 
-      const target = findProtectedDataRawWriteTarget(substitution.content);
+      const target = findProtectedDataRawWriteTarget(substitution.content, variables);
       if (target) {
         return target;
       }
@@ -499,33 +1340,158 @@ function findCommandSubstitutionWriteTarget(command: string): string | undefined
   return undefined;
 }
 
+function readShellQuoteStart(
+  command: string,
+  index: number
+): { quote: ShellQuote; length: number } | undefined {
+  const char = command[index];
+  if (char === "'" || char === `"`) {
+    return { quote: { char, ansiC: false, expandsParameters: char === `"` }, length: 1 };
+  }
+
+  const next = command[index + 1];
+  if (char === "$" && (next === "'" || next === `"`)) {
+    return {
+      quote: { char: next, ansiC: next === "'", expandsParameters: next === `"` },
+      length: 2
+    };
+  }
+
+  return undefined;
+}
+
+function readAnsiCEscape(command: string, index: number): { value: string; nextIndex: number } {
+  const escaped = command[index + 1];
+  if (escaped === undefined) {
+    return { value: "\\", nextIndex: index + 1 };
+  }
+
+  const simpleEscapes: Record<string, string> = {
+    a: "\u0007",
+    b: "\b",
+    e: "\u001B",
+    E: "\u001B",
+    f: "\f",
+    n: "\n",
+    r: "\r",
+    t: "\t",
+    v: "\v",
+    "\\": "\\",
+    "'": "'",
+    '"': '"'
+  };
+  const simpleEscape = simpleEscapes[escaped];
+  if (simpleEscape !== undefined) {
+    return { value: simpleEscape, nextIndex: index + 2 };
+  }
+
+  if (escaped === "x") {
+    const match = command.slice(index + 2).match(/^[0-9A-Fa-f]{1,2}/);
+    if (match) {
+      return {
+        value: String.fromCharCode(Number.parseInt(match[0], 16)),
+        nextIndex: index + 2 + match[0].length
+      };
+    }
+    return { value: "x", nextIndex: index + 2 };
+  }
+
+  if (escaped === "u" || escaped === "U") {
+    const maxDigits = escaped === "u" ? 4 : 8;
+    const match = command.slice(index + 2).match(new RegExp(`^[0-9A-Fa-f]{1,${maxDigits}}`));
+    if (match) {
+      const codePoint = Number.parseInt(match[0], 16);
+      return {
+        value: Number.isNaN(codePoint) ? "" : String.fromCodePoint(codePoint),
+        nextIndex: index + 2 + match[0].length
+      };
+    }
+    return { value: escaped, nextIndex: index + 2 };
+  }
+
+  if (/[0-7]/.test(escaped)) {
+    const match = command.slice(index + 1).match(/^[0-7]{1,3}/);
+    if (match) {
+      return {
+        value: String.fromCharCode(Number.parseInt(match[0], 8)),
+        nextIndex: index + 1 + match[0].length
+      };
+    }
+  }
+
+  return { value: escaped, nextIndex: index + 2 };
+}
+
 function readCommandSubstitution(
   command: string,
   openParenIndex: number
 ): { content: string; endIndex: number } | undefined {
-  let quote: "'" | '"' | undefined;
+  let quote: ShellQuote | undefined;
   let depth = 1;
   let index = openParenIndex + 1;
 
   while (index < command.length) {
     const char = command[index];
 
-    if (char === "\\") {
-      index += 2;
-      continue;
-    }
-
-    if (quote) {
-      if (char === quote) {
+    if (quote?.char === "'") {
+      if (char === "\\" && quote.ansiC) {
+        index = readAnsiCEscape(command, index).nextIndex;
+        continue;
+      }
+      if (char === quote.char) {
         quote = undefined;
       }
       index += 1;
       continue;
     }
 
-    if (char === "'" || char === `"`) {
-      quote = char;
+    if (quote?.char === `"`) {
+      if (char === "$" && command[index + 1] === "(") {
+        const substitution = readCommandSubstitution(command, index + 1);
+        if (!substitution) {
+          return undefined;
+        }
+        index = substitution.endIndex + 1;
+        continue;
+      }
+      if ((char === "<" || char === ">") && command[index + 1] === "(") {
+        const substitution = readCommandSubstitution(command, index + 1);
+        if (!substitution) {
+          return undefined;
+        }
+        index = substitution.endIndex + 1;
+        continue;
+      }
+      if (char === "`") {
+        const substitution = readBacktickCommandSubstitution(command, index);
+        if (!substitution) {
+          return undefined;
+        }
+        index = substitution.endIndex + 1;
+        continue;
+      }
+      if (char === "\\") {
+        index += command[index + 1] === undefined ? 1 : 2;
+        continue;
+      }
+      if (char === `"`) {
+        quote = undefined;
+        index += 1;
+        continue;
+      }
       index += 1;
+      continue;
+    }
+
+    const quoteStart = quote ? undefined : readShellQuoteStart(command, index);
+    if (quoteStart) {
+      quote = quoteStart.quote;
+      index += quoteStart.length;
+      continue;
+    }
+
+    if (char === "\\") {
+      index += command[index + 1] === undefined ? 1 : 2;
       continue;
     }
 
@@ -585,7 +1551,23 @@ function readBacktickCommandSubstitution(
 }
 
 function readShellOperator(command: string, index: number): string | undefined {
-  for (const operator of ["&>>", "&&", "||", ">>", ">|", "1>>", "2>>", "&>", "1>", "2>", ">", "|", ";"]) {
+  for (const operator of [
+    "&>>",
+    "&>",
+    "&&",
+    ">&",
+    "1>>",
+    "2>>",
+    ">>",
+    ">|",
+    "1>",
+    "2>",
+    "||",
+    ">",
+    "|",
+    ";",
+    "&"
+  ]) {
     if (command.startsWith(operator, index)) {
       return operator;
     }

--- a/packages/core/src/tools/data-raw-write-rule.ts
+++ b/packages/core/src/tools/data-raw-write-rule.ts
@@ -1,4 +1,3 @@
-import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
 import type { PolicyGateToolCall, PolicyRule } from "./policy-gate-core";
 
@@ -23,14 +22,20 @@ const DESTINATION_RAW_PATH_COMMANDS = new Set(["cp", "install", "ln", "rsync"]);
 const ANY_ENDPOINT_RAW_PATH_COMMANDS = new Set(["mv"]);
 const READ_ONLY_RAW_PATH_COMMANDS = new Set([
   "cat",
+  "du",
+  "file",
   "grep",
   "head",
   "ls",
+  "mapfile",
+  "read",
   "sha256sum",
   "stat",
   "tail",
+  "test",
   "wc"
 ]);
+const ASSIGNMENT_BUILTIN_COMMANDS = new Set(["declare", "export", "readonly", "typeset"]);
 const WRAPPER_COMMANDS = new Set(["command", "doas", "env", "nice", "nohup", "sudo", "time"]);
 const WRAPPER_OPTIONS_WITH_OPERANDS = new Map<string, ReadonlySet<string>>([
   ["doas", new Set(["-u"])],
@@ -71,12 +76,14 @@ type PathCandidate = {
 type PathEvaluationContext = {
   cwd?: string;
   cwdKnown: boolean;
+  pathAliases: ReadonlyMap<string, string>;
 };
 
 type ShellScanState = {
   variables: Map<string, string>;
   cwd?: string;
   cwdKnown: boolean;
+  pathAliases: Map<string, string>;
   scanBudget: ShellScanBudget;
 };
 
@@ -95,6 +102,8 @@ type SegmentCommandScanState = ShellScanState & {
   commandIndex?: number;
   uncertainWrapper: boolean;
 };
+
+const EMPTY_PATH_ALIASES = new Map<string, string>();
 
 export const DATA_RAW_WRITE_DENY_RULE: PolicyRule = {
   ruleId: DATA_RAW_WRITE_DENY_RULE_ID,
@@ -152,6 +161,7 @@ export function findProtectedDataRawWriteTarget(
     variables: new Map(initialVariables),
     cwd: normalizeInitialCwd(workDir),
     cwdKnown: true,
+    pathAliases: new Map(),
     scanBudget: makeShellScanBudget()
   });
 }
@@ -160,16 +170,18 @@ function findProtectedDataRawWriteTargetWithState(
   command: string,
   state: ShellScanState
 ): string | undefined {
-  if (!reserveShellCommandScanBudget(command, state.scanBudget)) {
-    return "data/raw";
-  }
-
   const heredocTarget = findExecutableHeredocRawWriteTarget(command, state);
   if (heredocTarget) {
     return heredocTarget;
   }
 
   const commandWithoutHeredocBodies = stripHeredocBodies(command);
+  if (!reserveShellCommandScanBudget(commandWithoutHeredocBodies, state.scanBudget)) {
+    return hasProtectedRawPathText(commandWithoutHeredocBodies) &&
+      hasShellWriteIntentMarker(commandWithoutHeredocBodies)
+      ? "data/raw"
+      : undefined;
+  }
 
   const substitutionTarget = findCommandSubstitutionWriteTarget(commandWithoutHeredocBodies, state);
   if (substitutionTarget) {
@@ -179,6 +191,14 @@ function findProtectedDataRawWriteTargetWithState(
   const groupedTarget = findGroupedCommandWriteTarget(commandWithoutHeredocBodies, state);
   if (groupedTarget) {
     return groupedTarget;
+  }
+
+  const positionalLoopTarget = findImplicitPositionalLoopWriteTarget(
+    commandWithoutHeredocBodies,
+    state
+  );
+  if (positionalLoopTarget) {
+    return positionalLoopTarget;
   }
 
   const tokens = tokenizeShellCommand(commandWithoutHeredocBodies);
@@ -200,6 +220,7 @@ function findProtectedDataRawWriteTargetWithState(
     }
 
     updateCwdFromCdSegment(expandedSegment, state);
+    recordSymlinkAlias(expandedSegment, state);
     recordVariableAssignments(expandedSegment, state.variables);
   }
 
@@ -272,6 +293,7 @@ function findGroupedCommandWriteTarget(
       variables: new Map(state.variables),
       cwd: state.cwd,
       cwdKnown: state.cwdKnown,
+      pathAliases: new Map(state.pathAliases),
       scanBudget: state.scanBudget
     };
     const target = findProtectedDataRawWriteTargetWithState(group.body, groupState);
@@ -474,10 +496,19 @@ function findMutationCommandTarget(
       return target;
     }
   }
+  if (command === "trap") {
+    const target = findTrapCommandTarget(args, commandState);
+    if (target) {
+      return target;
+    }
+  }
   if (isExecutableCodeStringCommand(command)) {
     const target = findExecutableCodeStringRawMutationTarget(command, args, commandState);
     if (target) {
       return target;
+    }
+    if (hasExecutableCodeStringArgument(command, args)) {
+      return undefined;
     }
   }
   if (ANY_RAW_PATH_MUTATION_COMMANDS.has(command)) {
@@ -524,6 +555,12 @@ function findMutationCommandTarget(
       return target;
     }
   }
+  if (command === "sed") {
+    const target = findSedScriptWriteTarget(args, context);
+    if (target) {
+      return target;
+    }
+  }
   if (command === "curl") {
     const target = findCurlOutputTarget(args, context);
     if (target) {
@@ -531,6 +568,10 @@ function findMutationCommandTarget(
     }
   }
   if (command === "find") {
+    const execTarget = findFindExecMutationTarget(args, commandState);
+    if (execTarget) {
+      return execTarget;
+    }
     const target = findFindMutationTarget(args, context);
     if (target) {
       return target;
@@ -560,6 +601,12 @@ function findMutationCommandTarget(
       return target;
     }
   }
+  if (command === "awk") {
+    const target = findAwkScriptWriteTarget(args, context);
+    if (target) {
+      return target;
+    }
+  }
   if (SHELL_COMMANDS.has(command)) {
     const shellInvocation = findShellCommandInvocation(args);
     if (shellInvocation) {
@@ -569,6 +616,7 @@ function findMutationCommandTarget(
           variables: shellVariables,
           cwd: commandState.cwd,
           cwdKnown: commandState.cwdKnown,
+          pathAliases: new Map(commandState.pathAliases),
           scanBudget: commandState.scanBudget
         });
       if (target) {
@@ -616,6 +664,7 @@ function buildSegmentCommandScanState(
     variables: new Map(state.variables),
     cwd: state.cwd,
     cwdKnown: state.cwdKnown,
+    pathAliases: new Map(state.pathAliases),
     scanBudget: state.scanBudget,
     uncertainWrapper: false
   };
@@ -842,6 +891,12 @@ function findProtectedRawPathCandidate(
   if (isProtectedDataRawCandidate(wholeTokenCandidate, context)) {
     return wholeTokenCandidate;
   }
+  const embeddedCandidate = findFirstProtectedRawPathInText(token.value, context, {
+    allowRelativeFallback: false
+  });
+  if (embeddedCandidate) {
+    return pathCandidateFromToken(token, embeddedCandidate);
+  }
 
   if (!token.value.startsWith("-")) {
     return undefined;
@@ -884,6 +939,9 @@ function isReadOnlySafeRawPathCommand(
   args: readonly ShellToken[],
   context: PathEvaluationContext
 ): boolean {
+  if (isInputOnlyRedirectCommand(command)) {
+    return true;
+  }
   if (READ_ONLY_RAW_PATH_COMMANDS.has(command)) {
     return true;
   }
@@ -912,6 +970,10 @@ function isReadOnlySafeRawPathCommand(
   return command === "cp" && isCopyOutOfRawCommand(args, context);
 }
 
+function isInputOnlyRedirectCommand(command: string): boolean {
+  return command === "<" || command === "0<" || command.startsWith("<") || command.startsWith("0<");
+}
+
 function isReadOnlyAwkCommand(args: readonly ShellToken[]): boolean {
   return !args.some((arg) => {
     if (!arg.fullyQuoted && (arg.value === ">" || arg.value === ">>")) {
@@ -919,6 +981,46 @@ function isReadOnlyAwkCommand(args: readonly ShellToken[]): boolean {
     }
     return /(^|[^A-Za-z_])(?:system|close)\s*\(|>{1,2}/.test(arg.value);
   });
+}
+
+function findAwkScriptWriteTarget(
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
+  for (const script of findAwkScriptArguments(args)) {
+    const target = findFirstProtectedRawPathInText(script.value, context, {
+      allowRelativeFallback: false
+    });
+    if (!target) {
+      continue;
+    }
+    if (/(^|[^A-Za-z_])system\s*\(|>{1,2}/.test(script.value)) {
+      return target;
+    }
+  }
+
+  return undefined;
+}
+
+function findAwkScriptArguments(args: readonly ShellToken[]): ShellToken[] {
+  const scripts: ShellToken[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg.value === "-f" || arg.value === "-v") {
+      index += 1;
+      continue;
+    }
+    if (arg.value.startsWith("-f") || arg.value.startsWith("-v")) {
+      continue;
+    }
+    if (arg.value.startsWith("-")) {
+      continue;
+    }
+    scripts.push(arg);
+    break;
+  }
+
+  return scripts;
 }
 
 function isCopyOutOfRawCommand(
@@ -1098,6 +1200,61 @@ function isSedInPlaceOption(arg: ShellToken): boolean {
   );
 }
 
+function findSedScriptWriteTarget(
+  args: readonly ShellToken[],
+  context: PathEvaluationContext
+): string | undefined {
+  for (const script of findSedScriptArguments(args)) {
+    const target = findFirstProtectedRawPathInText(script.value, context, {
+      allowRelativeFallback: false
+    });
+    if (!target) {
+      continue;
+    }
+    if (/(^|[;{}\n])\s*(?:s\b|[A-Za-z0-9,$!\/\\^.*+ -])*w\s+/.test(script.value)) {
+      return target;
+    }
+  }
+
+  return undefined;
+}
+
+function findSedScriptArguments(args: readonly ShellToken[]): ShellToken[] {
+  const scripts: ShellToken[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg.value === "-e" || arg.value === "--expression") {
+      if (args[index + 1]) {
+        scripts.push(args[index + 1]);
+      }
+      index += 1;
+      continue;
+    }
+    if (arg.value.startsWith("--expression=")) {
+      scripts.push(pathCandidateToken(arg, arg.value.slice("--expression=".length)));
+      continue;
+    }
+    if (arg.value === "-f" || arg.value === "--file") {
+      index += 1;
+      continue;
+    }
+    if (arg.value.startsWith("--file=")) {
+      continue;
+    }
+    if (arg.value.startsWith("-")) {
+      continue;
+    }
+    scripts.push(arg);
+    break;
+  }
+
+  return scripts;
+}
+
+function pathCandidateToken(token: ShellToken, value: string): ShellToken {
+  return { ...token, value };
+}
+
 function findFindMutationTarget(
   args: readonly ShellToken[],
   context: PathEvaluationContext
@@ -1138,7 +1295,7 @@ function findGitCloneTarget(
 function protectedCurrentWorkingDirectoryTarget(
   context: PathEvaluationContext
 ): string | undefined {
-  return context.cwdKnown && context.cwd && isProtectedDataRawPathVariant(context.cwd)
+  return context.cwdKnown && context.cwd && isProtectedDataRawPath(context.cwd, context)
     ? context.cwd
     : undefined;
 }
@@ -1330,9 +1487,63 @@ function findEvalCommandTarget(
         variables: new Map(state.variables),
         cwd: context.cwd,
         cwdKnown: context.cwdKnown,
+        pathAliases: new Map(context.pathAliases),
         scanBudget: state.scanBudget
       })
     : undefined;
+}
+
+function findTrapCommandTarget(
+  args: readonly ShellToken[],
+  state: ShellScanState
+): string | undefined {
+  const action = args.find((arg) => !arg.value.startsWith("-"));
+  if (!action || action.value === "-") {
+    return undefined;
+  }
+
+  return findProtectedDataRawWriteTargetWithState(action.value, {
+    variables: new Map(state.variables),
+    cwd: state.cwd,
+    cwdKnown: state.cwdKnown,
+    pathAliases: new Map(state.pathAliases),
+    scanBudget: state.scanBudget
+  });
+}
+
+function findFindExecMutationTarget(
+  args: readonly ShellToken[],
+  state: ShellScanState
+): string | undefined {
+  for (let index = 0; index < args.length; index += 1) {
+    if (!["-exec", "-execdir", "-ok", "-okdir"].includes(args[index].value)) {
+      continue;
+    }
+
+    const endIndex = findFindExecTerminatorIndex(args, index + 1);
+    const execSegment = args.slice(index + 1, endIndex);
+    if (execSegment.length === 0) {
+      continue;
+    }
+
+    const target = findMutationCommandTarget(execSegment, state);
+    if (target) {
+      return target;
+    }
+    index = endIndex;
+  }
+
+  return undefined;
+}
+
+function findFindExecTerminatorIndex(args: readonly ShellToken[], startIndex: number): number {
+  for (let index = startIndex; index < args.length; index += 1) {
+    if (args[index].value === ";" || args[index].value === "+") {
+      return index;
+    }
+  }
+
+  return args.length;
 }
 
 function isExecutableCodeStringCommand(command: string): boolean {
@@ -1379,6 +1590,14 @@ function findExecutableCodeStringRawMutationTarget(
   }
 
   return undefined;
+}
+
+function hasExecutableCodeStringArgument(command: string, args: readonly ShellToken[]): boolean {
+  if (command.toLowerCase() === "deno" && args[0]?.value === "eval") {
+    return true;
+  }
+
+  return args.some((_arg, index) => findExecutableCodeStringAt(args, index) !== undefined);
 }
 
 function findDenoEvalRawMutationTarget(
@@ -1469,7 +1688,7 @@ function shellCommandInvocationAt(
 
   return {
     command,
-    positionalArgs: args.slice(commandIndex + 2)
+    positionalArgs: args.slice(commandIndex + 1)
   };
 }
 
@@ -1477,9 +1696,66 @@ function bindShellPositionalParameters(
   variables: Map<string, string>,
   positionalArgs: readonly ShellToken[]
 ): void {
-  for (let index = 0; index < positionalArgs.length; index += 1) {
-    variables.set(String(index + 1), positionalArgs[index].value);
+  for (const key of [...variables.keys()]) {
+    if (/^(?:[0-9]+|[@*])$/.test(key)) {
+      variables.delete(key);
+    }
   }
+
+  if (positionalArgs.length > 0) {
+    variables.set("0", positionalArgs[0].value);
+  }
+
+  const shellParameters = positionalArgs.slice(1);
+  for (let index = 0; index < shellParameters.length; index += 1) {
+    variables.set(String(index + 1), shellParameters[index].value);
+  }
+  const joinedParameters = shellParameters.map((arg) => arg.value).join(" ");
+  variables.set("@", joinedParameters);
+  variables.set("*", joinedParameters);
+}
+
+function findImplicitPositionalLoopWriteTarget(
+  command: string,
+  state: ShellScanState
+): string | undefined {
+  const positionalValues = knownShellPositionalValues(state.variables);
+  if (positionalValues.length === 0 || !/\bfor\s+[A-Za-z_][A-Za-z0-9_]*\s*;?\s*do\b/.test(command)) {
+    return undefined;
+  }
+
+  const loopPattern = /\bfor\s+([A-Za-z_][A-Za-z0-9_]*)\s*;?\s*do\b([\s\S]*?)\bdone\b/g;
+  let match: RegExpExecArray | null;
+  while ((match = loopPattern.exec(command)) !== null) {
+    const [, loopVariable, body] = match;
+    for (const positionalValue of positionalValues) {
+      const loopState: ShellScanState = {
+        variables: new Map(state.variables),
+        cwd: state.cwd,
+        cwdKnown: state.cwdKnown,
+        pathAliases: new Map(state.pathAliases),
+        scanBudget: state.scanBudget
+      };
+      loopState.variables.set(loopVariable, positionalValue);
+      const target = findProtectedDataRawWriteTargetWithState(body, loopState);
+      if (target) {
+        return target;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function knownShellPositionalValues(variables: ReadonlyMap<string, string>): string[] {
+  return [...variables.entries()]
+    .map(([key, value]) => {
+      const numericKey = /^[0-9]+$/.test(key) ? Number(key) : undefined;
+      return numericKey !== undefined && numericKey > 0 ? { index: numericKey, value } : undefined;
+    })
+    .filter((entry): entry is { index: number; value: string } => entry !== undefined)
+    .sort((left, right) => left.index - right.index)
+    .map((entry) => entry.value);
 }
 
 function findExecutableHeredocRawWriteTarget(
@@ -1599,6 +1875,7 @@ function findExecutableStdinRawWriteTarget(
       variables: new Map(commandState.variables),
       cwd: commandState.cwd,
       cwdKnown: commandState.cwdKnown,
+      pathAliases: new Map(commandState.pathAliases),
       scanBudget: commandState.scanBudget
     });
   }
@@ -1641,6 +1918,82 @@ function updateCwdFromCdSegment(segment: readonly ShellToken[], state: ShellScan
   applyCwdTargetToState(target, state);
 }
 
+function recordSymlinkAlias(segment: readonly ShellToken[], state: ShellScanState): void {
+  const commandState = buildSegmentCommandScanState(segment, state);
+  const { commandIndex } = commandState;
+  if (commandIndex === undefined) {
+    return;
+  }
+
+  const command = path.posix.basename(segment[commandIndex].value);
+  if (command !== "ln") {
+    return;
+  }
+
+  const alias = parseLnSymlinkAlias(segment.slice(commandIndex + 1), commandState);
+  if (!alias) {
+    return;
+  }
+
+  state.pathAliases.set(alias.linkPath, alias.targetPath);
+}
+
+function parseLnSymlinkAlias(
+  args: readonly ShellToken[],
+  state: Pick<ShellScanState, "cwd" | "cwdKnown">
+): { linkPath: string; targetPath: string } | undefined {
+  let symbolic = false;
+  const operands: ShellToken[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index].value;
+    if (arg === "--") {
+      operands.push(...args.slice(index + 1));
+      break;
+    }
+    if (arg === "-t" || arg === "--target-directory") {
+      return undefined;
+    }
+    if (arg.startsWith("--target-directory=")) {
+      return undefined;
+    }
+    if (arg === "-s" || arg === "--symbolic") {
+      symbolic = true;
+      continue;
+    }
+    if (arg.startsWith("-") && !arg.startsWith("--")) {
+      symbolic = symbolic || arg.slice(1).includes("s");
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      continue;
+    }
+    operands.push(args[index]);
+  }
+
+  if (!symbolic || operands.length !== 2) {
+    return undefined;
+  }
+
+  const [target, link] = operands;
+  if (!isSimpleLiteralPathValue(target.value) || !isSimpleLiteralPathValue(link.value)) {
+    return undefined;
+  }
+
+  const resolvedLink = resolveShellPathWithKnowledge(state.cwd, state.cwdKnown, link.value);
+  if (!resolvedLink.cwdKnown || !resolvedLink.cwd) {
+    return undefined;
+  }
+
+  const linkPath = path.resolve(resolvedLink.cwd);
+  const targetPath =
+    path.isAbsolute(target.value) || path.posix.isAbsolute(target.value)
+      ? path.resolve(target.value)
+      : path.resolve(path.dirname(linkPath), target.value);
+
+  return { linkPath, targetPath };
+}
+
 function isSimpleLiteralCdTarget(target: ShellToken): boolean {
   return isSimpleLiteralPathValue(target.value);
 }
@@ -1668,10 +2021,15 @@ function normalizeInitialCwd(workDir: string | undefined): string {
   return path.resolve(workDir ?? process.cwd());
 }
 
-function pathContextFromState(state: Pick<ShellScanState, "cwd" | "cwdKnown">): PathEvaluationContext {
+function pathContextFromState(
+  state: Pick<ShellScanState, "cwd" | "cwdKnown"> & {
+    pathAliases?: ReadonlyMap<string, string>;
+  }
+): PathEvaluationContext {
   return {
     cwd: state.cwd,
-    cwdKnown: state.cwdKnown
+    cwdKnown: state.cwdKnown,
+    pathAliases: state.pathAliases ?? EMPTY_PATH_ALIASES
   };
 }
 
@@ -1710,6 +2068,9 @@ function findExecutableCodeRawMutationTargetInText(
   const scanResult = findProtectedRawPathsInText(value, context, scanBudget);
   if (scanResult.exceeded && hasExecutableCodeWriteIntentMarker(value)) {
     return scanResult.targets[0] ?? "data/raw";
+  }
+  if (scanResult.targets.length > 0 && hasExecutableCodeWriteIntentMarker(value)) {
+    return scanResult.targets[0];
   }
 
   for (const target of scanResult.targets) {
@@ -1754,6 +2115,35 @@ function findProtectedRawPathsInText(
   return { targets, exceeded: false };
 }
 
+function findFirstProtectedRawPathInText(
+  value: string,
+  context: PathEvaluationContext,
+  options: { allowRelativeFallback?: boolean } = {}
+): string | undefined {
+  const rawPathPattern = /(?:file:\/\/)?[A-Za-z0-9_./@%:+-]*data\/raw(?:\/[A-Za-z0-9_./@%:+-]*)?/gi;
+  let match: RegExpExecArray | null;
+  while ((match = rawPathPattern.exec(value)) !== null) {
+    const candidate = match[0];
+    if (isProtectedDataRawPath(candidate, context)) {
+      return candidate;
+    }
+
+    if (options.allowRelativeFallback === false) {
+      continue;
+    }
+
+    const rawPathIndex = candidate.toLowerCase().indexOf("data/raw");
+    if (rawPathIndex !== -1) {
+      const relativeCandidate = candidate.slice(rawPathIndex);
+      if (isProtectedDataRawPath(relativeCandidate, context)) {
+        return relativeCandidate;
+      }
+    }
+  }
+
+  return undefined;
+}
+
 function reserveExecutableCodeScanBudget(
   value: string,
   scanBudget: ShellScanBudget
@@ -1771,11 +2161,24 @@ function hasProtectedRawPathText(value: string): boolean {
   return value.toLowerCase().includes("data/raw");
 }
 
+function hasShellWriteIntentMarker(value: string): boolean {
+  return (
+    /(?:^|[\s;&|(){}])(?:rm|touch|truncate|mkdir|rmdir|chmod|chown|mv|cp|install|ln|rsync|dd|tee|curl|wget|tar|unzip|git|sed|awk|find|eval|bash|sh|zsh|python|python\d+(?:\.\d+)?|node|bun|deno|r|rscript|ruby|php|perl)\b/i.test(
+      value
+    ) || /(?:^|\s)(?:>|>>|>\||1>|1>>|2>|2>>|&>|&>>|>&)\s*/.test(value)
+  );
+}
+
 function hasExecutableCodeWriteIntentMarker(value: string): boolean {
   return (
-    /\b(?:open|writeFile|writeFileSync|appendFile|appendFileSync|createWriteStream|unlink|unlinkSync|rm|rmSync|remove|removeSync|rename|renameSync|mkdir|mkdirSync|rmdir|rmdirSync|truncate|truncateSync|writeLines|write\.csv|write\.table|saveRDS|save)\s*\(/i.test(
+    /\bopen\s*\([^)]*(?:,\s*(?:mode\s*=\s*)?["'][^"']*[wax+][^"']*["']|\bmode\s*=\s*["'][^"']*[wax+][^"']*["']|["']>{1,2}["'])/i.test(
       value
-    ) || /\.write_(?:text|bytes)\s*\(/i.test(value)
+    ) ||
+    /\b(?:writeFile|writeFileSync|appendFile|appendFileSync|createWriteStream|unlink|unlinkSync|rm|rmSync|remove|removeSync|rename|renameSync|mkdir|mkdirSync|rmdir|rmdirSync|truncate|truncateSync|writeLines|write\.csv|write\.table|saveRDS|save|file_put_contents)\s*\(/i.test(
+      value
+    ) ||
+    /\b(?:Bun\.write|File\.write)\s*\(/i.test(value) ||
+    /\.write_(?:text|bytes)\s*\(/i.test(value)
   );
 }
 
@@ -1816,7 +2219,7 @@ function expandTokenParameterReferences(
     expandBracedParameterExpression(match, expression, variables)
   );
   const expandedValue = expandedBraces.replace(
-    /\$([A-Za-z_][A-Za-z0-9_]*|[0-9]+)/g,
+    /\$([A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*])/g,
     (match, variableName: string) => variables.get(variableName) ?? match
   );
 
@@ -1828,12 +2231,39 @@ function expandBracedParameterExpression(
   expression: string,
   variables: ReadonlyMap<string, string>
 ): string {
-  const simple = expression.match(/^([A-Za-z_][A-Za-z0-9_]*|[0-9]+)$/);
+  const simple = expression.match(/^([A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*])$/);
   if (simple) {
     return variables.get(simple[1]) ?? match;
   }
 
-  const slice = expression.match(/^([A-Za-z_][A-Za-z0-9_]*|[0-9]+):([0-9]+)(?::([0-9]+))?$/);
+  const prefixOrSuffixRemoval = expression.match(
+    /^([A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*])(#{1,2}|%{1,2})(.+)$/
+  );
+  if (prefixOrSuffixRemoval) {
+    const value = variables.get(prefixOrSuffixRemoval[1]);
+    return value === undefined
+      ? match
+      : applyShellParameterTrim(value, prefixOrSuffixRemoval[2], prefixOrSuffixRemoval[3]);
+  }
+
+  const substitution = expression.match(
+    /^([A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*])(\/{1,2})([^/]*)\/(.*)$/
+  );
+  if (substitution) {
+    const value = variables.get(substitution[1]);
+    return value === undefined
+      ? match
+      : applyShellParameterSubstitution(
+          value,
+          substitution[3],
+          substitution[4],
+          substitution[2] === "//"
+        );
+  }
+
+  const slice = expression.match(
+    /^([A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*]):([0-9]+)(?::([0-9]+))?$/
+  );
   if (!slice) {
     return match;
   }
@@ -1846,6 +2276,79 @@ function expandBracedParameterExpression(
   const start = Number(slice[2]);
   const length = slice[3] === undefined ? undefined : Number(slice[3]);
   return length === undefined ? value.slice(start) : value.slice(start, start + length);
+}
+
+function applyShellParameterTrim(value: string, operator: string, pattern: string): string {
+  if (operator.startsWith("#")) {
+    const indexes =
+      operator === "##"
+        ? Array.from({ length: value.length + 1 }, (_item, index) => value.length - index)
+        : Array.from({ length: value.length + 1 }, (_item, index) => index);
+    for (const index of indexes) {
+      if (shellPatternMatchesWholeValue(value.slice(0, index), pattern)) {
+        return value.slice(index);
+      }
+    }
+    return value;
+  }
+
+  const indexes =
+    operator === "%%"
+      ? Array.from({ length: value.length + 1 }, (_item, index) => index)
+      : Array.from({ length: value.length + 1 }, (_item, index) => value.length - index);
+  for (const index of indexes) {
+    if (shellPatternMatchesWholeValue(value.slice(index), pattern)) {
+      return value.slice(0, index);
+    }
+  }
+  return value;
+}
+
+function applyShellParameterSubstitution(
+  value: string,
+  pattern: string,
+  replacement: string,
+  global: boolean
+): string {
+  if (pattern.length === 0) {
+    return value;
+  }
+
+  const regex = shellPatternToRegExp(pattern, global ? "g" : undefined);
+  return regex ? value.replace(regex, replacement) : value.replace(pattern, replacement);
+}
+
+function shellPatternMatchesWholeValue(value: string, pattern: string): boolean {
+  const regex = shellPatternToRegExp(pattern, undefined, true);
+  return regex ? regex.test(value) : value === pattern;
+}
+
+function shellPatternToRegExp(
+  pattern: string,
+  flags?: string,
+  anchored = false
+): RegExp | undefined {
+  let source = "";
+  let changed = false;
+  for (const char of pattern) {
+    if (char === "*") {
+      source += "[\\s\\S]*";
+      changed = true;
+      continue;
+    }
+    if (char === "?") {
+      source += "[\\s\\S]";
+      changed = true;
+      continue;
+    }
+    source += escapeRegExp(char);
+  }
+
+  try {
+    return new RegExp(anchored ? `^${source}$` : source, flags);
+  } catch {
+    return changed ? /[\s\S]*/ : undefined;
+  }
 }
 
 function recordVariableAssignments(
@@ -1861,12 +2364,12 @@ function recordVariableAssignments(
   }
 
   const command = path.posix.basename(segment[commandIndex].value);
-  if (command !== "export") {
+  if (!ASSIGNMENT_BUILTIN_COMMANDS.has(command)) {
     return;
   }
 
   for (const arg of segment.slice(commandIndex + 1)) {
-    if (arg.value.startsWith("-")) {
+    if (arg.value === "--" || arg.value.startsWith("-")) {
       continue;
     }
     recordVariableAssignment(arg, variables);
@@ -1912,9 +2415,6 @@ function isProtectedDataRawCandidate(
   if (isProtectedDataRawPath(candidate.value, context)) {
     return true;
   }
-  if (isProtectedDataRawAlias(candidate.value, context)) {
-    return true;
-  }
   if (
     !candidate.fullyQuoted &&
     expandShellBraceAlternatives(candidate.value).some((expanded) =>
@@ -1927,43 +2427,9 @@ function isProtectedDataRawCandidate(
   return canUnresolvedShellPathResolveToProtectedRaw(candidate, context);
 }
 
-function isProtectedDataRawAlias(candidate: string, context: PathEvaluationContext): boolean {
-  const localCandidate = normalizeLocalPathCandidate(candidate);
-  if (!localCandidate || !context.cwdKnown) {
-    return false;
-  }
-
-  const absoluteCandidate =
-    context.cwd && isRelativeLocalPath(localCandidate)
-      ? path.resolve(context.cwd, localCandidate)
-      : path.resolve(localCandidate);
-  const resolvedCandidate = resolveExistingPathAlias(absoluteCandidate);
-  return resolvedCandidate ? isProtectedDataRawPathVariant(resolvedCandidate) : false;
-}
-
-function resolveExistingPathAlias(absoluteCandidate: string): string | undefined {
-  let existingPrefix = absoluteCandidate;
-  const suffixSegments: string[] = [];
-
-  while (!existsSync(existingPrefix)) {
-    const parent = path.dirname(existingPrefix);
-    if (parent === existingPrefix) {
-      return undefined;
-    }
-    suffixSegments.unshift(path.basename(existingPrefix));
-    existingPrefix = parent;
-  }
-
-  try {
-    return path.join(realpathSync(existingPrefix), ...suffixSegments);
-  } catch {
-    return undefined;
-  }
-}
-
 function isProtectedDataRawPath(
   candidate: string,
-  context: PathEvaluationContext = { cwdKnown: false }
+  context: PathEvaluationContext = { cwdKnown: false, pathAliases: EMPTY_PATH_ALIASES }
 ): boolean {
   return candidatePathVariants(candidate, context).some((variant) =>
     isProtectedDataRawPathVariant(variant)
@@ -1992,7 +2458,10 @@ function candidatePathVariants(
   }
 
   if (context.cwdKnown && context.cwd && isRelativeLocalPath(localCandidate)) {
-    return [path.resolve(context.cwd, localCandidate)];
+    return withDeterministicAliasVariants(
+      [path.resolve(context.cwd, localCandidate)],
+      context.pathAliases
+    );
   }
 
   const variants = [localCandidate];
@@ -2000,7 +2469,45 @@ function candidatePathVariants(
     variants.push(path.resolve(context.cwd, localCandidate));
   }
 
-  return variants;
+  return withDeterministicAliasVariants(variants, context.pathAliases);
+}
+
+function withDeterministicAliasVariants(
+  variants: readonly string[],
+  pathAliases: ReadonlyMap<string, string>
+): string[] {
+  const expanded = [...variants];
+  for (const variant of variants) {
+    expanded.push(...resolveDeterministicPathAliases(variant, pathAliases));
+  }
+  return expanded;
+}
+
+function resolveDeterministicPathAliases(
+  candidate: string,
+  pathAliases: ReadonlyMap<string, string>
+): string[] {
+  if (pathAliases.size === 0 || !path.isAbsolute(candidate)) {
+    return [];
+  }
+
+  const resolved: string[] = [];
+  const normalizedCandidate = path.resolve(candidate);
+  for (const [aliasPath, targetPath] of pathAliases) {
+    if (!isPathEqualOrInside(normalizedCandidate, aliasPath)) {
+      continue;
+    }
+
+    const suffix = path.relative(aliasPath, normalizedCandidate);
+    resolved.push(suffix ? path.resolve(targetPath, suffix) : targetPath);
+  }
+
+  return resolved;
+}
+
+function isPathEqualOrInside(candidatePath: string, containingPath: string): boolean {
+  const relativePath = path.relative(containingPath, candidatePath);
+  return relativePath.length === 0 || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
 }
 
 function normalizeLocalPathCandidate(candidate: string): string | undefined {
@@ -2535,6 +3042,7 @@ function findCommandSubstitutionWriteTarget(
         variables: new Map(state.variables),
         cwd: state.cwd,
         cwdKnown: state.cwdKnown,
+        pathAliases: new Map(state.pathAliases),
         scanBudget: state.scanBudget
       });
       if (target) {
@@ -2554,6 +3062,7 @@ function findCommandSubstitutionWriteTarget(
         variables: new Map(state.variables),
         cwd: state.cwd,
         cwdKnown: state.cwdKnown,
+        pathAliases: new Map(state.pathAliases),
         scanBudget: state.scanBudget
       });
       if (target) {
@@ -2573,6 +3082,7 @@ function findCommandSubstitutionWriteTarget(
         variables: new Map(state.variables),
         cwd: state.cwd,
         cwdKnown: state.cwdKnown,
+        pathAliases: new Map(state.pathAliases),
         scanBudget: state.scanBudget
       });
       if (target) {

--- a/packages/core/src/tools/data-raw-write-rule.ts
+++ b/packages/core/src/tools/data-raw-write-rule.ts
@@ -15,11 +15,13 @@ const ANY_RAW_PATH_MUTATION_COMMANDS = new Set([
   "mkdir",
   "rm",
   "rmdir",
-  "touch"
+  "touch",
+  "truncate"
 ]);
 const DESTINATION_RAW_PATH_COMMANDS = new Set(["cp", "install", "ln"]);
 const ANY_ENDPOINT_RAW_PATH_COMMANDS = new Set(["mv"]);
 const WRAPPER_COMMANDS = new Set(["command", "doas", "env", "nice", "nohup", "sudo", "time"]);
+const SHELL_COMMANDS = new Set(["bash", "sh", "zsh"]);
 
 export const DATA_RAW_WRITE_DENY_RULE: PolicyRule = {
   ruleId: DATA_RAW_WRITE_DENY_RULE_ID,
@@ -143,16 +145,23 @@ function findMutationCommandTarget(segment: readonly string[]): string | undefin
     return args.find(isProtectedDataRawPath);
   }
   if (DESTINATION_RAW_PATH_COMMANDS.has(command)) {
-    return lastNonOptionArgument(args);
+    return findDestinationRawPathTarget(args);
   }
   if (ANY_ENDPOINT_RAW_PATH_COMMANDS.has(command)) {
     return args.find(isProtectedDataRawPath);
+  }
+  if (command === "dd") {
+    return findDdOutputTarget(args);
   }
   if (command === "tee") {
     return args.find((arg) => !arg.startsWith("-") && isProtectedDataRawPath(arg));
   }
   if (command === "sed" && args.some((arg) => arg === "-i" || arg.startsWith("-i"))) {
     return args.find(isProtectedDataRawPath);
+  }
+  if (SHELL_COMMANDS.has(command)) {
+    const shellCommand = findShellCommandArgument(args);
+    return shellCommand ? findProtectedDataRawWriteTarget(shellCommand) : undefined;
   }
 
   return undefined;
@@ -185,6 +194,64 @@ function findCommandTokenIndex(segment: readonly string[]): number | undefined {
 function lastNonOptionArgument(args: readonly string[]): string | undefined {
   const target = args.filter((arg) => !arg.startsWith("-")).at(-1);
   return target && isProtectedDataRawPath(target) ? target : undefined;
+}
+
+function findDestinationRawPathTarget(args: readonly string[]): string | undefined {
+  const targetDirectory = findTargetDirectoryArgument(args);
+  if (targetDirectory !== undefined) {
+    return isProtectedDataRawPath(targetDirectory) ? targetDirectory : undefined;
+  }
+
+  return lastNonOptionArgument(args);
+}
+
+function findTargetDirectoryArgument(args: readonly string[]): string | undefined {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "-t" || arg === "--target-directory") {
+      return args[index + 1] ?? "";
+    }
+    if (arg.startsWith("--target-directory=")) {
+      return arg.slice("--target-directory=".length);
+    }
+    if (arg.startsWith("-t") && !arg.startsWith("--") && arg.length > 2) {
+      return arg.slice(2);
+    }
+  }
+
+  return undefined;
+}
+
+function findDdOutputTarget(args: readonly string[]): string | undefined {
+  for (const arg of args) {
+    if (!arg.startsWith("of=")) {
+      continue;
+    }
+
+    const target = arg.slice("of=".length);
+    if (isProtectedDataRawPath(target)) {
+      return target;
+    }
+  }
+
+  return undefined;
+}
+
+function findShellCommandArgument(args: readonly string[]): string | undefined {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") {
+      continue;
+    }
+    if (arg === "-c") {
+      return args[index + 1];
+    }
+    if (arg.startsWith("-") && !arg.startsWith("--") && arg.includes("c")) {
+      return args[index + 1];
+    }
+  }
+
+  return undefined;
 }
 
 function isAssignment(token: string): boolean {
@@ -239,6 +306,13 @@ function tokenizeShellCommand(command: string): string[] {
 
     if (char === "'" || char === `"`) {
       quote = char;
+      index += 1;
+      continue;
+    }
+
+    if (char === "\n" || char === "\r") {
+      flush();
+      tokens.push(";");
       index += 1;
       continue;
     }

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -9,4 +9,6 @@ export type CoreToolModule = (typeof CORE_TOOL_MODULES)[number];
 
 export * from "./policy-gate-core";
 export * from "./policy-gate-registry";
+export * from "./data-raw-write-rule";
+export * from "./policy-gate-audit";
 export * from "./zero-reference-shape";

--- a/packages/core/src/tools/policy-gate-audit.ts
+++ b/packages/core/src/tools/policy-gate-audit.ts
@@ -1,0 +1,58 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+
+export const DEFAULT_POLICY_GATE_AUDIT_TASK_ID = "TASK-M1-SPIKE" as const;
+export const DEFAULT_POLICY_GATE_AUDIT_FILE = "policy-gate-audit.ndjson" as const;
+
+export interface PolicyGateAuditRow {
+  event: string;
+  tool_id: string;
+  rule: string;
+  decision: "allow" | "deny";
+  ts: string;
+  guard_class?: string;
+}
+
+export interface AppendPolicyGateAuditRowOptions {
+  workspaceRoot?: string;
+  taskId?: string;
+  fileName?: string;
+  now?: () => string;
+}
+
+export interface AppendPolicyGateAuditRowResult {
+  auditDir: string;
+  auditPath: string;
+  row: PolicyGateAuditRow;
+}
+
+export async function appendPolicyGateAuditRow(
+  row: Omit<PolicyGateAuditRow, "ts"> & { ts?: string },
+  options: AppendPolicyGateAuditRowOptions = {}
+): Promise<AppendPolicyGateAuditRowResult> {
+  const resolvedRow: PolicyGateAuditRow = {
+    ...row,
+    ts: row.ts ?? options.now?.() ?? new Date().toISOString()
+  };
+  const auditDir = getPolicyGateAuditDir(options);
+  const auditPath = path.join(auditDir, options.fileName ?? DEFAULT_POLICY_GATE_AUDIT_FILE);
+
+  await mkdir(auditDir, { recursive: true });
+  await appendFile(auditPath, `${JSON.stringify(resolvedRow)}\n`, "utf8");
+
+  return {
+    auditDir,
+    auditPath,
+    row: resolvedRow
+  };
+}
+
+export function getPolicyGateAuditDir(options: AppendPolicyGateAuditRowOptions = {}): string {
+  return path.join(
+    options.workspaceRoot ?? process.cwd(),
+    "workspace",
+    "tasks",
+    options.taskId ?? DEFAULT_POLICY_GATE_AUDIT_TASK_ID,
+    "audit"
+  );
+}

--- a/packages/core/src/tools/policy-gate-audit.ts
+++ b/packages/core/src/tools/policy-gate-audit.ts
@@ -1,5 +1,6 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import path from "node:path";
+import type { PolicyGateDenyDecision } from "./policy-gate-core";
 
 export const DEFAULT_POLICY_GATE_AUDIT_TASK_ID = "TASK-M1-SPIKE" as const;
 export const DEFAULT_POLICY_GATE_AUDIT_FILE = "policy-gate-audit.ndjson" as const;
@@ -11,6 +12,7 @@ export interface PolicyGateAuditRow {
   decision: "allow" | "deny";
   ts: string;
   guard_class?: string;
+  remediation_ref?: string;
 }
 
 export interface AppendPolicyGateAuditRowOptions {
@@ -26,6 +28,13 @@ export interface AppendPolicyGateAuditRowResult {
   row: PolicyGateAuditRow;
 }
 
+export interface BuildPolicyGateAuditRowFromDeniedDecisionInput {
+  event?: string;
+  toolId: string;
+  decision: PolicyGateDenyDecision;
+  ts?: string;
+}
+
 export async function appendPolicyGateAuditRow(
   row: Omit<PolicyGateAuditRow, "ts"> & { ts?: string },
   options: AppendPolicyGateAuditRowOptions = {}
@@ -34,8 +43,7 @@ export async function appendPolicyGateAuditRow(
     ...row,
     ts: row.ts ?? options.now?.() ?? new Date().toISOString()
   };
-  const auditDir = getPolicyGateAuditDir(options);
-  const auditPath = path.join(auditDir, options.fileName ?? DEFAULT_POLICY_GATE_AUDIT_FILE);
+  const { auditDir, auditPath } = resolvePolicyGateAuditLocation(options);
 
   await mkdir(auditDir, { recursive: true });
   await appendFile(auditPath, `${JSON.stringify(resolvedRow)}\n`, "utf8");
@@ -48,11 +56,65 @@ export async function appendPolicyGateAuditRow(
 }
 
 export function getPolicyGateAuditDir(options: AppendPolicyGateAuditRowOptions = {}): string {
-  return path.join(
-    options.workspaceRoot ?? process.cwd(),
-    "workspace",
-    "tasks",
-    options.taskId ?? DEFAULT_POLICY_GATE_AUDIT_TASK_ID,
-    "audit"
+  return resolvePolicyGateAuditLocation(options).auditDir;
+}
+
+export function buildPolicyGateAuditRowFromDeniedDecision(
+  input: BuildPolicyGateAuditRowFromDeniedDecisionInput
+): Omit<PolicyGateAuditRow, "ts"> & { ts?: string } {
+  return {
+    event: input.event ?? "tool.failed",
+    tool_id: input.toolId,
+    rule: input.decision.ruleId,
+    decision: "deny",
+    ...(input.decision.guard_class ? { guard_class: input.decision.guard_class } : {}),
+    remediation_ref: input.decision.remediation.ref,
+    ...(input.ts ? { ts: input.ts } : {})
+  };
+}
+
+function resolvePolicyGateAuditLocation(options: AppendPolicyGateAuditRowOptions = {}): {
+  auditDir: string;
+  auditPath: string;
+} {
+  const workspaceRoot = path.resolve(options.workspaceRoot ?? process.cwd());
+  const taskId = validateAuditPathSegment(
+    "taskId",
+    options.taskId ?? DEFAULT_POLICY_GATE_AUDIT_TASK_ID
   );
+  const fileName = validateAuditPathSegment(
+    "fileName",
+    options.fileName ?? DEFAULT_POLICY_GATE_AUDIT_FILE
+  );
+  const auditDir = path.resolve(workspaceRoot, "workspace", "tasks", taskId, "audit");
+  const auditPath = path.resolve(auditDir, fileName);
+
+  if (!isPathInside(auditPath, auditDir)) {
+    throw new Error("Invalid policy gate audit fileName: must stay inside audit directory.");
+  }
+
+  return {
+    auditDir,
+    auditPath
+  };
+}
+
+function validateAuditPathSegment(field: "taskId" | "fileName", value: string): string {
+  if (
+    value.length === 0 ||
+    value === "." ||
+    value === ".." ||
+    value.includes("/") ||
+    value.includes("\\") ||
+    path.basename(value) !== value
+  ) {
+    throw new Error(`Invalid policy gate audit ${field}: must be a single path segment.`);
+  }
+
+  return value;
+}
+
+function isPathInside(candidatePath: string, containingDir: string): boolean {
+  const relativePath = path.relative(containingDir, candidatePath);
+  return relativePath.length === 0 || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
 }

--- a/packages/core/src/tools/policy-gate-audit.ts
+++ b/packages/core/src/tools/policy-gate-audit.ts
@@ -21,6 +21,7 @@ export interface AppendPolicyGateAuditRowOptions {
   taskId?: string;
   fileName?: string;
   now?: () => string;
+  beforeWriteForTest?: () => void | Promise<void>;
 }
 
 export interface AppendPolicyGateAuditRowResult {
@@ -49,7 +50,13 @@ export async function appendPolicyGateAuditRow(
   await assertAuditDirectoryCanBeCreatedInsideWorkspace(workspaceRoot, auditDir);
   await mkdir(auditDir, { recursive: true });
   await assertAuditLocationInsideWorkspace(workspaceRoot, auditDir, auditPath);
-  await appendPolicyGateAuditLineNoFollow(auditPath, `${JSON.stringify(resolvedRow)}\n`);
+  await appendPolicyGateAuditLineNoFollow(
+    workspaceRoot,
+    auditDir,
+    auditPath,
+    `${JSON.stringify(resolvedRow)}\n`,
+    options.beforeWriteForTest
+  );
 
   return {
     auditDir,
@@ -173,8 +180,11 @@ async function assertAuditLocationInsideWorkspace(
 }
 
 async function appendPolicyGateAuditLineNoFollow(
+  workspaceRoot: string,
+  auditDir: string,
   auditPath: string,
-  line: string
+  line: string,
+  beforeWriteForTest?: () => void | Promise<void>
 ): Promise<void> {
   const noFollowFlag =
     typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
@@ -189,6 +199,8 @@ async function appendPolicyGateAuditLineNoFollow(
       }
     }
     fileHandle = await open(auditPath, flags, 0o600);
+    await beforeWriteForTest?.();
+    await assertOpenedAuditFileStillInsideWorkspace(workspaceRoot, auditDir, auditPath, fileHandle);
     await fileHandle.writeFile(line, "utf8");
   } catch (error) {
     if (isSymlinkOpenError(error)) {
@@ -197,6 +209,30 @@ async function appendPolicyGateAuditLineNoFollow(
     throw error;
   } finally {
     await fileHandle?.close();
+  }
+}
+
+async function assertOpenedAuditFileStillInsideWorkspace(
+  workspaceRoot: string,
+  auditDir: string,
+  auditPath: string,
+  fileHandle: Awaited<ReturnType<typeof open>>
+): Promise<void> {
+  const realWorkspaceRoot = await realpath(workspaceRoot);
+  const realAuditDir = await realpath(auditDir);
+  if (!isPathInside(realAuditDir, realWorkspaceRoot)) {
+    throw new Error("Invalid policy gate audit directory: resolves outside workspace.");
+  }
+
+  const realAuditPath = await realpath(auditPath);
+  if (!isPathInside(realAuditPath, realAuditDir)) {
+    throw new Error("Invalid policy gate audit fileName: resolves outside audit directory.");
+  }
+
+  const openedFile = await fileHandle.stat();
+  const currentPath = await lstat(auditPath);
+  if (!isSameFilesystemEntry(openedFile, currentPath)) {
+    throw new Error("Invalid policy gate audit fileName: changed before audit write.");
   }
 }
 
@@ -209,6 +245,13 @@ async function lstatIfExists(filePath: string) {
     }
     throw error;
   }
+}
+
+function isSameFilesystemEntry(
+  left: Awaited<ReturnType<Awaited<ReturnType<typeof open>>["stat"]>>,
+  right: Awaited<ReturnType<typeof lstat>>
+): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
 }
 
 function isSymlinkOpenError(error: unknown): boolean {

--- a/packages/core/src/tools/policy-gate-audit.ts
+++ b/packages/core/src/tools/policy-gate-audit.ts
@@ -154,6 +154,9 @@ async function assertAuditDirectoryCanBeCreatedInsideWorkspace(
     if (!isPathInside(realCurrentPath, realWorkspaceRoot)) {
       throw new Error("Invalid policy gate audit directory: resolves outside workspace.");
     }
+    if (existingPath.isSymbolicLink()) {
+      throw new Error("Invalid policy gate audit directory: must not be a symlink.");
+    }
   }
 }
 
@@ -166,6 +169,10 @@ async function assertAuditLocationInsideWorkspace(
   const realAuditDir = await realpath(auditDir);
   if (!isPathInside(realAuditDir, realWorkspaceRoot)) {
     throw new Error("Invalid policy gate audit directory: resolves outside workspace.");
+  }
+  const auditDirPath = await lstat(auditDir);
+  if (auditDirPath.isSymbolicLink()) {
+    throw new Error("Invalid policy gate audit directory: must not be a symlink.");
   }
 
   const existingAuditPath = await lstatIfExists(auditPath);
@@ -231,6 +238,10 @@ async function assertOpenedAuditFileStillInsideWorkspace(
   const realAuditDir = await realpath(auditDir);
   if (!isPathInside(realAuditDir, realWorkspaceRoot)) {
     throw new Error("Invalid policy gate audit directory: resolves outside workspace.");
+  }
+  const auditDirPath = await lstat(auditDir);
+  if (auditDirPath.isSymbolicLink()) {
+    throw new Error("Invalid policy gate audit directory: must not be a symlink.");
   }
 
   const realAuditPath = await realpath(auditPath);

--- a/packages/core/src/tools/policy-gate-audit.ts
+++ b/packages/core/src/tools/policy-gate-audit.ts
@@ -182,6 +182,9 @@ async function assertAuditLocationInsideWorkspace(
   if (!existingAuditPath.isSymbolicLink() && !existingAuditPath.isFile()) {
     throw new Error("Invalid policy gate audit fileName: must be a regular file.");
   }
+  if (existingAuditPath.nlink > 1) {
+    throw new Error("Invalid policy gate audit fileName: must not be a hardlink.");
+  }
 
   const realAuditPath = await realpath(auditPath);
   if (!isPathInside(realAuditPath, realAuditDir)) {
@@ -253,6 +256,9 @@ async function assertOpenedAuditFileStillInsideWorkspace(
   const currentPath = await lstat(auditPath);
   if (!openedFile.isFile() || !currentPath.isFile()) {
     throw new Error("Invalid policy gate audit fileName: must be a regular file.");
+  }
+  if (openedFile.nlink > 1 || currentPath.nlink > 1) {
+    throw new Error("Invalid policy gate audit fileName: must not be a hardlink.");
   }
   if (!isSameFilesystemEntry(openedFile, currentPath)) {
     throw new Error("Invalid policy gate audit fileName: changed before audit write.");

--- a/packages/core/src/tools/policy-gate-audit.ts
+++ b/packages/core/src/tools/policy-gate-audit.ts
@@ -1,4 +1,5 @@
-import { appendFile, mkdir } from "node:fs/promises";
+import { constants } from "node:fs";
+import { lstat, mkdir, open, realpath } from "node:fs/promises";
 import path from "node:path";
 import type { PolicyGateDenyDecision } from "./policy-gate-core";
 
@@ -43,10 +44,12 @@ export async function appendPolicyGateAuditRow(
     ...row,
     ts: row.ts ?? options.now?.() ?? new Date().toISOString()
   };
-  const { auditDir, auditPath } = resolvePolicyGateAuditLocation(options);
+  const { workspaceRoot, auditDir, auditPath } = resolvePolicyGateAuditLocation(options);
 
+  await assertAuditDirectoryCanBeCreatedInsideWorkspace(workspaceRoot, auditDir);
   await mkdir(auditDir, { recursive: true });
-  await appendFile(auditPath, `${JSON.stringify(resolvedRow)}\n`, "utf8");
+  await assertAuditLocationInsideWorkspace(workspaceRoot, auditDir, auditPath);
+  await appendPolicyGateAuditLineNoFollow(auditPath, `${JSON.stringify(resolvedRow)}\n`);
 
   return {
     auditDir,
@@ -74,6 +77,7 @@ export function buildPolicyGateAuditRowFromDeniedDecision(
 }
 
 function resolvePolicyGateAuditLocation(options: AppendPolicyGateAuditRowOptions = {}): {
+  workspaceRoot: string;
   auditDir: string;
   auditPath: string;
 } {
@@ -94,6 +98,7 @@ function resolvePolicyGateAuditLocation(options: AppendPolicyGateAuditRowOptions
   }
 
   return {
+    workspaceRoot,
     auditDir,
     auditPath
   };
@@ -117,4 +122,110 @@ function validateAuditPathSegment(field: "taskId" | "fileName", value: string): 
 function isPathInside(candidatePath: string, containingDir: string): boolean {
   const relativePath = path.relative(containingDir, candidatePath);
   return relativePath.length === 0 || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
+}
+
+async function assertAuditDirectoryCanBeCreatedInsideWorkspace(
+  workspaceRoot: string,
+  auditDir: string
+): Promise<void> {
+  const realWorkspaceRoot = await realpath(workspaceRoot);
+  const relativeAuditDir = path.relative(workspaceRoot, auditDir);
+  let currentPath = workspaceRoot;
+
+  for (const segment of relativeAuditDir.split(path.sep)) {
+    if (!segment) {
+      continue;
+    }
+
+    currentPath = path.join(currentPath, segment);
+    const existingPath = await lstatIfExists(currentPath);
+    if (!existingPath) {
+      break;
+    }
+
+    const realCurrentPath = await realpath(currentPath);
+    if (!isPathInside(realCurrentPath, realWorkspaceRoot)) {
+      throw new Error("Invalid policy gate audit directory: resolves outside workspace.");
+    }
+  }
+}
+
+async function assertAuditLocationInsideWorkspace(
+  workspaceRoot: string,
+  auditDir: string,
+  auditPath: string
+): Promise<void> {
+  const realWorkspaceRoot = await realpath(workspaceRoot);
+  const realAuditDir = await realpath(auditDir);
+  if (!isPathInside(realAuditDir, realWorkspaceRoot)) {
+    throw new Error("Invalid policy gate audit directory: resolves outside workspace.");
+  }
+
+  const existingAuditPath = await lstatIfExists(auditPath);
+  if (!existingAuditPath) {
+    return;
+  }
+
+  const realAuditPath = await realpath(auditPath);
+  if (!isPathInside(realAuditPath, realAuditDir)) {
+    throw new Error("Invalid policy gate audit fileName: resolves outside audit directory.");
+  }
+}
+
+async function appendPolicyGateAuditLineNoFollow(
+  auditPath: string,
+  line: string
+): Promise<void> {
+  const noFollowFlag =
+    typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+  const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_APPEND | noFollowFlag;
+  let fileHandle: Awaited<ReturnType<typeof open>> | undefined;
+
+  try {
+    if (noFollowFlag === 0) {
+      const existingAuditPath = await lstatIfExists(auditPath);
+      if (existingAuditPath?.isSymbolicLink()) {
+        throw new Error("Invalid policy gate audit fileName: must not be a symlink.");
+      }
+    }
+    fileHandle = await open(auditPath, flags, 0o600);
+    await fileHandle.writeFile(line, "utf8");
+  } catch (error) {
+    if (isSymlinkOpenError(error)) {
+      throw new Error("Invalid policy gate audit fileName: must not be a symlink.");
+    }
+    throw error;
+  } finally {
+    await fileHandle?.close();
+  }
+}
+
+async function lstatIfExists(filePath: string) {
+  try {
+    return await lstat(filePath);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function isSymlinkOpenError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    ((error as { code?: unknown }).code === "ELOOP" ||
+      (error as { code?: unknown }).code === "EMLINK")
+  );
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENOENT"
+  );
 }

--- a/packages/core/src/tools/policy-gate-audit.ts
+++ b/packages/core/src/tools/policy-gate-audit.ts
@@ -172,6 +172,9 @@ async function assertAuditLocationInsideWorkspace(
   if (!existingAuditPath) {
     return;
   }
+  if (!existingAuditPath.isSymbolicLink() && !existingAuditPath.isFile()) {
+    throw new Error("Invalid policy gate audit fileName: must be a regular file.");
+  }
 
   const realAuditPath = await realpath(auditPath);
   if (!isPathInside(realAuditPath, realAuditDir)) {
@@ -188,7 +191,10 @@ async function appendPolicyGateAuditLineNoFollow(
 ): Promise<void> {
   const noFollowFlag =
     typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
-  const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_APPEND | noFollowFlag;
+  const nonBlockingFlag =
+    typeof constants.O_NONBLOCK === "number" ? constants.O_NONBLOCK : 0;
+  const flags =
+    constants.O_WRONLY | constants.O_CREAT | constants.O_APPEND | noFollowFlag | nonBlockingFlag;
   let fileHandle: Awaited<ReturnType<typeof open>> | undefined;
 
   try {
@@ -205,6 +211,9 @@ async function appendPolicyGateAuditLineNoFollow(
   } catch (error) {
     if (isSymlinkOpenError(error)) {
       throw new Error("Invalid policy gate audit fileName: must not be a symlink.");
+    }
+    if (isSpecialFileOpenError(error)) {
+      throw new Error("Invalid policy gate audit fileName: must be a regular file.");
     }
     throw error;
   } finally {
@@ -231,6 +240,9 @@ async function assertOpenedAuditFileStillInsideWorkspace(
 
   const openedFile = await fileHandle.stat();
   const currentPath = await lstat(auditPath);
+  if (!openedFile.isFile() || !currentPath.isFile()) {
+    throw new Error("Invalid policy gate audit fileName: must be a regular file.");
+  }
   if (!isSameFilesystemEntry(openedFile, currentPath)) {
     throw new Error("Invalid policy gate audit fileName: changed before audit write.");
   }
@@ -261,6 +273,15 @@ function isSymlinkOpenError(error: unknown): boolean {
     "code" in error &&
     ((error as { code?: unknown }).code === "ELOOP" ||
       (error as { code?: unknown }).code === "EMLINK")
+  );
+}
+
+function isSpecialFileOpenError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENXIO"
   );
 }
 

--- a/packages/core/src/tools/policy-gate-core.ts
+++ b/packages/core/src/tools/policy-gate-core.ts
@@ -44,6 +44,8 @@ export type PolicyGateDecision =
       remediation: PolicyGateRemediation;
     };
 
+export type PolicyGateDenyDecision = Extract<PolicyGateDecision, { decision: "deny" }>;
+
 export interface PolicyRule {
   ruleId: string;
   guard_class?: GuardClass;

--- a/packages/core/src/tools/policy-gate-core.ts
+++ b/packages/core/src/tools/policy-gate-core.ts
@@ -3,6 +3,9 @@ import { RemediationNextActionSchema } from "../domain/schemas";
 
 export type HarnessRole = "coordinator" | "repo_explorer" | "worker" | "coder" | "reviewer";
 
+export const GuardClassSchema = z.enum(["authority", "capability"]);
+export type GuardClass = z.infer<typeof GuardClassSchema>;
+
 // Policy-gate denials require a navigable ref, even though generic ErrorRecord.ref is optional.
 export const PolicyGateRemediationSchema = z.object({
   next_action: RemediationNextActionSchema,
@@ -36,12 +39,14 @@ export type PolicyGateDecision =
   | {
       decision: "deny";
       ruleId: string;
+      guard_class?: GuardClass;
       reason: string;
       remediation: PolicyGateRemediation;
     };
 
 export interface PolicyRule {
   ruleId: string;
+  guard_class?: GuardClass;
   description: string;
   evaluate(call: PolicyGateToolCall, context: PolicyGateContext): PolicyRuleDecision;
 }
@@ -65,9 +70,11 @@ export function evaluatePolicyGate(
     }
 
     validatePolicyGateRemediation(rule.ruleId, result.remediation);
+    validateGuardClassMarker(rule.ruleId, rule.guard_class);
     return {
       decision: "deny",
       ruleId: rule.ruleId,
+      ...(rule.guard_class ? { guard_class: rule.guard_class } : {}),
       reason: result.reason,
       remediation: result.remediation
     };
@@ -88,4 +95,17 @@ function validatePolicyGateRemediation(ruleId: string, remediation: PolicyGateRe
     .join(", ");
 
   throw new Error(`Invalid policy gate remediation for ${ruleId}: ${fieldPaths || "remediation"}`);
+}
+
+function validateGuardClassMarker(ruleId: string, guardClass: GuardClass | undefined): void {
+  if (guardClass === undefined) {
+    return;
+  }
+
+  const parsed = GuardClassSchema.safeParse(guardClass);
+  if (parsed.success) {
+    return;
+  }
+
+  throw new Error(`Invalid policy gate guard_class for ${ruleId}: ${guardClass}`);
 }

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -41,7 +41,7 @@ describe("policy-gated zero tool registry", () => {
     expect(result?.output).toContain("policy_gate_denied");
     expect(result?.output).toContain("raw data writes are blocked");
     const payload = JSON.parse(result?.output ?? "{}") as {
-      ruleId?: string;
+      rule_id?: string;
       reason?: string;
       remediation?: {
         next_action?: string;
@@ -49,7 +49,7 @@ describe("policy-gated zero tool registry", () => {
         ref?: string;
       };
     };
-    expect(payload.ruleId).toBe("raw-data-write");
+    expect(payload.rule_id).toBe("raw-data-write");
     expect(payload.reason).toBe("raw data writes are blocked");
     expect(payload.remediation?.next_action).toBe("adjust_scope");
     expect(payload.remediation?.hint).toBe("Use a governed workspace path instead of data/raw.");

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -2,16 +2,21 @@ import { BaseTool, ToolRegistry } from "@zero-os/core";
 import type { ToolContext, ToolDefinition, ToolResult } from "@zero-os/shared";
 import {
   evaluatePolicyGate,
+  type GuardClass,
   type HarnessRole,
   type PolicyGateContext,
   type PolicyGateDecision,
+  type PolicyGateDenyDecision,
+  type PolicyGateRemediation,
   type PolicyGateToolCall
 } from "./policy-gate-core";
 
 export type {
   HarnessRole,
+  GuardClass,
   PolicyGateContext,
   PolicyGateDecision,
+  PolicyGateDenyDecision,
   PolicyGateRemediation,
   PolicyGateToolCall,
   PolicyRule,
@@ -32,6 +37,15 @@ export interface PolicyGateWrapperOptions {
   toolId?: string;
   role?: HarnessRole;
   evaluate: PolicyGateEvaluator;
+}
+
+export interface PolicyGateDeniedToolPayload {
+  error: "policy_gate_denied";
+  tool_id: string;
+  reason: string;
+  rule_id: string;
+  guard_class?: GuardClass;
+  remediation: PolicyGateRemediation;
 }
 
 export type PolicyGatedTool = BaseTool & {
@@ -161,21 +175,28 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
 
 function buildPolicyGateDeniedResult(
   toolId: string,
-  decision: Extract<PolicyGateDecision, { decision: "deny" }>
+  decision: PolicyGateDenyDecision
 ): ToolResult {
-  const payload = {
-    error: "policy_gate_denied",
-    tool_id: toolId,
-    reason: decision.reason,
-    rule_id: decision.ruleId,
-    ...(decision.guard_class ? { guard_class: decision.guard_class } : {}),
-    ...(decision.remediation ? { remediation: decision.remediation } : {})
-  };
+  const payload = buildPolicyGateDeniedToolPayload(toolId, decision);
 
   return {
     success: false,
     output: JSON.stringify(payload),
     outputSummary: `Policy gate denied ${toolId}: ${decision.reason}`
+  };
+}
+
+export function buildPolicyGateDeniedToolPayload(
+  toolId: string,
+  decision: PolicyGateDenyDecision
+): PolicyGateDeniedToolPayload {
+  return {
+    error: "policy_gate_denied",
+    tool_id: toolId,
+    reason: decision.reason,
+    rule_id: decision.ruleId,
+    ...(decision.guard_class ? { guard_class: decision.guard_class } : {}),
+    remediation: decision.remediation
   };
 }
 

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -167,7 +167,8 @@ function buildPolicyGateDeniedResult(
     error: "policy_gate_denied",
     tool_id: toolId,
     reason: decision.reason,
-    ...(decision.ruleId ? { ruleId: decision.ruleId } : {}),
+    rule_id: decision.ruleId,
+    ...(decision.guard_class ? { guard_class: decision.guard_class } : {}),
     ...(decision.remediation ? { remediation: decision.remediation } : {})
   };
 


### PR DESCRIPTION
## Status

Blocked by final agent review. Do not merge at the current head.

Tracks #19.

## Summary

- Add the `data/raw/**` bash write-denial policy rule with `guard_class=authority`.
- Add focused audit row append support for the M1 spike fixture path.
- Add a minimal `tool.failed` WebSocket event builder carrying an ErrorRecord-shaped payload with remediation.
- Extend policy-gate tests to cover pre-execution denial, remediation fields, WS envelope, audit row, and read-only allow behavior.

## Validation

- `/Users/danker/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/pnpm --package=bun@1.2.19 dlx bun run check`
- `openspec validate m1-foundation --strict --no-interactive`
- `git diff --check`
- `git -C zero diff --quiet && git -C zero rev-parse --short HEAD`

## Agent Review

Latest reviewed head: `4074cf423796f35dce3b38f906d707de2a7161f3`

Final comprehensive review + independent verifier gate is NOT clean.

Confirmed merge-blocking groups:
- executable/interpreter payload writes
- pipeline/stdin/dataflow execution
- dynamic write-target operands and curl/wget traversal
- shell dynamic state, scan budget, and dynamic symlink creation
- pre-existing symlink/hardlink/workDir alias boundary
- raw-read compatibility / fail-closed false positives

Conclusion: PR #46 is useful spike evidence, but the current pure static scanner strategy cannot satisfy the #19 invariant. Continue only after policy gate enforcement boundary is revisited in ADR/OpenSpec.
