### PR TITLE
M1-3.5: record policy gate spike revisit

### DIFF
--- a/docs/adr/0001-agent-runtime-and-topology.md
+++ b/docs/adr/0001-agent-runtime-and-topology.md
@@ -4,7 +4,8 @@ status: accepted
 
 # ADR-0001: Agent 运行时基座与拓扑（Zero + 单 Coordinator 星型）
 
-**状态**: accepted（2026-07-02） · **决策人**: PI + 工程师 · **方法**: future-aware-architecture 分析
+**状态**: accepted（2026-07-02） · **执行状态**: Trial，M1 spike 触发 revisit（2026-07-04）
+· **决策人**: PI + 工程师 · **方法**: future-aware-architecture 分析
 **事实基线**: zero@13e25c1（development 分支）· SHUD-Harness v0.8.3（97 篇 spec，零代码）
 
 ## 背景
@@ -69,6 +70,34 @@ status: accepted
 > （第三方 OpenAI 兼容端点）后，触发器 1/2 命中时"Claude Agent SDK (TS) 迁移"作为首选备胎的前提
 > （Anthropic 生态运行时）不再成立。备选评估顺序改为：① **自建薄工具注册层**（provider 无关，
 > 保留 Zero 其余复用面）；② Claude Agent SDK 迁移（仅当运行时模型回到 Anthropic 生态时才是候选）。
+
+## Revisit 记录
+
+### 2026-07-04: 触发器 1 命中（M1 policy-gate spike）
+
+判定：Zero 基座不转正，保持 Trial；M1 后续策略门任务暂停到 enforcement boundary 重审完成。
+
+证据：
+- spike 条 1（工具注册层横切包装）已由 issue [#17](https://github.com/DankerMu/SHUD-Harness/issues/17)
+  / PR [#43](https://github.com/DankerMu/SHUD-Harness/pull/43) 验证通过。
+- spike 条 4（策略门纯函数核心）已由 issue [#18](https://github.com/DankerMu/SHUD-Harness/issues/18)
+  / PR [#45](https://github.com/DankerMu/SHUD-Harness/pull/45) 验证通过。
+- spike 条 2（`data/raw/**` 写禁区）在 issue [#19](https://github.com/DankerMu/SHUD-Harness/issues/19)
+  / PR [#46](https://github.com/DankerMu/SHUD-Harness/pull/46) 中产生实现证据，但最终 comprehensive review
+  + independent verifier gate 确认仍有 merge-blocking 问题。失败类别覆盖 executable payload writes、
+  pipeline/stdin dataflow、dynamic write target、shell dynamic state、pre-existing filesystem alias，以及 raw-read
+  compatibility false positives。
+- spike 条 3（spawn 剖面超集拒绝，issue [#20](https://github.com/DankerMu/SHUD-Harness/issues/20)）未作为失败源执行；
+  因条 2 已触发不绿分支而停止。
+- spike 条 5 的确定性检查仍成立：`zero/` 无源码 diff，HEAD 保持 `13e25c1`；但五条全绿条件不满足。
+
+结论：当前纯 pre-exec static scanner 不能同时满足"任意 bash 写入 `data/raw/**` 前置拒绝"、
+"合法 raw 读取兼容"和"不实现 full shell parser"三项约束。#19 的当前 PR 仅作为 spike 证据保留，
+不得按 authority implementation 合并。
+
+下一步按 2026-07-02 修订注顺序评估：① 自建薄工具注册/执行边界，保留 Zero 可复用面，但把 raw-data
+写保护放到可观测真实目标路径的执行层或 OS sandbox/read-only mount；② Claude Agent SDK 迁移仅在运行时模型
+回到 Anthropic 生态时重新成为候选。
 
 ## 参照
 

--- a/openspec/changes/m1-foundation/policy-gate-spike-verdict.md
+++ b/openspec/changes/m1-foundation/policy-gate-spike-verdict.md
@@ -1,0 +1,38 @@
+# M1 Policy Gate Spike Verdict
+
+Date: 2026-07-04
+
+Issue: [#21](https://github.com/DankerMu/SHUD-Harness/issues/21)
+
+## Verdict
+
+The M1 policy-gate spike is not green. ADR-0001 trigger 1 is active, and the Zero runtime basis remains Trial rather than promoted.
+
+Reason: spike item 2, the `data/raw/**` bash write-denial rule, produced useful implementation evidence in PR [#46](https://github.com/DankerMu/SHUD-Harness/pull/46), but the final comprehensive review and independent verifier gate confirmed merge-blocking gaps. The failure class is not an isolated command-pattern miss. A pure pre-execution static scanner cannot satisfy arbitrary bash write denial while preserving required raw-read compatibility and without implementing a full shell interpreter.
+
+Immediate effect:
+- PR #46 remains draft and must not merge at head `4074cf423796f35dce3b38f906d707de2a7161f3`.
+- Stop policy-gate-dependent 3.x/5.x follow-up work until the enforcement boundary is revisited.
+- Treat the current #19 implementation as spike evidence, not as the M1 authority implementation.
+
+Non-policy M1 work may continue only when its dependency path does not rely on the unresolved policy-gate enforcement boundary.
+
+## Spike Evidence Matrix
+
+| Spike item | Issue / PR evidence | Status | Notes |
+| --- | --- | --- | --- |
+| 1. Tool-registration cross-cutting wrapper | [#17](https://github.com/DankerMu/SHUD-Harness/issues/17), merged PR [#43](https://github.com/DankerMu/SHUD-Harness/pull/43) | Green | Wrapper seam landed; Zero reference shape recorded as root Bun workspace inclusion of `zero/packages/*`; zero source remained clean. |
+| 2. `data/raw/**` governance rule E2E | [#19](https://github.com/DankerMu/SHUD-Harness/issues/19), draft PR [#46](https://github.com/DankerMu/SHUD-Harness/pull/46) | Not green | Local tests passed, but final reviewer/verifier gate confirmed F1-F6 merge blockers: executable payload writes, stdin/pipeline dataflow, dynamic write targets, shell dynamic state, filesystem aliases, and read compatibility false positives. |
+| 3. Spawn profile superset rejection | [#20](https://github.com/DankerMu/SHUD-Harness/issues/20) | Stopped | Not evaluated as a failure source. It depends on the policy-gate path and should not be implemented while item 2 has already triggered ADR-0001 revisit. |
+| 4. Pure policy-gate function + independent tests | [#18](https://github.com/DankerMu/SHUD-Harness/issues/18), merged PR [#45](https://github.com/DankerMu/SHUD-Harness/pull/45) | Green | Pure evaluator and remediation shape landed; concrete governance rules remain separate. |
+| 5. Zero source clean and pinned | Local check in #21 branch | Green as a deterministic check | `git -C zero diff --quiet` passes and `git -C zero rev-parse HEAD` remains `13e25c116c62411e6ee8a0ad67a6c53dc7c376c6`; overall spike still fails because item 2 is not green. |
+
+## Revisit Memo
+
+The current failure activates the ADR-0001 2026-07-02 fallback order.
+
+Preferred option to evaluate first: keep Zero's reusable packages and Web/runtime surface, but replace the current pure static bash write scanner as the authority boundary. The likely replacement is a thin SHUD-owned tool execution boundary around BashTool that can enforce protected raw-data writes by canonical path/inode checks or OS-level sandbox/read-only mount semantics. Under that shape, static preflight remains useful for early UX, remediation, and audit hints, but it is no longer the sole authority for arbitrary shell writes.
+
+Second option: evaluate Claude Agent SDK migration only if the runtime-model and provider assumptions return to an Anthropic-centered stack. ADR-0002 D9 currently makes this the secondary option rather than the first fallback.
+
+Rejected continuation path: keep adding static command patterns until review stops finding bypasses. The final #19 gate showed the same invariant family across executable payloads, dynamic shell state, pipelines, and filesystem aliases; continuing that loop would violate the "do not carry a not-green spike forward" rule.

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -22,11 +22,15 @@
 
 ## 3. 策略门 spike（policy-gate-spike）——ADR-0001 触发器 1
 
+> 判定（2026-07-04，#21）：spike 条 2（#19 / PR #46）最终 review+verifier gate 不绿，已触发 ADR-0001 revisit。
+> Zero 保持 Trial；#19 当前实现保留为 spike 证据，不 merge。策略门依赖的 3.x/5.x 后续任务暂停到 enforcement boundary 重审完成。
+> 逐条证据见 `policy-gate-spike-verdict.md`。
+
 - [ ] 3.1 spike 条 1：工具注册层横切包装（`ToolBase.beforeExecute` 包装/注册期 wrap；未包装工具装配失败负例；Zero 内核零改动）+ zero 引用技术形态定形（嵌套 Bun workspace 解析实测：workspace 纳入 vs `file:` 依赖 vs 运行时入口加载，实测结论回写 design.md Decision 3；验收含「Decision 3 已回写」）——依赖: 2.1
 - [ ] 3.2 spike 条 4：策略门纯函数核心（ToolCall → allow/deny + reason + remediation）+ 独立单测（正负例 + remediation 载荷断言）——依赖: 4.1（ErrorRecord.remediation 枚举）
 - [ ] 3.3 spike 条 2：`data/raw/**` 写禁区端到端穿透（bash 执行前拒 + remediation 三字段 + WS 复用注册表事件 `tool.failed` 推送（envelope 含 seq/event_id）+ audit 最小行落盘（event/tool_id/rule/decision/ts，路径与 fixture 任务见 policy-gate-spike spec））——依赖: 4.1
 - [ ] 3.4 spike 条 3：spawn 剖面超集拒绝负例（比对基准 = 5.1 映射表；断言 `remediation.next_action=adjust_scope`）——依赖: 5.1
-- [ ] 3.5 spike 条 5 核验 + 判定记录（`git -C zero diff --quiet` && HEAD=13e25c1；五条全绿 → Trial 转正记录；任一条 2 人周不绿 → ADR-0001 revisit 备忘并冻结 3.x/5.x 后续）——依赖: 节内 3.1–3.4 + 跨节 4.1、5.1（经 3.2/3.4 传递）
+- [x] 3.5 spike 条 5 核验 + 判定记录（`git -C zero diff --quiet` && HEAD=13e25c1；五条全绿 → Trial 转正记录；任一条 2 人周不绿 → ADR-0001 revisit 备忘并冻结 3.x/5.x 后续）——依赖: 节内 3.1–3.4 + 跨节 4.1、5.1（经 3.2/3.4 传递）
 
 ## 4. core schema（core-schemas）
 


### PR DESCRIPTION
Closes #21

## Summary

- Add `policy-gate-spike-verdict.md` with the five-item M1 policy-gate spike evidence matrix.
- Update ADR-0001 execution status: Zero remains Trial and trigger 1 is active after #19 / PR #46 failed the final verifier gate.
- Mark OpenSpec task 3.5 as completed via the not-green/revisit path and record that policy-gate-dependent 3.x/5.x follow-ups are paused until the enforcement boundary is revisited.

## Validation

- `openspec validate m1-foundation --strict --no-interactive`
- `git diff --check`
- `git diff --cached --check`
- `git -C zero diff --quiet`
- `git -C zero rev-parse HEAD` = `13e25c116c62411e6ee8a0ad67a6c53dc7c376c6`

## Boundary Notes

- This PR records the #21 verdict only; it does not fix or merge #19.
- PR #46 remains draft spike evidence and is not merge-ready.
- #20 is recorded as stopped, not failed, because #19 already triggered the not-green branch.
