### PR TITLE
fix(policy-gate): bound non-spawn input preparation

### DIFF
--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/.openspec.yaml
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/README.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/README.md
@@ -1,0 +1,3 @@
+# m1-policy-gate-non-spawn-input-bounds
+
+Bound generic non-spawn policy-gate input preparation

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/design.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/design.md
@@ -1,9 +1,9 @@
 ## Context
 
-Issue #51 is a PR #50 follow-up for the shared policy-gate wrapper. The current
-generic non-spawn path clones input once for execution and again for evaluator
-inspection. That preserves isolation, but it also makes large or deeply nested
-inputs pay repeated preparation cost before policy evaluation can deny.
+Issue #51 is a PR #52 invariant-closure follow-up for the shared policy-gate
+wrapper. The generic non-spawn path must reject pathological input before
+expensive descriptor materialization, give honest evaluators cloneable data, and
+keep evaluator mutation away from the input later supplied to the inner tool.
 
 Fixture level: expanded; repair intensity: high. Project profile: SHUD-Harness.
 
@@ -17,9 +17,11 @@ Expanded-trigger rationale:
 
 Goals:
 - Bound generic non-spawn preparation before expensive cloning.
-- Use one execution snapshot for generic non-spawn input.
-- Give policy evaluators a read-only view so evaluator mutation cannot alter
-  inner tool execution.
+- Use separate execution and evaluator snapshots for generic non-spawn input.
+- Make evaluator snapshots cloneable plain data, with recursive null prototypes
+  for plain objects.
+- Isolate evaluator direct mutation and block input-derived prototype mutation
+  paths from altering inner tool execution.
 - Preserve fail-closed behavior and running-tool metadata finalization.
 - Leave `spawn_agent` normalization and authority snapshot behavior unchanged.
 
@@ -31,20 +33,29 @@ Non-Goals:
 
 ## Decisions
 
-1. Generic non-spawn input gets a budget check before `structuredClone`.
-   The check inspects descriptors rather than reading accessor values. Accessors,
-   functions, symbols, excessive depth, excessive node count, excessive array
-   length, or excessive string budget fail closed as preparation errors.
+1. Generic non-spawn input gets cheap budget checks before descriptor reads.
+   Arrays reject over-length `length` before own-key or element-descriptor
+   enumeration. Plain objects reject over-budget own-key counts before per-key
+   descriptor reads. Accessors, functions, symbols, bigint values, symbol keys,
+   excessive depth, excessive node count, excessive array length, excessive
+   object key count, or excessive string budget fail closed as preparation
+   errors.
 
-2. Generic non-spawn input uses a single execution snapshot.
-   After the budget check, one `structuredClone` creates the value passed to the
-   inner tool. The evaluator receives a recursively read-only view of that
-   snapshot, not a second clone.
+2. Generic non-spawn input uses bounded twin snapshots.
+   After descriptor-safe inspection, the wrapper creates one execution snapshot
+   for the inner tool and one evaluator snapshot for policy evaluation. Both
+   snapshots are plain structured data. Plain object snapshots use null
+   prototypes recursively; evaluator arrays also use null prototypes so
+   input-derived array `constructor` / prototype paths cannot mutate shared
+   array prototypes.
 
-3. The read-only evaluator view is a policy wrapper concern only.
-   Mutation attempts from custom evaluators fail inside evaluator execution and
-   return the existing failed ToolResult shape without invoking the inner tool.
-   Honest evaluators continue to read the same data shape as before.
+3. Evaluator mutation is isolated by snapshot separation.
+   Direct top-level or nested evaluator mutation may succeed on the evaluator
+   snapshot, but the inner tool receives the original execution snapshot.
+   Honest evaluators can `structuredClone(call.input)` before returning allow.
+   Prototype mutation attempts through `Object.getPrototypeOf(call.input)` or
+   `call.input.constructor?.prototype` either have no reachable prototype or do
+   not affect the execution snapshot.
 
 4. Spawn remains separate.
    `spawn_agent` keeps using `normalizeSpawnAgentInput()` plus its existing
@@ -82,13 +93,14 @@ Domain packs:
 
 Invariant Matrix:
 - Governing invariant: Generic non-spawn policy-gate preparation must bound
-  untrusted input cost and must not let evaluator mutation change the input that
-  the inner tool executes.
+  untrusted input cost, preserve cloneable honest-evaluator read semantics, and
+  must not let evaluator mutation change the input that the inner tool executes.
 - Source-of-truth identity/contract: issue #51 acceptance criteria,
   `PolicyGatedBaseToolAdapter.preparePolicyGateInput()`, and existing
   `policy_gate_input_preparation_failed` / evaluator-failure ToolResult shapes.
 - Producers: non-spawn tool callers and custom policy evaluators.
-- Validators/preflight: generic preparation budget check and structured clone.
+- Validators/preflight: generic preparation budget check, descriptor-safe
+  inspection, and bounded snapshot creation.
 - Storage/cache/query: none - no persisted runtime state.
 - Public routes/entrypoints: wrapped non-spawn `BaseTool.run()` path.
 - Frontend/downstream consumers: none in this slice.
@@ -100,22 +112,25 @@ Invariant Matrix:
 - Regression rows:
   - Oversized/deep non-spawn input -> preparation fails closed before evaluator
     and inner tool execution, with existing preparation failure payload.
-  - Evaluator mutates top-level or nested non-spawn input -> evaluator failure
-    is returned, inner tool does not run, and the execution snapshot remains
-    isolated.
-  - Honest evaluator reads valid non-spawn input -> inner tool receives the
-    expected snapshot exactly once.
-  - Existing accessor/prototype-polluting hostile input -> preparation still
-    fails closed without leaking getter text or running the inner tool.
+  - Over-length arrays and over-wide objects -> cheap budget rejection happens
+    before array own-key / element descriptor enumeration or per-key object
+    descriptor reads.
+  - Evaluator mutates top-level or nested non-spawn input -> inner tool still
+    receives the original execution snapshot.
+  - Honest evaluator snapshots valid non-spawn input with `structuredClone` ->
+    clone succeeds and inner tool receives the expected execution snapshot.
+  - Existing accessor/prototype-polluting/proxy-hostile/unsafe value input ->
+    preparation still fails closed without leaking trap or getter text and
+    without running the inner tool.
   - `spawn_agent` valid and invalid profile paths -> unchanged behavior.
 
 Boundary-surface checklist:
 - Shared helper roots: `packages/core/src/tools/policy-gate-registry.ts`.
 - Public entrypoints: wrapped non-spawn `run()` path; spawn path audited as
   unchanged.
-- Read surfaces: evaluator reads of prepared input.
-- Write/delete/overwrite surfaces: evaluator mutation attempts against prepared
-  input.
+- Read surfaces: evaluator reads and `structuredClone()` of prepared input.
+- Write/delete/overwrite surfaces: evaluator mutation attempts against its
+  isolated prepared input.
 - Failure/evidence boundaries: preparation failure payload, evaluator failure
   ToolResult, and running-tool finalization.
 - Unchanged downstream consumers: raw-data sandbox wrapper, spawn profile subset
@@ -123,9 +138,9 @@ Boundary-surface checklist:
 
 ## Risks / Trade-offs
 
-- Read-only evaluator views may surface mutation attempts as evaluator failures.
-  Mitigation: policy evaluators are inspection code; tests lock the failure as
-  fail-closed and non-executing.
+- Evaluator snapshots are mutable by direct assignment, so mutation attempts no
+  longer fail immediately. Mitigation: the execution snapshot is separate, and
+  tests lock that the inner tool only sees the original values.
 - Budget constants can reject pathological but technically cloneable inputs.
   Mitigation: this boundary is a shared policy gate; safe, bounded inspection is
   preferred over unbounded preparation.

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/design.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/design.md
@@ -67,29 +67,28 @@ Non-Goals:
    compatibility, and arrays are normal arrays. Evaluator snapshots use
    null-prototype plain objects recursively, make those plain objects
    non-extensible after existing properties are installed, and preserve the
-   explicitly supported array read/mutation APIs (`for...of`, spread,
-   `.includes()`, `.map()`, direct numeric indexing, and `push`) through
-   isolated array prototypes with no functional `constructor`, null-prototype
-   frozen exposed methods/iterators, and `.map()` results that are
-   evaluator-isolated arrays rather than ordinary `Array.prototype` arrays.
+   explicitly supported array read APIs (`for...of`, spread, `.includes()`,
+   `.map()`, and direct numeric indexing) through isolated array prototypes with
+   no functional `constructor`, null-prototype frozen exposed methods/iterators,
+   and `.map()` results that are evaluator-isolated non-extensible arrays rather
+   than ordinary `Array.prototype` arrays.
 
 3. Evaluator mutation is isolated by snapshot separation.
    Direct top-level or nested evaluator mutation may succeed on the evaluator
    snapshot, but the inner tool receives the original execution snapshot.
    Honest evaluators can `structuredClone(call.input)`, read array fields with
    direct numeric indexing, iterate and spread them, call `.includes()` /
-   `.map()`, and use `push` on the evaluator-local array before returning allow.
+   `.map()`, mutate existing numeric indices evaluator-locally, and return allow.
    Existing top-level/nested fields remain writable for evaluator-local
    assignment; adding new properties to evaluator plain objects is outside the
    supported contract because those objects are non-extensible. Isolated array
    prototype containers, isolated method functions, iterator objects, and
    iterator `next` functions are frozen or non-extensible after their desired
-   prototypes are set. Evaluator arrays remain extensible so `push` and direct
-   element writes work; if evaluator code reparents such an evaluator-local
-   array or a `.map()` result to a global prototype, the wrapper restores
-   input-derived intrinsic residue on `Object.prototype`, `Array.prototype`,
-   `Function.prototype`, global array method functions, constructors, and array
-   iterator prototypes before inner execution continues. Prototype mutation
+   prototypes are set. Evaluator arrays are made non-extensible after existing
+   numeric indices are installed. This intentionally removes `push` and other
+   array-growth APIs from the supported evaluator contract so evaluator-local
+   arrays and `.map()` results cannot be reparented to global prototypes.
+   Prototype mutation
    attempts through `Object.setPrototypeOf(call.input, ...)`,
    `Object.setPrototypeOf(call.input.nested, ...)`,
    `Object.setPrototypeOf(values, Array.prototype)`,
@@ -178,9 +177,9 @@ Invariant Matrix:
     receives the original execution snapshot.
   - Honest evaluator snapshots valid non-spawn input with `structuredClone` and
     reads array fields via direct numeric indexing, `for...of`, spread,
-    `.includes()`, `.map()`, and evaluator-local `push` -> reads succeed, map
-    results stay evaluator-isolated, and inner tool receives the expected
-    execution snapshot.
+    `.includes()`, `.map()`, plus evaluator-local existing-index assignment ->
+    reads succeed, map results stay evaluator-isolated and non-extensible, and
+    inner tool receives the expected execution snapshot.
   - Evaluator prototype mutation probes through direct object reparenting,
     array instance reparenting, isolated array prototype containers, array
     constructor, array methods, map-result arrays/prototypes/functions, and
@@ -208,15 +207,11 @@ Boundary-surface checklist:
 
 ## Risks / Trade-offs
 
-- Evaluator snapshots allow direct assignment to existing fields and evaluator
-  arrays remain extensible so `push` keeps working. Mitigation: the execution
-  snapshot is separate, evaluator plain objects are non-extensible to block
-  reparenting/new-property residue, isolated prototypes/functions/iterators are
-  frozen, and tests lock that the inner tool only sees the original values.
-- Evaluator array instances cannot be made non-extensible without breaking
-  supported `push`. Mitigation: array instance reparenting is evaluator-local,
-  and the non-spawn wrapper restores input-derived intrinsic residue before
-  continuing to inner execution.
+- Evaluator snapshots allow direct assignment to existing fields and existing
+  array indices, but evaluator arrays are non-extensible. Trade-off: `push` and
+  array-growth APIs are no longer supported for evaluator snapshots. Mitigation:
+  this is a deliberate contract narrowing because preserving `push` required
+  extensible arrays and left input-derived paths to global `Array.prototype`.
 - Budget constants can reject pathological but technically cloneable inputs.
   Mitigation: this boundary is a shared policy gate; safe, bounded preparation
   is preferred over unbounded execution.

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/design.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/design.md
@@ -39,31 +39,39 @@ Non-Goals:
 
 1. Generic non-spawn input uses a conservative stable-materialization boundary.
    Proxy inputs are rejected before key discovery or descriptor traps are
-   reached. Arrays reject over-length `length` before any index descriptor
-   reads and are accepted only as JSON-style numeric-index arrays: preparation
-   reads bounded descriptors for indices `0..length-1`, preserves sparse holes
-   where possible, rejects unsafe accessors/functions/symbols/bigints in
-   numeric indices, and omits non-index own array properties without discovering
-   them. For ordinary plain objects, JavaScript cannot count keys without
+   reached. Live arrays must have the ordinary `Array.prototype`; array
+   subclasses, custom-prototype arrays, and nested variants fail closed before
+   evaluator or inner execution. Ordinary arrays reject over-length `length`
+   before any index descriptor reads and are accepted only as JSON-style
+   numeric-index arrays: preparation reads bounded descriptors for indices
+   `0..length-1`, preserves sparse holes where possible, rejects unsafe
+   accessors/functions/symbols/bigints in numeric indices, and omits non-index
+   own array properties without discovering them. For ordinary plain objects,
+   JavaScript cannot count keys without
    enumerating them, so the object key budget is checked after
    `Reflect.ownKeys()` and before per-key descriptor/value reads. Accessors,
    functions, symbols, bigint values, symbol keys, excessive depth, excessive
    node count, excessive array length, excessive object key count, excessive
-   string budget, non-ordinary prototypes, or prototype-polluting keys on
-   ordinary object properties fail closed as preparation errors.
+   string budget, non-ordinary non-array prototypes, non-ordinary array
+   prototypes, or prototype-polluting keys on ordinary object properties fail
+   closed as preparation errors.
 
 2. Generic non-spawn input uses one canonical materialization plus derived
    snapshots. The wrapper materializes the accepted live input once into a
    stable inert structured-data graph. It then creates one execution snapshot
    for the inner tool and one evaluator snapshot for policy evaluation from
    that canonical graph, so evaluator and execution preparation never reread a
-   live proxy/accessor source differently. Plain object snapshots use null
-   prototypes recursively. Evaluator arrays preserve the explicitly supported
-   read/mutation APIs (`for...of`, spread, `.includes()`, `.map()`, direct
-   numeric indexing, and `push`) through isolated array prototypes with no
-   functional `constructor`, null-prototype exposed methods/iterators, and
-   `.map()` results that are evaluator-isolated arrays rather than ordinary
-   `Array.prototype` arrays.
+   live proxy/accessor source differently. Execution snapshots preserve the
+   previous structuredClone-like shape: plain objects are ordinary `{}` objects
+   with `Object.prototype`, nested plain objects keep ordinary object
+   compatibility, and arrays are normal arrays. Evaluator snapshots use
+   null-prototype plain objects recursively, make those plain objects
+   non-extensible after existing properties are installed, and preserve the
+   explicitly supported array read/mutation APIs (`for...of`, spread,
+   `.includes()`, `.map()`, direct numeric indexing, and `push`) through
+   isolated array prototypes with no functional `constructor`, null-prototype
+   frozen exposed methods/iterators, and `.map()` results that are
+   evaluator-isolated arrays rather than ordinary `Array.prototype` arrays.
 
 3. Evaluator mutation is isolated by snapshot separation.
    Direct top-level or nested evaluator mutation may succeed on the evaluator
@@ -71,12 +79,25 @@ Non-Goals:
    Honest evaluators can `structuredClone(call.input)`, read array fields with
    direct numeric indexing, iterate and spread them, call `.includes()` /
    `.map()`, and use `push` on the evaluator-local array before returning allow.
-   Prototype mutation attempts through `Object.getPrototypeOf(call.input)`,
+   Existing top-level/nested fields remain writable for evaluator-local
+   assignment; adding new properties to evaluator plain objects is outside the
+   supported contract because those objects are non-extensible. Isolated array
+   prototype containers, isolated method functions, iterator objects, and
+   iterator `next` functions are frozen or non-extensible after their desired
+   prototypes are set. Evaluator arrays remain extensible so `push` and direct
+   element writes work; if evaluator code reparents such an evaluator-local
+   array or a `.map()` result to a global prototype, the wrapper restores
+   input-derived intrinsic residue on `Object.prototype`, `Array.prototype`,
+   `Function.prototype`, global array method functions, constructors, and array
+   iterator prototypes before inner execution continues. Prototype mutation
+   attempts through `Object.setPrototypeOf(call.input, ...)`,
+   `Object.setPrototypeOf(call.input.nested, ...)`,
+   `Object.setPrototypeOf(values, Array.prototype)`,
+   `Object.setPrototypeOf(Object.getPrototypeOf(values), Array.prototype)`,
+   `Object.setPrototypeOf(Object.getPrototypeOf(values).map, Function.prototype)`,
    `Object.getPrototypeOf(values.constructor)`,
-   `Object.getPrototypeOf(Object.getPrototypeOf(values).map)`,
    `Object.getPrototypeOf(values.map(...))`, or a directly accessed iterator
-   either have no reachable shared prototype or affect only evaluator-local
-   objects, not execution input, `Function.prototype`, or `Array.prototype`.
+   therefore cannot mutate execution input or leave cross-call/global residue.
 
 4. Spawn remains separate.
    `spawn_agent` keeps using `normalizeSpawnAgentInput()` plus its existing
@@ -139,12 +160,20 @@ Invariant Matrix:
     evaluator and inner tool execution, without trap text or trap calls.
   - Over-length ordinary arrays -> cheap length rejection happens before array
     own-key discovery or numeric index descriptor reads.
+  - Non-ordinary non-array inputs -> class instances, `Date`, `Map`, and
+    custom-prototype objects fail closed before evaluator and inner execution.
+  - Non-ordinary arrays -> array subclasses and custom-prototype arrays fail
+    closed at top level and when nested in ordinary objects.
   - Low-length ordinary arrays with over-budget or unsafe non-index own
     properties -> preparation does not call array `Reflect.ownKeys()`, omits
     those properties from evaluator/execution snapshots, and still materializes
     safe numeric indices.
   - Over-wide ordinary objects -> key-count rejection happens after ordinary
     own-key enumeration and before per-key descriptor/value reads.
+  - Execution compatibility -> inner tools receive ordinary plain-object
+    execution snapshots where `input.hasOwnProperty(...)` works and
+    `input instanceof Object` is true, while evaluator plain objects remain
+    null-prototype and non-extensible.
   - Evaluator mutates top-level or nested non-spawn input -> inner tool still
     receives the original execution snapshot.
   - Honest evaluator snapshots valid non-spawn input with `structuredClone` and
@@ -152,9 +181,14 @@ Invariant Matrix:
     `.includes()`, `.map()`, and evaluator-local `push` -> reads succeed, map
     results stay evaluator-isolated, and inner tool receives the expected
     execution snapshot.
-  - Evaluator prototype mutation probes through array constructor, array method,
-    map-result, and iterator paths -> no `Function.prototype` or
-    `Array.prototype` residue and inner execution input remains unchanged.
+  - Evaluator prototype mutation probes through direct object reparenting,
+    array instance reparenting, isolated array prototype containers, array
+    constructor, array methods, map-result arrays/prototypes/functions, and
+    iterator objects/functions -> no `Object.prototype`, `Function.prototype`,
+    or `Array.prototype` residue and inner execution input remains unchanged.
+  - Cross-call residue -> writing custom properties to evaluator-visible
+    prototypes, methods, iterator objects, iterator functions, and map-result
+    paths in one evaluator call is not observable by the next evaluator call.
   - Existing accessor/prototype-polluting/proxy-hostile/unsafe value input ->
     preparation still fails closed without leaking trap or getter text and
     without running the inner tool.
@@ -174,9 +208,15 @@ Boundary-surface checklist:
 
 ## Risks / Trade-offs
 
-- Evaluator snapshots are mutable by direct assignment, so mutation attempts no
-  longer fail immediately. Mitigation: the execution snapshot is separate, and
-  tests lock that the inner tool only sees the original values.
+- Evaluator snapshots allow direct assignment to existing fields and evaluator
+  arrays remain extensible so `push` keeps working. Mitigation: the execution
+  snapshot is separate, evaluator plain objects are non-extensible to block
+  reparenting/new-property residue, isolated prototypes/functions/iterators are
+  frozen, and tests lock that the inner tool only sees the original values.
+- Evaluator array instances cannot be made non-extensible without breaking
+  supported `push`. Mitigation: array instance reparenting is evaluator-local,
+  and the non-spawn wrapper restores input-derived intrinsic residue before
+  continuing to inner execution.
 - Budget constants can reject pathological but technically cloneable inputs.
   Mitigation: this boundary is a shared policy gate; safe, bounded preparation
   is preferred over unbounded execution.

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/design.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/design.md
@@ -1,9 +1,10 @@
 ## Context
 
 Issue #51 is a PR #52 invariant-closure follow-up for the shared policy-gate
-wrapper. The generic non-spawn path must reject pathological input before
-expensive descriptor materialization, give honest evaluators cloneable data, and
-keep evaluator mutation away from the input later supplied to the inner tool.
+wrapper. The generic non-spawn path must reject unstable live input, materialize
+accepted input once into a stable bounded graph, give honest evaluators cloneable
+data with ordinary array read APIs, and keep evaluator mutation away from the
+input later supplied to the inner tool.
 
 Fixture level: expanded; repair intensity: high. Project profile: SHUD-Harness.
 
@@ -16,10 +17,13 @@ Expanded-trigger rationale:
 ## Goals / Non-Goals
 
 Goals:
-- Bound generic non-spawn preparation before expensive cloning.
-- Use separate execution and evaluator snapshots for generic non-spawn input.
+- Reject generic non-spawn proxies and non-ordinary objects whose discovery cost
+  or descriptor stability cannot be bounded.
+- Materialize accepted generic non-spawn input once into a stable canonical graph.
+- Use separate execution and evaluator snapshots derived from that canonical
+  graph for generic non-spawn input.
 - Make evaluator snapshots cloneable plain data, with recursive null prototypes
-  for plain objects.
+  for plain objects and compatible read APIs for arrays.
 - Isolate evaluator direct mutation and block input-derived prototype mutation
   paths from altering inner tool execution.
 - Preserve fail-closed behavior and running-tool metadata finalization.
@@ -33,29 +37,36 @@ Non-Goals:
 
 ## Decisions
 
-1. Generic non-spawn input gets cheap budget checks before descriptor reads.
-   Arrays reject over-length `length` before own-key or element-descriptor
-   enumeration. Plain objects reject over-budget own-key counts before per-key
-   descriptor reads. Accessors, functions, symbols, bigint values, symbol keys,
-   excessive depth, excessive node count, excessive array length, excessive
-   object key count, or excessive string budget fail closed as preparation
-   errors.
+1. Generic non-spawn input uses a conservative stable-materialization boundary.
+   Proxy inputs are rejected before key discovery or descriptor traps are
+   reached. Arrays reject over-length `length` before own-key or element
+   descriptor enumeration. For ordinary plain objects, JavaScript cannot count
+   keys without enumerating them, so the object key budget is checked after
+   `Reflect.ownKeys()` and before per-key descriptor/value reads. Accessors,
+   functions, symbols, bigint values, symbol keys, excessive depth, excessive
+   node count, excessive array length, excessive object key count, excessive
+   string budget, non-ordinary prototypes, or prototype-polluting keys fail
+   closed as preparation errors.
 
-2. Generic non-spawn input uses bounded twin snapshots.
-   After descriptor-safe inspection, the wrapper creates one execution snapshot
-   for the inner tool and one evaluator snapshot for policy evaluation. Both
-   snapshots are plain structured data. Plain object snapshots use null
-   prototypes recursively; evaluator arrays also use null prototypes so
-   input-derived array `constructor` / prototype paths cannot mutate shared
-   array prototypes.
+2. Generic non-spawn input uses one canonical materialization plus derived
+   snapshots. The wrapper materializes the accepted live input once into a
+   stable inert structured-data graph. It then creates one execution snapshot
+   for the inner tool and one evaluator snapshot for policy evaluation from
+   that canonical graph, so evaluator and execution preparation never reread a
+   live proxy/accessor source differently. Plain object snapshots use null
+   prototypes recursively. Evaluator arrays preserve ordinary read APIs through
+   isolated array prototypes that copy array methods without linking mutation
+   paths to global `Array.prototype`.
 
 3. Evaluator mutation is isolated by snapshot separation.
    Direct top-level or nested evaluator mutation may succeed on the evaluator
    snapshot, but the inner tool receives the original execution snapshot.
-   Honest evaluators can `structuredClone(call.input)` before returning allow.
+   Honest evaluators can `structuredClone(call.input)`, iterate array fields,
+   spread them, and call `.includes()` / `.map()` before returning allow.
    Prototype mutation attempts through `Object.getPrototypeOf(call.input)` or
-   `call.input.constructor?.prototype` either have no reachable prototype or do
-   not affect the execution snapshot.
+   `call.input.constructor?.prototype` either have no reachable shared prototype
+   or affect only the evaluator-local prototype, not execution input or global
+   prototypes.
 
 4. Spawn remains separate.
    `spawn_agent` keeps using `normalizeSpawnAgentInput()` plus its existing
@@ -92,15 +103,17 @@ Domain packs:
   shared Zero tool wrapper boundary.
 
 Invariant Matrix:
-- Governing invariant: Generic non-spawn policy-gate preparation must bound
-  untrusted input cost, preserve cloneable honest-evaluator read semantics, and
-  must not let evaluator mutation change the input that the inner tool executes.
+- Governing invariant: Generic non-spawn policy-gate preparation must
+  materialize untrusted input into one stable bounded source of truth, derive
+  evaluator/execution inputs from that source without rereading live input,
+  preserve cloneable honest-evaluator read semantics, and must not let evaluator
+  mutation change the input that the inner tool executes.
 - Source-of-truth identity/contract: issue #51 acceptance criteria,
   `PolicyGatedBaseToolAdapter.preparePolicyGateInput()`, and existing
   `policy_gate_input_preparation_failed` / evaluator-failure ToolResult shapes.
 - Producers: non-spawn tool callers and custom policy evaluators.
-- Validators/preflight: generic preparation budget check, descriptor-safe
-  inspection, and bounded snapshot creation.
+- Validators/preflight: proxy/non-ordinary rejection, generic preparation budget
+  checks, canonical materialization, and bounded snapshot cloning.
 - Storage/cache/query: none - no persisted runtime state.
 - Public routes/entrypoints: wrapped non-spawn `BaseTool.run()` path.
 - Frontend/downstream consumers: none in this slice.
@@ -112,13 +125,17 @@ Invariant Matrix:
 - Regression rows:
   - Oversized/deep non-spawn input -> preparation fails closed before evaluator
     and inner tool execution, with existing preparation failure payload.
-  - Over-length arrays and over-wide objects -> cheap budget rejection happens
-    before array own-key / element descriptor enumeration or per-key object
-    descriptor reads.
+  - Proxy or hostile key-discovery input -> preparation fails closed before
+    evaluator and inner tool execution, without trap text or trap calls.
+  - Over-length ordinary arrays -> cheap length rejection happens before array
+    own-key / element descriptor enumeration.
+  - Over-wide ordinary objects -> key-count rejection happens after ordinary
+    own-key enumeration and before per-key descriptor/value reads.
   - Evaluator mutates top-level or nested non-spawn input -> inner tool still
     receives the original execution snapshot.
-  - Honest evaluator snapshots valid non-spawn input with `structuredClone` ->
-    clone succeeds and inner tool receives the expected execution snapshot.
+  - Honest evaluator snapshots valid non-spawn input with `structuredClone` and
+    reads array fields via `for...of`, spread, `.includes()`, and `.map()` ->
+    reads succeed and inner tool receives the expected execution snapshot.
   - Existing accessor/prototype-polluting/proxy-hostile/unsafe value input ->
     preparation still fails closed without leaking trap or getter text and
     without running the inner tool.
@@ -142,5 +159,9 @@ Boundary-surface checklist:
   longer fail immediately. Mitigation: the execution snapshot is separate, and
   tests lock that the inner tool only sees the original values.
 - Budget constants can reject pathological but technically cloneable inputs.
-  Mitigation: this boundary is a shared policy gate; safe, bounded inspection is
-  preferred over unbounded preparation.
+  Mitigation: this boundary is a shared policy gate; safe, bounded preparation
+  is preferred over unbounded execution.
+- Ordinary object own-key enumeration itself cannot be pre-budgeted with native
+  JavaScript reflection. Mitigation: proxy-shaped inputs are rejected before key
+  discovery, and the contract only claims ordinary object rejection after
+  own-key enumeration and before per-key descriptor/value reads.

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/design.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/design.md
@@ -82,12 +82,14 @@ Non-Goals:
    Existing top-level/nested fields remain writable for evaluator-local
    assignment; adding new properties to evaluator plain objects is outside the
    supported contract because those objects are non-extensible. Isolated array
-   prototype containers, isolated method functions, iterator objects, and
-   iterator `next` functions are frozen or non-extensible after their desired
-   prototypes are set. Evaluator arrays are made non-extensible after existing
-   numeric indices are installed. This intentionally removes `push` and other
-   array-growth APIs from the supported evaluator contract so evaluator-local
-   arrays and `.map()` results cannot be reparented to global prototypes.
+   prototype containers, isolated method functions, iterator objects, iterator
+   `next` functions, and iterator result objects are frozen or non-extensible
+   after their desired properties are installed. Evaluator arrays are made
+   non-extensible and their `length` control surface is sealed after existing
+   numeric indices are installed. This intentionally removes `push`, length
+   growth, and other array-growth APIs from the supported evaluator contract so
+   evaluator-local arrays and `.map()` results cannot be reparented to global
+   prototypes or expanded beyond the bounded canonical input length.
    Prototype mutation
    attempts through `Object.setPrototypeOf(call.input, ...)`,
    `Object.setPrototypeOf(call.input.nested, ...)`,
@@ -182,12 +184,15 @@ Invariant Matrix:
     inner tool receives the expected execution snapshot.
   - Evaluator prototype mutation probes through direct object reparenting,
     array instance reparenting, isolated array prototype containers, array
-    constructor, array methods, map-result arrays/prototypes/functions, and
-    iterator objects/functions -> no `Object.prototype`, `Function.prototype`,
-    or `Array.prototype` residue and inner execution input remains unchanged.
+    constructor, array methods, map-result arrays/prototypes/functions, iterator
+    objects/functions/results, and evaluator-local length growth -> no
+    `Object.prototype`, `Function.prototype`, or `Array.prototype` residue, no
+    over-budget evaluator array reads, and inner execution input remains
+    unchanged.
   - Cross-call residue -> writing custom properties to evaluator-visible
-    prototypes, methods, iterator objects, iterator functions, and map-result
-    paths in one evaluator call is not observable by the next evaluator call.
+    prototypes, methods, iterator objects, iterator functions, iterator results,
+    and map-result paths in one evaluator call is not observable by the next
+    evaluator call.
   - Existing accessor/prototype-polluting/proxy-hostile/unsafe value input ->
     preparation still fails closed without leaking trap or getter text and
     without running the inner tool.
@@ -208,10 +213,12 @@ Boundary-surface checklist:
 ## Risks / Trade-offs
 
 - Evaluator snapshots allow direct assignment to existing fields and existing
-  array indices, but evaluator arrays are non-extensible. Trade-off: `push` and
-  array-growth APIs are no longer supported for evaluator snapshots. Mitigation:
-  this is a deliberate contract narrowing because preserving `push` required
-  extensible arrays and left input-derived paths to global `Array.prototype`.
+  array indices, but evaluator arrays are non-extensible and length growth is
+  unsupported. Trade-off: `push`, length growth, and array-growth APIs are no
+  longer supported for evaluator snapshots. Mitigation: this is a deliberate
+  contract narrowing because preserving array growth required extensible arrays
+  and left input-derived paths to global `Array.prototype` and unbounded
+  evaluator reads.
 - Budget constants can reject pathological but technically cloneable inputs.
   Mitigation: this boundary is a shared policy gate; safe, bounded preparation
   is preferred over unbounded execution.

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/design.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/design.md
@@ -1,0 +1,131 @@
+## Context
+
+Issue #51 is a PR #50 follow-up for the shared policy-gate wrapper. The current
+generic non-spawn path clones input once for execution and again for evaluator
+inspection. That preserves isolation, but it also makes large or deeply nested
+inputs pay repeated preparation cost before policy evaluation can deny.
+
+Fixture level: expanded; repair intensity: high. Project profile: SHUD-Harness.
+
+Expanded-trigger rationale:
+- Core triggers: shared wrapper entrypoint, resource-limit behavior, hostile
+  input handling, and error/finalization paths.
+- Profile triggers: `remediation`, `guard_class`, `Zero`, `ToolBase`, and
+  tool registry governance.
+
+## Goals / Non-Goals
+
+Goals:
+- Bound generic non-spawn preparation before expensive cloning.
+- Use one execution snapshot for generic non-spawn input.
+- Give policy evaluators a read-only view so evaluator mutation cannot alter
+  inner tool execution.
+- Preserve fail-closed behavior and running-tool metadata finalization.
+- Leave `spawn_agent` normalization and authority snapshot behavior unchanged.
+
+Non-Goals:
+- Changing spawn profile subset enforcement.
+- Changing raw-data sandbox semantics.
+- Accepting arbitrary live proxies, accessors, functions, symbols, or
+  prototype-polluting objects as safe policy-gate input.
+
+## Decisions
+
+1. Generic non-spawn input gets a budget check before `structuredClone`.
+   The check inspects descriptors rather than reading accessor values. Accessors,
+   functions, symbols, excessive depth, excessive node count, excessive array
+   length, or excessive string budget fail closed as preparation errors.
+
+2. Generic non-spawn input uses a single execution snapshot.
+   After the budget check, one `structuredClone` creates the value passed to the
+   inner tool. The evaluator receives a recursively read-only view of that
+   snapshot, not a second clone.
+
+3. The read-only evaluator view is a policy wrapper concern only.
+   Mutation attempts from custom evaluators fail inside evaluator execution and
+   return the existing failed ToolResult shape without invoking the inner tool.
+   Honest evaluators continue to read the same data shape as before.
+
+4. Spawn remains separate.
+   `spawn_agent` keeps using `normalizeSpawnAgentInput()` plus its existing
+   cloned evaluator snapshot because its role/tool authority path has separate
+   invariants from issue #20.
+
+Risk packs considered:
+- Public API / CLI / script entry: selected - every wrapped non-spawn tool
+  enters through `run()`.
+- Config / project setup: not selected - no setup or environment change.
+- File IO / path safety / overwrite: not selected - no path write semantics
+  change in this slice.
+- Schema / columns / units / field names: not selected - no schema field change.
+- Auth / permissions / secrets: selected - spawn profile authority,
+  `guard_class`, and deny/allow behavior must remain unchanged while the generic
+  non-spawn path changes.
+- Concurrency / shared state / ordering: selected - evaluator code must not
+  mutate the execution snapshot before the inner tool runs.
+- Resource limits / large input / discovery: selected - the issue is resource
+  pressure from large/deep inputs.
+- Legacy compatibility / examples: selected - existing non-spawn allow/deny and
+  spawn behavior must remain compatible.
+- Error handling / rollback / partial outputs: selected - preparation and
+  evaluator failures must fail closed and finalize running metadata.
+- Release / packaging / dependency compatibility: selected - no new runtime
+  dependency and Zero source diff stays 0.
+- Documentation / migration notes: not selected - PR evidence is sufficient.
+Domain packs:
+- Scientific governance / PI gate / evidence lineage: not selected - no
+  scientific evidence or PI decision change.
+- Hydrology runtime / SHUD-rSHUD-AutoSHUD compatibility: not selected - no
+  solver/runtime behavior change.
+- Zero adapter / tool registry / agent role governance: selected - this is a
+  shared Zero tool wrapper boundary.
+
+Invariant Matrix:
+- Governing invariant: Generic non-spawn policy-gate preparation must bound
+  untrusted input cost and must not let evaluator mutation change the input that
+  the inner tool executes.
+- Source-of-truth identity/contract: issue #51 acceptance criteria,
+  `PolicyGatedBaseToolAdapter.preparePolicyGateInput()`, and existing
+  `policy_gate_input_preparation_failed` / evaluator-failure ToolResult shapes.
+- Producers: non-spawn tool callers and custom policy evaluators.
+- Validators/preflight: generic preparation budget check and structured clone.
+- Storage/cache/query: none - no persisted runtime state.
+- Public routes/entrypoints: wrapped non-spawn `BaseTool.run()` path.
+- Frontend/downstream consumers: none in this slice.
+- Failure paths/rollback/stale state: preparation failures and evaluator
+  mutation failures return stable failed ToolResults, skip inner tool execution,
+  and finish any running-tool handle.
+- Evidence/audit/readiness: unit tests, OpenSpec validation, `bun run check`,
+  `git diff --check`, and `git -C zero diff --quiet`.
+- Regression rows:
+  - Oversized/deep non-spawn input -> preparation fails closed before evaluator
+    and inner tool execution, with existing preparation failure payload.
+  - Evaluator mutates top-level or nested non-spawn input -> evaluator failure
+    is returned, inner tool does not run, and the execution snapshot remains
+    isolated.
+  - Honest evaluator reads valid non-spawn input -> inner tool receives the
+    expected snapshot exactly once.
+  - Existing accessor/prototype-polluting hostile input -> preparation still
+    fails closed without leaking getter text or running the inner tool.
+  - `spawn_agent` valid and invalid profile paths -> unchanged behavior.
+
+Boundary-surface checklist:
+- Shared helper roots: `packages/core/src/tools/policy-gate-registry.ts`.
+- Public entrypoints: wrapped non-spawn `run()` path; spawn path audited as
+  unchanged.
+- Read surfaces: evaluator reads of prepared input.
+- Write/delete/overwrite surfaces: evaluator mutation attempts against prepared
+  input.
+- Failure/evidence boundaries: preparation failure payload, evaluator failure
+  ToolResult, and running-tool finalization.
+- Unchanged downstream consumers: raw-data sandbox wrapper, spawn profile subset
+  rule, and role-tool map tests.
+
+## Risks / Trade-offs
+
+- Read-only evaluator views may surface mutation attempts as evaluator failures.
+  Mitigation: policy evaluators are inspection code; tests lock the failure as
+  fail-closed and non-executing.
+- Budget constants can reject pathological but technically cloneable inputs.
+  Mitigation: this boundary is a shared policy gate; safe, bounded inspection is
+  preferred over unbounded preparation.

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/design.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/design.md
@@ -39,14 +39,18 @@ Non-Goals:
 
 1. Generic non-spawn input uses a conservative stable-materialization boundary.
    Proxy inputs are rejected before key discovery or descriptor traps are
-   reached. Arrays reject over-length `length` before own-key or element
-   descriptor enumeration. For ordinary plain objects, JavaScript cannot count
-   keys without enumerating them, so the object key budget is checked after
+   reached. Arrays reject over-length `length` before any index descriptor
+   reads and are accepted only as JSON-style numeric-index arrays: preparation
+   reads bounded descriptors for indices `0..length-1`, preserves sparse holes
+   where possible, rejects unsafe accessors/functions/symbols/bigints in
+   numeric indices, and omits non-index own array properties without discovering
+   them. For ordinary plain objects, JavaScript cannot count keys without
+   enumerating them, so the object key budget is checked after
    `Reflect.ownKeys()` and before per-key descriptor/value reads. Accessors,
    functions, symbols, bigint values, symbol keys, excessive depth, excessive
    node count, excessive array length, excessive object key count, excessive
-   string budget, non-ordinary prototypes, or prototype-polluting keys fail
-   closed as preparation errors.
+   string budget, non-ordinary prototypes, or prototype-polluting keys on
+   ordinary object properties fail closed as preparation errors.
 
 2. Generic non-spawn input uses one canonical materialization plus derived
    snapshots. The wrapper materializes the accepted live input once into a
@@ -54,19 +58,25 @@ Non-Goals:
    for the inner tool and one evaluator snapshot for policy evaluation from
    that canonical graph, so evaluator and execution preparation never reread a
    live proxy/accessor source differently. Plain object snapshots use null
-   prototypes recursively. Evaluator arrays preserve ordinary read APIs through
-   isolated array prototypes that copy array methods without linking mutation
-   paths to global `Array.prototype`.
+   prototypes recursively. Evaluator arrays preserve the explicitly supported
+   read/mutation APIs (`for...of`, spread, `.includes()`, `.map()`, direct
+   numeric indexing, and `push`) through isolated array prototypes with no
+   functional `constructor`, null-prototype exposed methods/iterators, and
+   `.map()` results that are evaluator-isolated arrays rather than ordinary
+   `Array.prototype` arrays.
 
 3. Evaluator mutation is isolated by snapshot separation.
    Direct top-level or nested evaluator mutation may succeed on the evaluator
    snapshot, but the inner tool receives the original execution snapshot.
-   Honest evaluators can `structuredClone(call.input)`, iterate array fields,
-   spread them, and call `.includes()` / `.map()` before returning allow.
-   Prototype mutation attempts through `Object.getPrototypeOf(call.input)` or
-   `call.input.constructor?.prototype` either have no reachable shared prototype
-   or affect only the evaluator-local prototype, not execution input or global
-   prototypes.
+   Honest evaluators can `structuredClone(call.input)`, read array fields with
+   direct numeric indexing, iterate and spread them, call `.includes()` /
+   `.map()`, and use `push` on the evaluator-local array before returning allow.
+   Prototype mutation attempts through `Object.getPrototypeOf(call.input)`,
+   `Object.getPrototypeOf(values.constructor)`,
+   `Object.getPrototypeOf(Object.getPrototypeOf(values).map)`,
+   `Object.getPrototypeOf(values.map(...))`, or a directly accessed iterator
+   either have no reachable shared prototype or affect only evaluator-local
+   objects, not execution input, `Function.prototype`, or `Array.prototype`.
 
 4. Spawn remains separate.
    `spawn_agent` keeps using `normalizeSpawnAgentInput()` plus its existing
@@ -128,14 +138,23 @@ Invariant Matrix:
   - Proxy or hostile key-discovery input -> preparation fails closed before
     evaluator and inner tool execution, without trap text or trap calls.
   - Over-length ordinary arrays -> cheap length rejection happens before array
-    own-key / element descriptor enumeration.
+    own-key discovery or numeric index descriptor reads.
+  - Low-length ordinary arrays with over-budget or unsafe non-index own
+    properties -> preparation does not call array `Reflect.ownKeys()`, omits
+    those properties from evaluator/execution snapshots, and still materializes
+    safe numeric indices.
   - Over-wide ordinary objects -> key-count rejection happens after ordinary
     own-key enumeration and before per-key descriptor/value reads.
   - Evaluator mutates top-level or nested non-spawn input -> inner tool still
     receives the original execution snapshot.
   - Honest evaluator snapshots valid non-spawn input with `structuredClone` and
-    reads array fields via `for...of`, spread, `.includes()`, and `.map()` ->
-    reads succeed and inner tool receives the expected execution snapshot.
+    reads array fields via direct numeric indexing, `for...of`, spread,
+    `.includes()`, `.map()`, and evaluator-local `push` -> reads succeed, map
+    results stay evaluator-isolated, and inner tool receives the expected
+    execution snapshot.
+  - Evaluator prototype mutation probes through array constructor, array method,
+    map-result, and iterator paths -> no `Function.prototype` or
+    `Array.prototype` residue and inner execution input remains unchanged.
   - Existing accessor/prototype-polluting/proxy-hostile/unsafe value input ->
     preparation still fails closed without leaking trap or getter text and
     without running the inner tool.

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/proposal.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/proposal.md
@@ -1,10 +1,10 @@
 ## Why
 
 PR #52 follow-up review found that generic non-spawn policy-gate input
-preparation still had three invariant gaps: it read live input separately for
-execution and evaluator snapshots, narrowed evaluator arrays enough to break
-ordinary read APIs, and overclaimed key-discovery bounds for proxy-shaped or
-otherwise unstable inputs.
+preparation still had invariant gaps around array-shaped input: arrays with
+bounded `length` could still force unbounded own-key discovery through
+non-index properties, and evaluator-visible array prototypes exposed global
+`Function.prototype` / `Array.prototype` mutation paths.
 
 ## What Changes
 
@@ -15,11 +15,16 @@ otherwise unstable inputs.
 - Reject proxy/non-ordinary live inputs whose discovery or stability cannot be
   bounded; for ordinary objects, check the key budget after own-key enumeration
   and before per-key descriptor/value reads.
+- Treat accepted generic non-spawn arrays as JSON-style numeric-index arrays:
+  only indices `0..length-1` are materialized, non-index own array properties
+  are outside the contract and omitted without discovery, and sparse holes are
+  preserved where possible.
 - Give plain object snapshots null prototypes recursively so evaluator
   `Object.prototype` / inherited `constructor` mutation paths cannot affect the
   inner execution input.
 - Preserve evaluator array read compatibility (`for...of`, spread, `.includes()`,
-  `.map()`) through isolated array prototypes that do not mutate global
+  `.map()`, and `push`) through isolated array prototypes, null-prototype
+  exposed methods/iterators, and `.map()` results that do not expose global
   `Array.prototype`.
 - Preserve fail-closed preparation errors, running metadata finalization, and
   the existing spawn_agent authority snapshot path.

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/proposal.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/proposal.md
@@ -19,18 +19,25 @@ non-index properties, and evaluator-visible array prototypes exposed global
   only indices `0..length-1` are materialized, non-index own array properties
   are outside the contract and omitted without discovery, and sparse holes are
   preserved where possible.
-- Give plain object snapshots null prototypes recursively so evaluator
-  `Object.prototype` / inherited `constructor` mutation paths cannot affect the
-  inner execution input.
+- Reject live non-spawn arrays whose prototype is not the ordinary
+  `Array.prototype`, including array subclasses and custom-prototype arrays.
+- Preserve execution snapshots as structuredClone-like ordinary plain objects
+  and normal arrays, while keeping evaluator plain objects null-prototype and
+  hardened.
 - Preserve evaluator array read compatibility (`for...of`, spread, `.includes()`,
-  `.map()`, and `push`) through isolated array prototypes, null-prototype
-  exposed methods/iterators, and `.map()` results that do not expose global
-  `Array.prototype`.
+  `.map()`, and `push`) through frozen isolated array prototypes,
+  null-prototype frozen exposed methods/iterators, evaluator-local arrays, and
+  `.map()` results that do not expose global `Array.prototype`.
+- Guard non-spawn evaluator execution against input-derived global
+  `Object.prototype` / `Array.prototype` / `Function.prototype` residue,
+  including array reparent attempts that can only affect evaluator-local arrays.
 - Preserve fail-closed preparation errors, running metadata finalization, and
   the existing spawn_agent authority snapshot path.
 - Add regression tests for bounded-input rejection, hostile preparation
-  failures, evaluator/inner-tool isolation, structured-clone evaluator reads,
-  and unchanged spawn behavior.
+  failures, non-ordinary live input rejection, evaluator/inner-tool isolation,
+  execution plain-object compatibility, evaluator graph hardening,
+  cross-call residue isolation, structured-clone evaluator reads, and unchanged
+  spawn behavior.
 
 ## Capabilities
 

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/proposal.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/proposal.md
@@ -25,12 +25,12 @@ non-index properties, and evaluator-visible array prototypes exposed global
   and normal arrays, while keeping evaluator plain objects null-prototype and
   hardened.
 - Preserve evaluator array read compatibility (`for...of`, spread, `.includes()`,
-  `.map()`, and `push`) through frozen isolated array prototypes,
+  and `.map()`) through frozen isolated array prototypes,
   null-prototype frozen exposed methods/iterators, evaluator-local arrays, and
   `.map()` results that do not expose global `Array.prototype`.
-- Guard non-spawn evaluator execution against input-derived global
-  `Object.prototype` / `Array.prototype` / `Function.prototype` residue,
-  including array reparent attempts that can only affect evaluator-local arrays.
+- Prevent input-derived global `Object.prototype` / `Array.prototype` /
+  `Function.prototype` residue by making evaluator arrays and `.map()` results
+  non-extensible rather than attempting same-realm global intrinsic repair.
 - Preserve fail-closed preparation errors, running metadata finalization, and
   the existing spawn_agent authority snapshot path.
 - Add regression tests for bounded-input rejection, hostile preparation

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/proposal.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/proposal.md
@@ -1,20 +1,24 @@
 ## Why
 
-PR #50 follow-up review found that generic non-spawn policy-gate input
-preparation snapshots tool input twice before the evaluator can deny. Large or
-deep tool inputs can therefore create avoidable CPU and memory pressure inside
-the shared policy-gate wrapper.
+PR #52 follow-up review found that generic non-spawn policy-gate input
+preparation still had three invariant gaps: it materialized descriptors before
+cheap budget rejection, exposed evaluator input through a non-cloneable Proxy
+view, and let evaluator prototype paths reach shared prototypes before inner
+tool execution.
 
 ## What Changes
 
 - Add an explicit bounded preparation contract for generic non-spawn tool input.
-- Prepare non-spawn execution input from a single trusted snapshot while giving
-  the evaluator a mutation-blocking view so evaluator code cannot affect inner
-  tool execution.
+- Prepare generic non-spawn execution and evaluator inputs as separate
+  cloneable plain-data snapshots after descriptor-safe budget inspection.
+- Give plain object snapshots null prototypes recursively so evaluator
+  `Object.prototype` / inherited `constructor` mutation paths cannot affect the
+  inner execution input.
 - Preserve fail-closed preparation errors, running metadata finalization, and
   the existing spawn_agent authority snapshot path.
-- Add regression tests for oversized/deep non-spawn input, hostile preparation
-  failures, evaluator/inner-tool isolation, and unchanged spawn behavior.
+- Add regression tests for cheap budget rejection, hostile preparation
+  failures, evaluator/inner-tool isolation, structured-clone evaluator reads,
+  and unchanged spawn behavior.
 
 ## Capabilities
 

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/proposal.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+PR #50 follow-up review found that generic non-spawn policy-gate input
+preparation snapshots tool input twice before the evaluator can deny. Large or
+deep tool inputs can therefore create avoidable CPU and memory pressure inside
+the shared policy-gate wrapper.
+
+## What Changes
+
+- Add an explicit bounded preparation contract for generic non-spawn tool input.
+- Prepare non-spawn execution input from a single trusted snapshot while giving
+  the evaluator a mutation-blocking view so evaluator code cannot affect inner
+  tool execution.
+- Preserve fail-closed preparation errors, running metadata finalization, and
+  the existing spawn_agent authority snapshot path.
+- Add regression tests for oversized/deep non-spawn input, hostile preparation
+  failures, evaluator/inner-tool isolation, and unchanged spawn behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `policy-gate-non-spawn-input-bounds`: Bounded, isolated generic non-spawn
+  policy-gate input preparation.
+
+### Modified Capabilities
+
+- None. This is a bug-fix fixture for M1 policy-gate implementation behavior;
+  no archived baseline spec currently exists under `openspec/specs/`.
+
+## Impact
+
+- Affected code: `packages/core/src/tools/policy-gate-registry.ts`.
+- Affected tests: `packages/core/src/tools/policy-gate-registry.test.ts`.
+- No runtime dependency changes, no Zero source edits, and no change to
+  `spawn_agent` profile authority semantics.

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/proposal.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/proposal.md
@@ -1,22 +1,29 @@
 ## Why
 
 PR #52 follow-up review found that generic non-spawn policy-gate input
-preparation still had three invariant gaps: it materialized descriptors before
-cheap budget rejection, exposed evaluator input through a non-cloneable Proxy
-view, and let evaluator prototype paths reach shared prototypes before inner
-tool execution.
+preparation still had three invariant gaps: it read live input separately for
+execution and evaluator snapshots, narrowed evaluator arrays enough to break
+ordinary read APIs, and overclaimed key-discovery bounds for proxy-shaped or
+otherwise unstable inputs.
 
 ## What Changes
 
 - Add an explicit bounded preparation contract for generic non-spawn tool input.
-- Prepare generic non-spawn execution and evaluator inputs as separate
-  cloneable plain-data snapshots after descriptor-safe budget inspection.
+- Materialize generic non-spawn input once into a stable canonical structured
+  graph, then derive separate execution and evaluator snapshots from that
+  canonical source without rereading live input.
+- Reject proxy/non-ordinary live inputs whose discovery or stability cannot be
+  bounded; for ordinary objects, check the key budget after own-key enumeration
+  and before per-key descriptor/value reads.
 - Give plain object snapshots null prototypes recursively so evaluator
   `Object.prototype` / inherited `constructor` mutation paths cannot affect the
   inner execution input.
+- Preserve evaluator array read compatibility (`for...of`, spread, `.includes()`,
+  `.map()`) through isolated array prototypes that do not mutate global
+  `Array.prototype`.
 - Preserve fail-closed preparation errors, running metadata finalization, and
   the existing spawn_agent authority snapshot path.
-- Add regression tests for cheap budget rejection, hostile preparation
+- Add regression tests for bounded-input rejection, hostile preparation
   failures, evaluator/inner-tool isolation, structured-clone evaluator reads,
   and unchanged spawn behavior.
 

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/specs/policy-gate-non-spawn-input-bounds/spec.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/specs/policy-gate-non-spawn-input-bounds/spec.md
@@ -9,16 +9,31 @@ inspection SHALL fail closed with the existing
 `policy_gate_input_preparation_failed` tool result, and the wrapped inner tool
 MUST NOT execute. Proxy-shaped and non-ordinary live inputs SHALL be rejected
 instead of treated as safely bounded structured data.
+Accepted generic arrays SHALL be JSON-style numeric-index arrays: only numeric
+indices `0..length-1` are part of the accepted generic array contract,
+non-index own array properties are outside the contract and SHALL be omitted
+without discovery, and sparse holes SHOULD be preserved where JavaScript array
+semantics permit.
 
 #### Scenario: ordinary array and object budgets reject before value expansion
 
 - **WHEN** a non-spawn tool receives an over-length array or over-wide object
-- **THEN** ordinary array length is checked before array own-key / element
-  descriptor enumeration
+- **THEN** ordinary array length is checked before array own-key discovery or
+  numeric index descriptor reads
 - **AND** ordinary object own-key count is checked after own-key enumeration and
   before per-key descriptor/value reads
 - **AND** preparation fails closed before policy evaluation and before inner
   tool execution
+
+#### Scenario: ordinary array non-index properties are outside the contract
+
+- **WHEN** a non-spawn tool receives a low-length ordinary array with
+  over-budget non-index own properties
+- **THEN** preparation does not call array own-key discovery
+- **AND** preparation does not read non-index own array descriptors
+- **AND** non-index own array properties containing functions, symbols, bigints,
+  or prototype-polluting keys are omitted from evaluator and execution snapshots
+- **AND** safe numeric indices remain available and sparse holes are preserved
 
 #### Scenario: proxy key discovery fails closed
 
@@ -50,10 +65,15 @@ accepted input once into a stable bounded canonical structured-data graph, then
 prepare separate execution and evaluator snapshots from that canonical graph.
 The evaluator snapshot SHALL be plain structured data, SHALL be
 structured-cloneable, SHALL use null prototypes recursively for plain objects,
-and SHALL preserve ordinary array read APIs including iteration, spread,
-`.includes()`, and `.map()`. Evaluator mutation attempts MUST NOT change the
-input later supplied to the inner tool or global prototypes through
-input-derived prototype paths.
+and SHALL preserve the explicitly supported evaluator array APIs: direct numeric
+indexing, `for...of`, spread, `.includes()`, `.map()`, and `push`. Supported
+array-returning evaluator methods, including `.map()`, SHALL return
+evaluator-isolated arrays rather than arrays linked to global `Array.prototype`.
+Evaluator-visible array prototype functions and iterator `next` functions
+SHOULD have null prototypes where the runtime permits, and evaluator arrays
+SHALL NOT expose a functional constructor path to global `Function.prototype`.
+Evaluator mutation attempts MUST NOT change the input later supplied to the
+inner tool or global prototypes through input-derived prototype paths.
 
 #### Scenario: evaluator mutation cannot affect inner execution
 
@@ -65,17 +85,23 @@ input-derived prototype paths.
 #### Scenario: honest evaluator preserves normal execution
 
 - **WHEN** a custom evaluator snapshots a valid non-spawn input with
-  `structuredClone(call.input)`, reads array fields with `for...of`, spread,
-  `.includes()`, and `.map()`, and returns allow
+  `structuredClone(call.input)`, reads array fields with direct numeric
+  indexing, `for...of`, spread, `.includes()`, and `.map()`, uses evaluator-local
+  `push`, and returns allow
 - **THEN** the inner tool executes with the expected cloned input value
+- **AND** `.map()` results are evaluator-isolated arrays, not arrays linked to
+  global `Array.prototype`
 
 #### Scenario: evaluator prototype mutation paths cannot affect execution
 
 - **WHEN** a custom evaluator attempts to mutate prototypes reachable from
-  `Object.getPrototypeOf(call.input)` or `call.input.constructor?.prototype`
+  `Object.getPrototypeOf(call.input)`, `Object.getPrototypeOf(values.constructor)`,
+  `Object.getPrototypeOf(Object.getPrototypeOf(values).map)`,
+  `Object.getPrototypeOf(values.map(...))`, or a directly accessed
+  `[Symbol.iterator]()` result
 - **THEN** the mutation fails closed or is isolated from the execution snapshot
 - **AND** input-derived prototype mutation paths do not leave global prototype
-  residue
+  residue on `Function.prototype` or `Array.prototype`
 
 ### Requirement: Spawn authority preparation remains unchanged
 

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/specs/policy-gate-non-spawn-input-bounds/spec.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/specs/policy-gate-non-spawn-input-bounds/spec.md
@@ -8,7 +8,9 @@ that exceed the preparation budget or require unsafe/stability-unbounded
 inspection SHALL fail closed with the existing
 `policy_gate_input_preparation_failed` tool result, and the wrapped inner tool
 MUST NOT execute. Proxy-shaped and non-ordinary live inputs SHALL be rejected
-instead of treated as safely bounded structured data.
+instead of treated as safely bounded structured data. Non-ordinary live arrays,
+including array subclasses and custom-prototype arrays, SHALL be rejected under
+the same non-ordinary live input boundary.
 Accepted generic arrays SHALL be JSON-style numeric-index arrays: only numeric
 indices `0..length-1` are part of the accepted generic array contract,
 non-index own array properties are outside the contract and SHALL be omitted
@@ -24,6 +26,15 @@ semantics permit.
   before per-key descriptor/value reads
 - **AND** preparation fails closed before policy evaluation and before inner
   tool execution
+
+#### Scenario: non-ordinary live inputs fail closed
+
+- **WHEN** a non-spawn tool receives class-backed, `Date`, `Map`,
+  custom-prototype object, array subclass, or custom-prototype array input
+- **THEN** preparation fails closed before policy evaluation and before inner
+  tool execution
+- **AND** nested array subclasses and custom-prototype arrays fail under the
+  same boundary
 
 #### Scenario: ordinary array non-index properties are outside the contract
 
@@ -63,17 +74,36 @@ semantics permit.
 For tools other than `spawn_agent`, the policy-gate wrapper SHALL materialize
 accepted input once into a stable bounded canonical structured-data graph, then
 prepare separate execution and evaluator snapshots from that canonical graph.
-The evaluator snapshot SHALL be plain structured data, SHALL be
-structured-cloneable, SHALL use null prototypes recursively for plain objects,
-and SHALL preserve the explicitly supported evaluator array APIs: direct numeric
-indexing, `for...of`, spread, `.includes()`, `.map()`, and `push`. Supported
-array-returning evaluator methods, including `.map()`, SHALL return
-evaluator-isolated arrays rather than arrays linked to global `Array.prototype`.
-Evaluator-visible array prototype functions and iterator `next` functions
-SHOULD have null prototypes where the runtime permits, and evaluator arrays
-SHALL NOT expose a functional constructor path to global `Function.prototype`.
-Evaluator mutation attempts MUST NOT change the input later supplied to the
-inner tool or global prototypes through input-derived prototype paths.
+The execution snapshot SHALL preserve structuredClone-like plain-object
+compatibility for inner tools: plain objects SHALL be ordinary objects with
+`Object.prototype`, nested plain objects SHALL retain ordinary object
+compatibility, and arrays SHALL be normal arrays. The evaluator snapshot SHALL
+be plain structured data, SHALL be structured-cloneable, SHALL use null
+prototypes recursively for plain objects, SHALL make evaluator plain objects
+non-extensible after existing properties are installed, and SHALL preserve the
+explicitly supported evaluator array APIs: direct numeric indexing, `for...of`,
+spread, `.includes()`, `.map()`, and `push`. Supported array-returning
+evaluator methods, including `.map()`, SHALL return evaluator-isolated arrays
+rather than arrays linked to global `Array.prototype`. Evaluator-visible array
+prototype containers, array prototype functions, iterator objects, and iterator
+`next` functions SHALL be frozen or made non-extensible where the runtime
+permits, and evaluator arrays SHALL NOT expose a functional constructor path to
+global `Function.prototype`. Evaluator arrays MAY remain extensible to preserve
+`push` and direct index mutation; any evaluator-local array reparenting MUST
+NOT leave residue on global `Object.prototype`, `Array.prototype`, or
+`Function.prototype` before inner execution continues. Evaluator mutation
+attempts MUST NOT change the input later supplied to the inner tool or global
+prototypes through input-derived prototype paths.
+
+#### Scenario: execution snapshot preserves ordinary object compatibility
+
+- **WHEN** a non-spawn tool receives valid plain-object input and the evaluator
+  returns allow
+- **THEN** the inner tool receives ordinary plain objects for the execution
+  snapshot
+- **AND** `input.hasOwnProperty(...)` works on the execution snapshot
+- **AND** `input instanceof Object` is true for execution plain objects
+- **AND** evaluator plain objects remain null-prototype and hardened
 
 #### Scenario: evaluator mutation cannot affect inner execution
 
@@ -95,13 +125,24 @@ inner tool or global prototypes through input-derived prototype paths.
 #### Scenario: evaluator prototype mutation paths cannot affect execution
 
 - **WHEN** a custom evaluator attempts to mutate prototypes reachable from
-  `Object.getPrototypeOf(call.input)`, `Object.getPrototypeOf(values.constructor)`,
+  direct `Object.setPrototypeOf()` on evaluator top-level objects, nested
+  objects, evaluator arrays, isolated array prototypes, exposed array methods,
+  map-result arrays/prototypes/functions, iterator objects/functions,
+  `Object.getPrototypeOf(values.constructor)`,
   `Object.getPrototypeOf(Object.getPrototypeOf(values).map)`,
   `Object.getPrototypeOf(values.map(...))`, or a directly accessed
   `[Symbol.iterator]()` result
 - **THEN** the mutation fails closed or is isolated from the execution snapshot
 - **AND** input-derived prototype mutation paths do not leave global prototype
-  residue on `Function.prototype` or `Array.prototype`
+  residue on `Object.prototype`, `Function.prototype`, or `Array.prototype`
+
+#### Scenario: evaluator-visible graph does not retain cross-call residue
+
+- **WHEN** one non-spawn evaluator call attempts to write custom properties to
+  evaluator-visible array prototypes, exposed methods, iterator objects,
+  iterator functions, and map-result paths
+- **THEN** a later evaluator call MUST NOT observe those custom properties
+- **AND** the inner execution input remains isolated from both evaluator calls
 
 ### Requirement: Spawn authority preparation remains unchanged
 

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/specs/policy-gate-non-spawn-input-bounds/spec.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/specs/policy-gate-non-spawn-input-bounds/spec.md
@@ -86,17 +86,19 @@ spread, `.includes()`, and `.map()`. Supported array-returning evaluator
 methods, including `.map()`, SHALL return evaluator-isolated non-extensible
 arrays rather than arrays linked to global `Array.prototype`.
 Evaluator-visible array prototype containers, array prototype functions,
-iterator objects, and iterator `next` functions SHALL be frozen or made
-non-extensible where the runtime permits, and evaluator arrays SHALL NOT expose
-a functional constructor path to global `Function.prototype`. Evaluator arrays
-SHALL be non-extensible after existing numeric indices are installed; direct
-assignment to existing indices MAY remain evaluator-local, but `push` and other
-array-growth APIs are outside the supported evaluator contract. Evaluator-local
-array reparenting MUST fail or remain isolated and MUST NOT leave residue on
-global `Object.prototype`, `Array.prototype`, or `Function.prototype` before
-inner execution continues. Evaluator mutation attempts MUST NOT change the input
-later supplied to the inner tool or global prototypes through input-derived
-prototype paths.
+iterator objects, iterator `next` functions, and iterator result objects SHALL
+be frozen or made non-extensible where the runtime permits, and evaluator arrays
+SHALL NOT expose a functional constructor path to global `Function.prototype`.
+Evaluator arrays SHALL be non-extensible after existing numeric indices are
+installed and SHALL keep their `length` control surface bounded for supported
+read APIs; direct assignment to existing indices MAY remain evaluator-local, but
+`push`, length growth, and other array-growth APIs are outside the supported
+evaluator contract. Evaluator-local array, iterator, or iterator-result
+reparenting MUST fail or remain isolated and MUST NOT leave residue on global
+`Object.prototype`, `Array.prototype`, or `Function.prototype` before inner
+execution continues. Evaluator mutation attempts MUST NOT change the input later
+supplied to the inner tool or global prototypes through input-derived prototype
+paths.
 
 #### Scenario: execution snapshot preserves ordinary object compatibility
 
@@ -130,11 +132,11 @@ prototype paths.
 - **WHEN** a custom evaluator attempts to mutate prototypes reachable from
   direct `Object.setPrototypeOf()` on evaluator top-level objects, nested
   objects, evaluator arrays, isolated array prototypes, exposed array methods,
-  map-result arrays/prototypes/functions, iterator objects/functions,
+  map-result arrays/prototypes/functions, iterator objects/functions/results,
   `Object.getPrototypeOf(values.constructor)`,
   `Object.getPrototypeOf(Object.getPrototypeOf(values).map)`,
   `Object.getPrototypeOf(values.map(...))`, or a directly accessed
-  `[Symbol.iterator]()` result
+  `[Symbol.iterator]()` result, or a directly accessed iterator `.next()` result
 - **THEN** the mutation fails closed or is isolated from the execution snapshot
 - **AND** input-derived prototype mutation paths do not leave global prototype
   residue on `Object.prototype`, `Function.prototype`, or `Array.prototype`
@@ -143,7 +145,7 @@ prototype paths.
 
 - **WHEN** one non-spawn evaluator call attempts to write custom properties to
   evaluator-visible array prototypes, exposed methods, iterator objects,
-  iterator functions, and map-result paths
+  iterator functions, iterator results, and map-result paths
 - **THEN** a later evaluator call MUST NOT observe those custom properties
 - **AND** the inner execution input remains isolated from both evaluator calls
 

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/specs/policy-gate-non-spawn-input-bounds/spec.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/specs/policy-gate-non-spawn-input-bounds/spec.md
@@ -3,18 +3,30 @@
 ### Requirement: Generic non-spawn policy-gate input preparation is bounded
 
 For tools other than `spawn_agent`, the policy-gate wrapper SHALL bound input
-preparation before expensive cloning. Inputs that exceed the preparation budget
-or require unsafe inspection SHALL fail closed with the existing
+preparation before evaluator execution and before inner tool execution. Inputs
+that exceed the preparation budget or require unsafe/stability-unbounded
+inspection SHALL fail closed with the existing
 `policy_gate_input_preparation_failed` tool result, and the wrapped inner tool
-MUST NOT execute.
+MUST NOT execute. Proxy-shaped and non-ordinary live inputs SHALL be rejected
+instead of treated as safely bounded structured data.
 
-#### Scenario: cheap array and object budgets reject before descriptor expansion
+#### Scenario: ordinary array and object budgets reject before value expansion
 
 - **WHEN** a non-spawn tool receives an over-length array or over-wide object
-- **THEN** array length and object own-key budgets are checked before array
-  own-key / element descriptor enumeration or object per-key descriptor reads
+- **THEN** ordinary array length is checked before array own-key / element
+  descriptor enumeration
+- **AND** ordinary object own-key count is checked after own-key enumeration and
+  before per-key descriptor/value reads
 - **AND** preparation fails closed before policy evaluation and before inner
   tool execution
+
+#### Scenario: proxy key discovery fails closed
+
+- **WHEN** a non-spawn tool receives proxy-shaped input whose key discovery or
+  descriptor stability cannot be bounded
+- **THEN** preparation fails closed before policy evaluation and before inner
+  tool execution
+- **AND** untrusted trap text is not leaked in the failure result
 
 #### Scenario: oversized generic input fails closed
 
@@ -33,11 +45,15 @@ MUST NOT execute.
 
 ### Requirement: Generic evaluator input cannot mutate execution input
 
-For tools other than `spawn_agent`, the policy-gate wrapper SHALL prepare
-separate execution and evaluator snapshots after bounded inspection. The
-evaluator snapshot SHALL be plain structured data, SHALL be structured-cloneable,
-and SHALL use null prototypes recursively for plain objects. Evaluator mutation
-attempts MUST NOT change the input later supplied to the inner tool.
+For tools other than `spawn_agent`, the policy-gate wrapper SHALL materialize
+accepted input once into a stable bounded canonical structured-data graph, then
+prepare separate execution and evaluator snapshots from that canonical graph.
+The evaluator snapshot SHALL be plain structured data, SHALL be
+structured-cloneable, SHALL use null prototypes recursively for plain objects,
+and SHALL preserve ordinary array read APIs including iteration, spread,
+`.includes()`, and `.map()`. Evaluator mutation attempts MUST NOT change the
+input later supplied to the inner tool or global prototypes through
+input-derived prototype paths.
 
 #### Scenario: evaluator mutation cannot affect inner execution
 
@@ -49,7 +65,8 @@ attempts MUST NOT change the input later supplied to the inner tool.
 #### Scenario: honest evaluator preserves normal execution
 
 - **WHEN** a custom evaluator snapshots a valid non-spawn input with
-  `structuredClone(call.input)` and returns allow
+  `structuredClone(call.input)`, reads array fields with `for...of`, spread,
+  `.includes()`, and `.map()`, and returns allow
 - **THEN** the inner tool executes with the expected cloned input value
 
 #### Scenario: evaluator prototype mutation paths cannot affect execution
@@ -57,8 +74,8 @@ attempts MUST NOT change the input later supplied to the inner tool.
 - **WHEN** a custom evaluator attempts to mutate prototypes reachable from
   `Object.getPrototypeOf(call.input)` or `call.input.constructor?.prototype`
 - **THEN** the mutation fails closed or is isolated from the execution snapshot
-- **AND** no global prototype residue is required for the inner tool to receive
-  the original input
+- **AND** input-derived prototype mutation paths do not leave global prototype
+  residue
 
 ### Requirement: Spawn authority preparation remains unchanged
 

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/specs/policy-gate-non-spawn-input-bounds/spec.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/specs/policy-gate-non-spawn-input-bounds/spec.md
@@ -8,6 +8,14 @@ or require unsafe inspection SHALL fail closed with the existing
 `policy_gate_input_preparation_failed` tool result, and the wrapped inner tool
 MUST NOT execute.
 
+#### Scenario: cheap array and object budgets reject before descriptor expansion
+
+- **WHEN** a non-spawn tool receives an over-length array or over-wide object
+- **THEN** array length and object own-key budgets are checked before array
+  own-key / element descriptor enumeration or object per-key descriptor reads
+- **AND** preparation fails closed before policy evaluation and before inner
+  tool execution
+
 #### Scenario: oversized generic input fails closed
 
 - **WHEN** a non-spawn tool receives an input whose depth, node count, array
@@ -18,29 +26,39 @@ MUST NOT execute.
 #### Scenario: hostile generic input still fails closed
 
 - **WHEN** a non-spawn tool receives accessor-backed, function-backed, symbol,
-  proxy-hostile, or prototype-polluting input that cannot be safely prepared
-- **THEN** preparation fails closed without leaking untrusted getter text and
-  without executing the inner tool
+  bigint, proxy-hostile, symbol-keyed, or prototype-polluting input that cannot
+  be safely prepared
+- **THEN** preparation fails closed without leaking untrusted getter or trap text
+  and without executing the inner tool
 
 ### Requirement: Generic evaluator input cannot mutate execution input
 
-For tools other than `spawn_agent`, the policy-gate wrapper SHALL prepare one
-execution snapshot and SHALL provide policy evaluators an isolated or read-only
-view. Evaluator mutation attempts MUST NOT change the input later supplied to
-the inner tool.
+For tools other than `spawn_agent`, the policy-gate wrapper SHALL prepare
+separate execution and evaluator snapshots after bounded inspection. The
+evaluator snapshot SHALL be plain structured data, SHALL be structured-cloneable,
+and SHALL use null prototypes recursively for plain objects. Evaluator mutation
+attempts MUST NOT change the input later supplied to the inner tool.
 
 #### Scenario: evaluator mutation cannot affect inner execution
 
 - **WHEN** a custom evaluator attempts to mutate top-level or nested fields of
   a prepared non-spawn input
-- **THEN** the mutation fails closed or is otherwise isolated, and the inner
-  tool does not execute with mutated input
+- **THEN** the mutation is isolated from the execution snapshot
+- **AND** the inner tool does not execute with mutated input
 
 #### Scenario: honest evaluator preserves normal execution
 
-- **WHEN** a custom evaluator only reads a valid non-spawn input and returns
-  allow
+- **WHEN** a custom evaluator snapshots a valid non-spawn input with
+  `structuredClone(call.input)` and returns allow
 - **THEN** the inner tool executes with the expected cloned input value
+
+#### Scenario: evaluator prototype mutation paths cannot affect execution
+
+- **WHEN** a custom evaluator attempts to mutate prototypes reachable from
+  `Object.getPrototypeOf(call.input)` or `call.input.constructor?.prototype`
+- **THEN** the mutation fails closed or is isolated from the execution snapshot
+- **AND** no global prototype residue is required for the inner tool to receive
+  the original input
 
 ### Requirement: Spawn authority preparation remains unchanged
 

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/specs/policy-gate-non-spawn-input-bounds/spec.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/specs/policy-gate-non-spawn-input-bounds/spec.md
@@ -82,18 +82,21 @@ be plain structured data, SHALL be structured-cloneable, SHALL use null
 prototypes recursively for plain objects, SHALL make evaluator plain objects
 non-extensible after existing properties are installed, and SHALL preserve the
 explicitly supported evaluator array APIs: direct numeric indexing, `for...of`,
-spread, `.includes()`, `.map()`, and `push`. Supported array-returning
-evaluator methods, including `.map()`, SHALL return evaluator-isolated arrays
-rather than arrays linked to global `Array.prototype`. Evaluator-visible array
-prototype containers, array prototype functions, iterator objects, and iterator
-`next` functions SHALL be frozen or made non-extensible where the runtime
-permits, and evaluator arrays SHALL NOT expose a functional constructor path to
-global `Function.prototype`. Evaluator arrays MAY remain extensible to preserve
-`push` and direct index mutation; any evaluator-local array reparenting MUST
-NOT leave residue on global `Object.prototype`, `Array.prototype`, or
-`Function.prototype` before inner execution continues. Evaluator mutation
-attempts MUST NOT change the input later supplied to the inner tool or global
-prototypes through input-derived prototype paths.
+spread, `.includes()`, and `.map()`. Supported array-returning evaluator
+methods, including `.map()`, SHALL return evaluator-isolated non-extensible
+arrays rather than arrays linked to global `Array.prototype`.
+Evaluator-visible array prototype containers, array prototype functions,
+iterator objects, and iterator `next` functions SHALL be frozen or made
+non-extensible where the runtime permits, and evaluator arrays SHALL NOT expose
+a functional constructor path to global `Function.prototype`. Evaluator arrays
+SHALL be non-extensible after existing numeric indices are installed; direct
+assignment to existing indices MAY remain evaluator-local, but `push` and other
+array-growth APIs are outside the supported evaluator contract. Evaluator-local
+array reparenting MUST fail or remain isolated and MUST NOT leave residue on
+global `Object.prototype`, `Array.prototype`, or `Function.prototype` before
+inner execution continues. Evaluator mutation attempts MUST NOT change the input
+later supplied to the inner tool or global prototypes through input-derived
+prototype paths.
 
 #### Scenario: execution snapshot preserves ordinary object compatibility
 
@@ -116,11 +119,11 @@ prototypes through input-derived prototype paths.
 
 - **WHEN** a custom evaluator snapshots a valid non-spawn input with
   `structuredClone(call.input)`, reads array fields with direct numeric
-  indexing, `for...of`, spread, `.includes()`, and `.map()`, uses evaluator-local
-  `push`, and returns allow
+  indexing, `for...of`, spread, `.includes()`, and `.map()`, mutates an existing
+  evaluator-local numeric index, and returns allow
 - **THEN** the inner tool executes with the expected cloned input value
-- **AND** `.map()` results are evaluator-isolated arrays, not arrays linked to
-  global `Array.prototype`
+- **AND** `.map()` results are evaluator-isolated non-extensible arrays, not
+  arrays linked to global `Array.prototype`
 
 #### Scenario: evaluator prototype mutation paths cannot affect execution
 

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/specs/policy-gate-non-spawn-input-bounds/spec.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/specs/policy-gate-non-spawn-input-bounds/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Generic non-spawn policy-gate input preparation is bounded
+
+For tools other than `spawn_agent`, the policy-gate wrapper SHALL bound input
+preparation before expensive cloning. Inputs that exceed the preparation budget
+or require unsafe inspection SHALL fail closed with the existing
+`policy_gate_input_preparation_failed` tool result, and the wrapped inner tool
+MUST NOT execute.
+
+#### Scenario: oversized generic input fails closed
+
+- **WHEN** a non-spawn tool receives an input whose depth, node count, array
+  length, or string budget exceeds the generic preparation budget
+- **THEN** preparation fails closed before policy evaluation and before inner
+  tool execution
+
+#### Scenario: hostile generic input still fails closed
+
+- **WHEN** a non-spawn tool receives accessor-backed, function-backed, symbol,
+  proxy-hostile, or prototype-polluting input that cannot be safely prepared
+- **THEN** preparation fails closed without leaking untrusted getter text and
+  without executing the inner tool
+
+### Requirement: Generic evaluator input cannot mutate execution input
+
+For tools other than `spawn_agent`, the policy-gate wrapper SHALL prepare one
+execution snapshot and SHALL provide policy evaluators an isolated or read-only
+view. Evaluator mutation attempts MUST NOT change the input later supplied to
+the inner tool.
+
+#### Scenario: evaluator mutation cannot affect inner execution
+
+- **WHEN** a custom evaluator attempts to mutate top-level or nested fields of
+  a prepared non-spawn input
+- **THEN** the mutation fails closed or is otherwise isolated, and the inner
+  tool does not execute with mutated input
+
+#### Scenario: honest evaluator preserves normal execution
+
+- **WHEN** a custom evaluator only reads a valid non-spawn input and returns
+  allow
+- **THEN** the inner tool executes with the expected cloned input value
+
+### Requirement: Spawn authority preparation remains unchanged
+
+The generic non-spawn preparation change MUST NOT change `spawn_agent`
+normalization, profile subset authority checks, or spawn evaluator snapshot
+behavior delivered by issue #20.
+
+#### Scenario: spawn profile paths remain stable
+
+- **WHEN** valid and invalid `spawn_agent` profile inputs are evaluated
+- **THEN** their allow/deny behavior and normalized execution inputs remain
+  consistent with the issue #20 contract

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/tasks.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/tasks.md
@@ -5,8 +5,9 @@
 - [x] 1.2 Change generic non-spawn preparation to create separate execution and
   evaluator snapshots from one canonical materialized graph, using cloneable
   plain data, recursive null prototypes for plain object snapshots, and
-  evaluator array prototypes that preserve read APIs without shared global
-  prototype mutation paths.
+  JSON-style numeric-index array materialization plus evaluator array
+  prototypes that preserve supported APIs without shared global prototype
+  mutation paths.
 - [x] 1.3 Preserve existing preparation failure payloads, evaluator failure
   behavior, and running-tool metadata finalization.
 - [x] 1.4 Audit and preserve the `spawn_agent` preparation path unchanged.
@@ -19,9 +20,9 @@
     array length + 1; object key count = generic max key count + 1; total
     string budget = generic max string budget + 1.
   - Ordering evidence: proxy inputs fail before key/descriptor traps;
-    over-length dense arrays fail before array own-key / element descriptor
-    enumeration; over-wide ordinary objects fail after own-key enumeration and
-    before per-key value reads.
+    over-length dense arrays fail before array own-key discovery or numeric
+    index descriptor reads; over-wide ordinary objects fail after own-key
+    enumeration and before per-key value reads.
   - Expected: result contains `policy_gate_input_preparation_failed`, evaluator
     calls = 0, inner tool calls = 0, running handle finished with failed summary.
 - [x] 2.2 Add tests that evaluator top-level and nested mutation attempts cannot
@@ -37,10 +38,16 @@
     symbol value, bigint value, symbol key, own `__proto__` data key,
     `constructor` key, and `prototype` key.
 - [x] 2.4 Add tests that honest evaluators can `structuredClone(call.input)`,
-  iterate and spread evaluator array fields, call `.includes()` / `.map()`, and
-  that evaluator prototype mutation paths cannot affect inner execution or
-  global prototypes.
-- [x] 2.5 Add or preserve tests proving representative `spawn_agent` paths remain
+  use direct numeric indexing, iterate and spread evaluator array fields, call
+  `.includes()` / `.map()`, use `push`, receive evaluator-isolated `.map()`
+  results, and cannot mutate inner execution or global prototypes through array
+  constructor, method, map-result, or iterator paths.
+- [x] 2.5 Add tests that low-length ordinary arrays with over-budget non-index
+  own properties do not trigger array `Reflect.ownKeys()`, do not read non-index
+  descriptors, preserve sparse numeric-index holes, and omit non-index
+  function/symbol/bigint/prototype-polluting properties from evaluator and
+  execution snapshots.
+- [x] 2.6 Add or preserve tests proving representative `spawn_agent` paths remain
   unchanged.
   - Valid input: `role="worker"`, `tools=["read"]`, non-empty instruction ->
     allow path preserves normalized execution input.

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/tasks.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/tasks.md
@@ -18,7 +18,8 @@
 - [x] 1.6 Harden evaluator-visible graph after setup: evaluator plain objects
   are non-extensible, isolated array prototype containers and exposed method /
   iterator functions are frozen or non-extensible, evaluator arrays and map
-  results are non-extensible, and evaluator-local array reparent attempts fail
+  results are non-extensible with bounded `length`, iterator results are frozen
+  or non-extensible, and evaluator-local array/iterator reparent attempts fail
   before reaching global intrinsics.
 
 ## 2. Regression Tests
@@ -56,7 +57,7 @@
   receive evaluator-isolated non-extensible `.map()` results, and cannot mutate
   inner execution or global prototypes through direct object reparenting, array
   reparenting, array constructor, method,
-  map-result, or iterator paths.
+  map-result, iterator, or iterator-result paths.
 - [x] 2.5 Add tests that low-length ordinary arrays with over-budget non-index
   own properties do not trigger array `Reflect.ownKeys()`, do not read non-index
   descriptors, preserve sparse numeric-index holes, and omit non-index
@@ -85,13 +86,15 @@
 - [x] 2.10 Add tests that evaluator-visible graph hardening and residue cleanup
   cover direct `Object.setPrototypeOf()` probes against top object, nested
   object, evaluator arrays, isolated array prototype, isolated method function,
-  iterator object, iterator next function, map result array/prototype/function
-  paths, and global prototype residue. Evaluator array and map-result reparent
-  attempts must fail because those arrays are non-extensible.
+  iterator object, iterator next function, iterator result object, map result
+  array/prototype/function paths, and global prototype residue. Evaluator array
+  and map-result reparent attempts must fail because those arrays are
+  non-extensible; evaluator length-growth attempts must not make supported read
+  APIs exceed the bounded canonical array length.
 - [x] 2.11 Add a cross-call residue test proving custom properties written to
   evaluator-visible prototypes, exposed methods, iterators, iterator functions,
-  and map-result paths in one evaluator call are not observable by the next
-  evaluator call.
+  iterator results, and map-result paths in one evaluator call are not
+  observable by the next evaluator call.
 
 ## 3. Risk Pack Evidence Matrix
 
@@ -104,7 +107,9 @@
 - [x] 3.3 Concurrency / shared state / ordering: evaluator mutation tests prove
   evaluator code cannot mutate the execution snapshot observed by the inner
   tool, evaluator array reparenting cannot reach global intrinsics, and
-  evaluator-visible method/prototype residue cannot persist across calls.
+  evaluator-visible method/prototype/iterator-result residue cannot persist
+  across calls; supported evaluator read APIs remain bounded after
+  evaluator-local mutation.
 - [x] 3.4 Resource limits / large input / discovery: depth, array-length, and
   string-budget tests fail closed before evaluator execution; proxy tests prove
   key/descriptor traps are not reached; ordinary object tests prove over-wide

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/tasks.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/tasks.md
@@ -1,10 +1,12 @@
 ## 1. Preparation Contract
 
-- [x] 1.1 Add generic non-spawn preparation budgets and descriptor-safe
-  inspection before structured cloning.
+- [x] 1.1 Add generic non-spawn preparation budgets and proxy/non-ordinary
+  fail-closed checks before live key discovery or evaluator execution.
 - [x] 1.2 Change generic non-spawn preparation to create separate execution and
-  evaluator snapshots after inspection, using cloneable plain data and recursive
-  null prototypes for plain object snapshots.
+  evaluator snapshots from one canonical materialized graph, using cloneable
+  plain data, recursive null prototypes for plain object snapshots, and
+  evaluator array prototypes that preserve read APIs without shared global
+  prototype mutation paths.
 - [x] 1.3 Preserve existing preparation failure payloads, evaluator failure
   behavior, and running-tool metadata finalization.
 - [x] 1.4 Audit and preserve the `spawn_agent` preparation path unchanged.
@@ -16,9 +18,10 @@
   - Inputs: object depth = generic max depth + 1; array length = generic max
     array length + 1; object key count = generic max key count + 1; total
     string budget = generic max string budget + 1.
-  - Ordering evidence: over-length dense arrays fail before array own-key /
-    element descriptor enumeration; over-wide objects fail before per-key
-    descriptor reads.
+  - Ordering evidence: proxy inputs fail before key/descriptor traps;
+    over-length dense arrays fail before array own-key / element descriptor
+    enumeration; over-wide ordinary objects fail after own-key enumeration and
+    before per-key value reads.
   - Expected: result contains `policy_gate_input_preparation_failed`, evaluator
     calls = 0, inner tool calls = 0, running handle finished with failed summary.
 - [x] 2.2 Add tests that evaluator top-level and nested mutation attempts cannot
@@ -33,8 +36,10 @@
   - Inputs: accessor-backed field, proxy-hostile own-key trap, function value,
     symbol value, bigint value, symbol key, own `__proto__` data key,
     `constructor` key, and `prototype` key.
-- [x] 2.4 Add tests that honest evaluators can `structuredClone(call.input)` and
-  that evaluator prototype mutation paths cannot affect inner execution.
+- [x] 2.4 Add tests that honest evaluators can `structuredClone(call.input)`,
+  iterate and spread evaluator array fields, call `.includes()` / `.map()`, and
+  that evaluator prototype mutation paths cannot affect inner execution or
+  global prototypes.
 - [x] 2.5 Add or preserve tests proving representative `spawn_agent` paths remain
   unchanged.
   - Valid input: `role="worker"`, `tools=["read"]`, non-empty instruction ->
@@ -55,8 +60,9 @@
   evaluator code cannot mutate the execution snapshot observed by the inner
   tool.
 - [x] 3.4 Resource limits / large input / discovery: depth, array-length, and
-  string-budget tests fail closed before evaluator execution; cheap array/object
-  ordering tests prove descriptor paths are not reached after budget rejection.
+  string-budget tests fail closed before evaluator execution; proxy tests prove
+  key/descriptor traps are not reached; ordinary object tests prove over-wide
+  inputs fail before per-key value reads.
 - [x] 3.5 Legacy compatibility / examples: existing non-spawn deny, preparation
   failure, raw-data wrapper, and spawn tests remain green under `bun run check`.
 - [x] 3.6 Error handling / rollback / partial outputs: preparation and evaluator

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/tasks.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/tasks.md
@@ -4,13 +4,22 @@
   fail-closed checks before live key discovery or evaluator execution.
 - [x] 1.2 Change generic non-spawn preparation to create separate execution and
   evaluator snapshots from one canonical materialized graph, using cloneable
-  plain data, recursive null prototypes for plain object snapshots, and
-  JSON-style numeric-index array materialization plus evaluator array
-  prototypes that preserve supported APIs without shared global prototype
-  mutation paths.
+  plain data, ordinary plain objects for execution snapshots, recursive
+  null-prototype non-extensible plain objects for evaluator snapshots, and
+  JSON-style numeric-index array materialization plus frozen evaluator array
+  prototypes/functions/iterators that preserve supported APIs without shared
+  global prototype mutation paths.
 - [x] 1.3 Preserve existing preparation failure payloads, evaluator failure
   behavior, and running-tool metadata finalization.
 - [x] 1.4 Audit and preserve the `spawn_agent` preparation path unchanged.
+- [x] 1.5 Reject live non-ordinary generic arrays, including array subclasses
+  and custom-prototype arrays at top level or nested under ordinary objects,
+  while leaving materialized canonical arrays and execution arrays ordinary.
+- [x] 1.6 Harden evaluator-visible graph after setup: evaluator plain objects
+  are non-extensible, isolated array prototype containers and exposed method /
+  iterator functions are frozen or non-extensible, and non-spawn evaluator
+  execution restores input-derived intrinsic residue after evaluator-local
+  array reparent attempts.
 
 ## 2. Regression Tests
 
@@ -23,6 +32,10 @@
     over-length dense arrays fail before array own-key discovery or numeric
     index descriptor reads; over-wide ordinary objects fail after own-key
     enumeration and before per-key value reads.
+  - Follow-up 3 ordering evidence: an over-length ordinary array with patched
+    `Reflect.ownKeys` and array numeric `Reflect.getOwnPropertyDescriptor`
+    fails with array own-key calls = 0, numeric descriptor reads = 0,
+    evaluator calls = 0, and inner tool calls = 0.
   - Expected: result contains `policy_gate_input_preparation_failed`, evaluator
     calls = 0, inner tool calls = 0, running handle finished with failed summary.
 - [x] 2.2 Add tests that evaluator top-level and nested mutation attempts cannot
@@ -40,8 +53,9 @@
 - [x] 2.4 Add tests that honest evaluators can `structuredClone(call.input)`,
   use direct numeric indexing, iterate and spread evaluator array fields, call
   `.includes()` / `.map()`, use `push`, receive evaluator-isolated `.map()`
-  results, and cannot mutate inner execution or global prototypes through array
-  constructor, method, map-result, or iterator paths.
+  results, and cannot mutate inner execution or global prototypes through direct
+  object reparenting, array reparenting, array constructor, method,
+  map-result, or iterator paths.
 - [x] 2.5 Add tests that low-length ordinary arrays with over-budget non-index
   own properties do not trigger array `Reflect.ownKeys()`, do not read non-index
   descriptors, preserve sparse numeric-index holes, and omit non-index
@@ -54,6 +68,28 @@
   - Invalid input: `role="worker"`, `tools=["read","edit"]` -> deny before spawn
     with `ruleId=spawn-profile-subset`, `guard_class=authority`, and
     `remediation.next_action=adjust_scope`.
+- [x] 2.7 Add tests that non-ordinary non-array inputs fail closed before
+  evaluator and inner execution.
+  - Inputs: class instance, `Date`, `Map`, and custom-prototype object.
+- [x] 2.8 Add tests that non-ordinary arrays fail closed before evaluator and
+  inner execution.
+  - Inputs: array subclass and custom-prototype array at top level; array
+    subclass and custom-prototype array nested in an ordinary object.
+- [x] 2.9 Add tests that execution snapshots preserve ordinary plain-object
+  compatibility while evaluator snapshots remain null-prototype and hardened.
+  - Expected: inner execution input supports `input.hasOwnProperty(...)`,
+    `input instanceof Object`, ordinary nested object prototypes, and normal
+    `Array.prototype` arrays; evaluator top/nested objects are null-prototype
+    and non-extensible.
+- [x] 2.10 Add tests that evaluator-visible graph hardening and residue cleanup
+  cover direct `Object.setPrototypeOf()` probes against top object, nested
+  object, evaluator arrays, isolated array prototype, isolated method function,
+  iterator object, iterator next function, map result array/prototype/function
+  paths, and global prototype residue.
+- [x] 2.11 Add a cross-call residue test proving custom properties written to
+  evaluator-visible prototypes, exposed methods, iterators, iterator functions,
+  and map-result paths in one evaluator call are not observable by the next
+  evaluator call.
 
 ## 3. Risk Pack Evidence Matrix
 
@@ -65,11 +101,20 @@
   `guard_class=authority`.
 - [x] 3.3 Concurrency / shared state / ordering: evaluator mutation tests prove
   evaluator code cannot mutate the execution snapshot observed by the inner
-  tool.
+  tool, and evaluator-visible method/prototype residue cannot persist across
+  calls.
 - [x] 3.4 Resource limits / large input / discovery: depth, array-length, and
   string-budget tests fail closed before evaluator execution; proxy tests prove
   key/descriptor traps are not reached; ordinary object tests prove over-wide
-  inputs fail before per-key value reads.
+  inputs fail before per-key value reads; ordinary over-length array tests
+  prove length rejection happens before array key discovery and numeric
+  descriptor reads.
+- [x] 3.4a Non-ordinary live input boundary: class/Date/Map/custom-prototype
+  non-array inputs and array subclass/custom-prototype inputs fail closed before
+  evaluator and inner execution.
+- [x] 3.4b Execution/evaluator snapshot compatibility: execution snapshots keep
+  ordinary structuredClone-like object compatibility, while evaluator snapshots
+  keep null-prototype hardened plain objects and isolated arrays.
 - [x] 3.5 Legacy compatibility / examples: existing non-spawn deny, preparation
   failure, raw-data wrapper, and spawn tests remain green under `bun run check`.
 - [x] 3.6 Error handling / rollback / partial outputs: preparation and evaluator

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/tasks.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/tasks.md
@@ -1,0 +1,66 @@
+## 1. Preparation Contract
+
+- [x] 1.1 Add generic non-spawn preparation budgets and descriptor-safe
+  inspection before structured cloning.
+- [x] 1.2 Change generic non-spawn preparation to use one execution snapshot and
+  a mutation-blocking evaluator view.
+- [x] 1.3 Preserve existing preparation failure payloads, evaluator failure
+  behavior, and running-tool metadata finalization.
+- [x] 1.4 Audit and preserve the `spawn_agent` preparation path unchanged.
+
+## 2. Regression Tests
+
+- [x] 2.1 Add tests for oversized and deeply nested non-spawn inputs failing
+  closed before evaluator and inner tool execution.
+  - Inputs: object depth = generic max depth + 1; array length = generic max
+    array length + 1; total string budget = generic max string budget + 1.
+  - Expected: result contains `policy_gate_input_preparation_failed`, evaluator
+    calls = 0, inner tool calls = 0, running handle finished with failed summary.
+- [x] 2.2 Add tests that evaluator top-level and nested mutation attempts cannot
+  affect inner tool execution.
+  - Inputs: `{ command: "original", nested: { flag: "original" } }`.
+  - Mutations attempted by evaluator: `input.command = "mutated"` and
+    `input.nested.flag = "mutated"`.
+  - Expected: mutation returns a failed ToolResult before inner execution, or the
+    inner tool receives `command="original"` and `nested.flag="original"`; in no
+    case may the inner tool execute mutated input.
+- [x] 2.3 Keep hostile accessor/prototype-pollution preparation tests green.
+- [x] 2.4 Add or preserve tests proving representative `spawn_agent` paths remain
+  unchanged.
+  - Valid input: `role="worker"`, `tools=["read"]`, non-empty instruction ->
+    allow path preserves normalized execution input.
+  - Invalid input: `role="worker"`, `tools=["read","edit"]` -> deny before spawn
+    with `ruleId=spawn-profile-subset`, `guard_class=authority`, and
+    `remediation.next_action=adjust_scope`.
+
+## 3. Risk Pack Evidence Matrix
+
+- [x] 3.1 Public API / CLI / script entry: wrapped non-spawn `run()` tests cover
+  the public entrypoint result shape for allow, preparation failure, and
+  evaluator failure.
+- [x] 3.2 Auth / permissions / secrets: representative valid and invalid
+  `spawn_agent` profile tests preserve issue #20 authority semantics and
+  `guard_class=authority`.
+- [x] 3.3 Concurrency / shared state / ordering: evaluator mutation tests prove
+  evaluator code cannot mutate the execution snapshot observed by the inner
+  tool.
+- [x] 3.4 Resource limits / large input / discovery: depth, array-length, and
+  string-budget tests fail closed before evaluator execution.
+- [x] 3.5 Legacy compatibility / examples: existing non-spawn deny, preparation
+  failure, raw-data wrapper, and spawn tests remain green under `bun run check`.
+- [x] 3.6 Error handling / rollback / partial outputs: preparation and evaluator
+  failures skip inner execution and finish running-tool handles.
+- [x] 3.7 Release / packaging / dependency compatibility: no dependency manifest
+  or Zero source changes; `git -C zero diff --quiet` stays clean.
+- [x] 3.8 Zero adapter / tool registry / agent role governance: SHUD policy-gated
+  registry and spawn profile subset tests remain green.
+
+## 4. Verification
+
+- [x] 4.1 Run focused core policy-gate tests; expected exit 0.
+- [x] 4.2 Run `npx --yes bun@1.2.19 run check`; expected exit 0.
+- [x] 4.3 Run `openspec validate m1-policy-gate-non-spawn-input-bounds --strict --no-interactive`; expected exit 0.
+- [x] 4.4 Run `git diff --check` and `git -C zero diff --quiet`; expected clean
+  whitespace diff and zero submodule diff.
+- [x] 4.5 Verify no runtime dependency manifest changes are present unless an
+  unexpected implementation blocker is documented in PR evidence.

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/tasks.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/tasks.md
@@ -2,8 +2,9 @@
 
 - [x] 1.1 Add generic non-spawn preparation budgets and descriptor-safe
   inspection before structured cloning.
-- [x] 1.2 Change generic non-spawn preparation to use one execution snapshot and
-  a mutation-blocking evaluator view.
+- [x] 1.2 Change generic non-spawn preparation to create separate execution and
+  evaluator snapshots after inspection, using cloneable plain data and recursive
+  null prototypes for plain object snapshots.
 - [x] 1.3 Preserve existing preparation failure payloads, evaluator failure
   behavior, and running-tool metadata finalization.
 - [x] 1.4 Audit and preserve the `spawn_agent` preparation path unchanged.
@@ -13,7 +14,11 @@
 - [x] 2.1 Add tests for oversized and deeply nested non-spawn inputs failing
   closed before evaluator and inner tool execution.
   - Inputs: object depth = generic max depth + 1; array length = generic max
-    array length + 1; total string budget = generic max string budget + 1.
+    array length + 1; object key count = generic max key count + 1; total
+    string budget = generic max string budget + 1.
+  - Ordering evidence: over-length dense arrays fail before array own-key /
+    element descriptor enumeration; over-wide objects fail before per-key
+    descriptor reads.
   - Expected: result contains `policy_gate_input_preparation_failed`, evaluator
     calls = 0, inner tool calls = 0, running handle finished with failed summary.
 - [x] 2.2 Add tests that evaluator top-level and nested mutation attempts cannot
@@ -21,11 +26,16 @@
   - Inputs: `{ command: "original", nested: { flag: "original" } }`.
   - Mutations attempted by evaluator: `input.command = "mutated"` and
     `input.nested.flag = "mutated"`.
-  - Expected: mutation returns a failed ToolResult before inner execution, or the
-    inner tool receives `command="original"` and `nested.flag="original"`; in no
-    case may the inner tool execute mutated input.
-- [x] 2.3 Keep hostile accessor/prototype-pollution preparation tests green.
-- [x] 2.4 Add or preserve tests proving representative `spawn_agent` paths remain
+  - Expected: evaluator returns allow and the inner tool receives
+    `command="original"` and `nested.flag="original"`.
+- [x] 2.3 Keep hostile accessor/proxy/prototype-pollution and unsafe value
+  preparation tests green.
+  - Inputs: accessor-backed field, proxy-hostile own-key trap, function value,
+    symbol value, bigint value, symbol key, own `__proto__` data key,
+    `constructor` key, and `prototype` key.
+- [x] 2.4 Add tests that honest evaluators can `structuredClone(call.input)` and
+  that evaluator prototype mutation paths cannot affect inner execution.
+- [x] 2.5 Add or preserve tests proving representative `spawn_agent` paths remain
   unchanged.
   - Valid input: `role="worker"`, `tools=["read"]`, non-empty instruction ->
     allow path preserves normalized execution input.
@@ -45,7 +55,8 @@
   evaluator code cannot mutate the execution snapshot observed by the inner
   tool.
 - [x] 3.4 Resource limits / large input / discovery: depth, array-length, and
-  string-budget tests fail closed before evaluator execution.
+  string-budget tests fail closed before evaluator execution; cheap array/object
+  ordering tests prove descriptor paths are not reached after budget rejection.
 - [x] 3.5 Legacy compatibility / examples: existing non-spawn deny, preparation
   failure, raw-data wrapper, and spawn tests remain green under `bun run check`.
 - [x] 3.6 Error handling / rollback / partial outputs: preparation and evaluator

--- a/openspec/changes/m1-policy-gate-non-spawn-input-bounds/tasks.md
+++ b/openspec/changes/m1-policy-gate-non-spawn-input-bounds/tasks.md
@@ -17,9 +17,9 @@
   while leaving materialized canonical arrays and execution arrays ordinary.
 - [x] 1.6 Harden evaluator-visible graph after setup: evaluator plain objects
   are non-extensible, isolated array prototype containers and exposed method /
-  iterator functions are frozen or non-extensible, and non-spawn evaluator
-  execution restores input-derived intrinsic residue after evaluator-local
-  array reparent attempts.
+  iterator functions are frozen or non-extensible, evaluator arrays and map
+  results are non-extensible, and evaluator-local array reparent attempts fail
+  before reaching global intrinsics.
 
 ## 2. Regression Tests
 
@@ -52,9 +52,10 @@
     `constructor` key, and `prototype` key.
 - [x] 2.4 Add tests that honest evaluators can `structuredClone(call.input)`,
   use direct numeric indexing, iterate and spread evaluator array fields, call
-  `.includes()` / `.map()`, use `push`, receive evaluator-isolated `.map()`
-  results, and cannot mutate inner execution or global prototypes through direct
-  object reparenting, array reparenting, array constructor, method,
+  `.includes()` / `.map()`, mutate existing evaluator-local numeric indices,
+  receive evaluator-isolated non-extensible `.map()` results, and cannot mutate
+  inner execution or global prototypes through direct object reparenting, array
+  reparenting, array constructor, method,
   map-result, or iterator paths.
 - [x] 2.5 Add tests that low-length ordinary arrays with over-budget non-index
   own properties do not trigger array `Reflect.ownKeys()`, do not read non-index
@@ -85,7 +86,8 @@
   cover direct `Object.setPrototypeOf()` probes against top object, nested
   object, evaluator arrays, isolated array prototype, isolated method function,
   iterator object, iterator next function, map result array/prototype/function
-  paths, and global prototype residue.
+  paths, and global prototype residue. Evaluator array and map-result reparent
+  attempts must fail because those arrays are non-extensible.
 - [x] 2.11 Add a cross-call residue test proving custom properties written to
   evaluator-visible prototypes, exposed methods, iterators, iterator functions,
   and map-result paths in one evaluator call are not observable by the next
@@ -101,8 +103,8 @@
   `guard_class=authority`.
 - [x] 3.3 Concurrency / shared state / ordering: evaluator mutation tests prove
   evaluator code cannot mutate the execution snapshot observed by the inner
-  tool, and evaluator-visible method/prototype residue cannot persist across
-  calls.
+  tool, evaluator array reparenting cannot reach global intrinsics, and
+  evaluator-visible method/prototype residue cannot persist across calls.
 - [x] 3.4 Resource limits / large input / discovery: depth, array-length, and
   string-budget tests fail closed before evaluator execution; proxy tests prove
   key/descriptor traps are not reached; ordinary object tests prove over-wide

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -234,6 +234,168 @@ describe("policy-gated zero tool registry", () => {
     expect(bashLikeTool.calls).toBe(0);
   });
 
+  test("oversized non-spawn inputs fail closed before evaluator and inner tool execution", async () => {
+    const tailSentinel = "STRING_BUDGET_TAIL_SENTINEL";
+    const cases: Array<{ label: string; input: unknown }> = [
+      {
+        label: "deep",
+        input: createNestedPolicyGateInput(33)
+      },
+      {
+        label: "array-length",
+        input: {
+          values: Array.from({ length: 1_025 }, () => "x")
+        }
+      },
+      {
+        label: "object-key-count",
+        input: createObjectWithKeyCount(257)
+      },
+      {
+        label: "node-count",
+        input: createNodeDensePolicyGateInput()
+      },
+      {
+        label: "string-budget",
+        input: {
+          command: `${"x".repeat(131_073)}${tailSentinel}`
+        }
+      }
+    ];
+
+    for (const testCase of cases) {
+      const editTool = new RecordingTool("edit");
+      const runningToolRegistry = new TestRunningToolRegistry();
+      const toolUseId = `POLICY-BUDGET-${testCase.label}`;
+      const handle = runningToolRegistry.register({
+        toolUseId,
+        toolName: "edit",
+        abortable: false
+      });
+      let evaluatorCalls = 0;
+      const wrapped = wrapToolWithPolicyGate(editTool, {
+        evaluate: async () => {
+          evaluatorCalls += 1;
+          return { decision: "allow" };
+        }
+      });
+
+      const result = await wrapped.run(
+        {
+          ...createToolContext("worker"),
+          currentToolUseId: toolUseId,
+          runningToolRegistry
+        },
+        testCase.input
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("policy_gate_input_preparation_failed");
+      expect(result.output).not.toContain(tailSentinel);
+      expect(result.outputSummary).toBe("Policy gate input preparation failed for edit");
+      expect(evaluatorCalls).toBe(0);
+      expect(editTool.calls).toBe(0);
+      expect(handle.getState()).toBe("finished");
+      expect(handle.getTerminalMetadata()).toMatchObject({
+        cause: "completed",
+        success: false,
+        outputSummary: result.outputSummary
+      });
+    }
+  });
+
+  test("non-spawn evaluator mutation attempts fail closed without reaching the inner tool", async () => {
+    const cases: Array<{ label: string; mutate: (input: unknown) => void }> = [
+      {
+        label: "top-level",
+        mutate(input) {
+          (input as { command: string }).command = "mutated";
+        }
+      },
+      {
+        label: "nested",
+        mutate(input) {
+          (input as { nested: { flag: string } }).nested.flag = "mutated";
+        }
+      },
+      {
+        label: "descriptor-nested",
+        mutate(input) {
+          const nested = Object.getOwnPropertyDescriptor(input as object, "nested")?.value as {
+            flag: string;
+          };
+          nested.flag = "mutated";
+        }
+      }
+    ];
+
+    for (const testCase of cases) {
+      const editTool = new RecordingTool("edit");
+      const input = {
+        command: "original",
+        nested: {
+          flag: "original"
+        }
+      };
+      const wrapped = wrapToolWithPolicyGate(editTool, {
+        evaluate: async (call) => {
+          testCase.mutate(call.input);
+          return { decision: "allow" };
+        }
+      });
+
+      const result = await wrapped.run(createToolContext("worker"), input);
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("Policy gate evaluator input is read-only");
+      expect(result.outputSummary).toContain("Error: Policy gate evaluator input is read-only");
+      expect(editTool.calls).toBe(0);
+      expect(input).toEqual({
+        command: "original",
+        nested: {
+          flag: "original"
+        }
+      });
+    }
+  });
+
+  test("non-spawn evaluator reads a readonly view while inner tool receives the execution snapshot", async () => {
+    const editTool = new RecordingTool("edit");
+    const input = {
+      command: "original",
+      nested: {
+        flag: "original"
+      }
+    };
+    let evaluatorInput: unknown;
+    let evaluatorSawCommand: unknown;
+    let evaluatorSawNestedFlag: unknown;
+    const wrapped = wrapToolWithPolicyGate(editTool, {
+      evaluate: async (call) => {
+        evaluatorInput = call.input;
+        evaluatorSawCommand = (call.input as { command?: unknown }).command;
+        evaluatorSawNestedFlag = (call.input as { nested?: { flag?: unknown } }).nested?.flag;
+        return { decision: "allow" };
+      }
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), input);
+
+    expect(result.success).toBe(true);
+    expect(evaluatorSawCommand).toBe("original");
+    expect(evaluatorSawNestedFlag).toBe("original");
+    expect(editTool.calls).toBe(1);
+    expect(editTool.lastInput).toEqual({
+      command: "original",
+      nested: {
+        flag: "original"
+      }
+    });
+    expect(editTool.lastInput).not.toBe(input);
+    expect((editTool.lastInput as { nested: unknown }).nested).not.toBe(input.nested);
+    expect(evaluatorInput).not.toBe(editTool.lastInput);
+  });
+
   test("malformed raw-rule deny from custom evaluator fails closed and finishes running handle", async () => {
     const bashTool = new RecordingTool("bash");
     const runningToolRegistry = new TestRunningToolRegistry();
@@ -3202,6 +3364,34 @@ class RequiredCommandRecordingTool extends RecordingTool {
     },
     required: ["command"],
     additionalProperties: true
+  };
+}
+
+function createNestedPolicyGateInput(depth: number): Record<string, unknown> {
+  let value: Record<string, unknown> = {
+    leaf: "value"
+  };
+  for (let index = 0; index < depth; index += 1) {
+    value = {
+      child: value
+    };
+  }
+  return value;
+}
+
+function createObjectWithKeyCount(count: number): Record<string, unknown> {
+  return Object.fromEntries(
+    Array.from({ length: count }, (_, index) => [`key_${index}`, "value"])
+  );
+}
+
+function createNodeDensePolicyGateInput(): Record<string, unknown> {
+  return {
+    batches: Array.from({ length: 10 }, () =>
+      Array.from({ length: 1_024 }, () => ({
+        value: "x"
+      }))
+    )
   };
 }
 

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -266,6 +266,148 @@ describe("policy-gated zero tool registry", () => {
     expect(descriptorCalls).toBe(0);
   });
 
+  test("ordinary arrays ignore over-budget non-index own properties without array key discovery", async () => {
+    const editTool = new RecordingTool("edit");
+    const sentinel = "ARRAY_NON_INDEX_PROPERTY_SENTINEL";
+    const values = ["alpha", , "gamma"] as unknown[];
+    for (let index = 0; index < 300; index += 1) {
+      Object.defineProperty(values, `extra_${index}`, {
+        configurable: true,
+        enumerable: true,
+        get() {
+          throw new Error(`${sentinel}_${index}`);
+        }
+      });
+    }
+    Object.defineProperty(values, "callable", {
+      configurable: true,
+      enumerable: true,
+      value: () => sentinel
+    });
+    Object.defineProperty(values, "symbolValue", {
+      configurable: true,
+      enumerable: true,
+      value: Symbol(sentinel)
+    });
+    Object.defineProperty(values, "bigintValue", {
+      configurable: true,
+      enumerable: true,
+      value: 1n
+    });
+    Object.defineProperty(values, "__proto__", {
+      configurable: true,
+      enumerable: true,
+      value: {
+        polluted: true
+      }
+    });
+    Object.defineProperty(values, "constructor", {
+      configurable: true,
+      enumerable: true,
+      value: {
+        prototype: {
+          polluted: true
+        }
+      }
+    });
+    Object.defineProperty(values, "prototype", {
+      configurable: true,
+      enumerable: true,
+      value: {
+        polluted: true
+      }
+    });
+    Object.defineProperty(values, Symbol("ignored-array-extra"), {
+      configurable: true,
+      enumerable: true,
+      value: sentinel
+    });
+
+    let arrayOwnKeysCalls = 0;
+    let arrayNonIndexDescriptorReads = 0;
+    let evaluatorObservation:
+      | {
+          direct: unknown[];
+          hasSparseHole: boolean;
+          extraVisible: boolean;
+          unsafeVisible: boolean;
+          constructorValue: unknown;
+        }
+      | undefined;
+    const originalOwnKeys = Reflect.ownKeys;
+    const originalGetOwnPropertyDescriptor = Reflect.getOwnPropertyDescriptor;
+    Reflect.ownKeys = ((target: object): (string | symbol)[] => {
+      if (Array.isArray(target)) {
+        arrayOwnKeysCalls += 1;
+        throw new Error("array ownKeys must not be called");
+      }
+      return originalOwnKeys(target);
+    }) as typeof Reflect.ownKeys;
+    Reflect.getOwnPropertyDescriptor = ((
+      target: object,
+      propertyKey: PropertyKey
+    ): PropertyDescriptor | undefined => {
+      if (Array.isArray(target) && !isExpectedNumericArrayDescriptorKey(propertyKey, target.length)) {
+        arrayNonIndexDescriptorReads += 1;
+        throw new Error(`array non-index descriptor must not be read: ${String(propertyKey)}`);
+      }
+      return originalGetOwnPropertyDescriptor(target, propertyKey);
+    }) as typeof Reflect.getOwnPropertyDescriptor;
+
+    try {
+      const wrapped = wrapToolWithPolicyGate(editTool, {
+        evaluate: async (call) => {
+          const evaluatorValues = (call.input as { values: unknown[] }).values;
+          evaluatorObservation = {
+            direct: [evaluatorValues[0], evaluatorValues[1], evaluatorValues[2]],
+            hasSparseHole: Object.prototype.hasOwnProperty.call(evaluatorValues, "1"),
+            extraVisible: Object.prototype.hasOwnProperty.call(evaluatorValues, "extra_0"),
+            unsafeVisible:
+              Object.prototype.hasOwnProperty.call(evaluatorValues, "callable") ||
+              Object.prototype.hasOwnProperty.call(evaluatorValues, "symbolValue") ||
+              Object.prototype.hasOwnProperty.call(evaluatorValues, "bigintValue") ||
+              Object.prototype.hasOwnProperty.call(evaluatorValues, "__proto__") ||
+              Object.prototype.hasOwnProperty.call(evaluatorValues, "constructor") ||
+              Object.prototype.hasOwnProperty.call(evaluatorValues, "prototype"),
+            constructorValue: (evaluatorValues as { constructor?: unknown }).constructor
+          };
+          return { decision: "allow" };
+        }
+      });
+
+      const result = await wrapped.run(createToolContext("worker"), { values });
+
+      expect(result.success).toBe(true);
+      expect(editTool.calls).toBe(1);
+    } finally {
+      Reflect.ownKeys = originalOwnKeys;
+      Reflect.getOwnPropertyDescriptor = originalGetOwnPropertyDescriptor;
+    }
+
+    expect(arrayOwnKeysCalls).toBe(0);
+    expect(arrayNonIndexDescriptorReads).toBe(0);
+    expect(evaluatorObservation).toEqual({
+      direct: ["alpha", undefined, "gamma"],
+      hasSparseHole: false,
+      extraVisible: false,
+      unsafeVisible: false,
+      constructorValue: undefined
+    });
+    const executionValues = (editTool.lastInput as { values?: unknown[] }).values;
+    expect(executionValues).toHaveLength(3);
+    expect(executionValues?.[0]).toBe("alpha");
+    expect(executionValues?.[1]).toBeUndefined();
+    expect(executionValues?.[2]).toBe("gamma");
+    expect(Object.prototype.hasOwnProperty.call(executionValues, "1")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(executionValues, "extra_0")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(executionValues, "callable")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(executionValues, "symbolValue")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(executionValues, "bigintValue")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(executionValues, "__proto__")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(executionValues, "constructor")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(executionValues, "prototype")).toBe(false);
+  });
+
   test("wide ordinary objects fail before per-key value reads", async () => {
     const editTool = new RecordingTool("edit");
     let evaluatorCalls = 0;
@@ -649,12 +791,20 @@ describe("policy-gated zero tool registry", () => {
           spread: string[];
           includesBeta: boolean;
           mapped: string[];
+          pushedLength: number;
+          afterPush: string[];
         }
       | undefined;
     let evaluatorInputPrototype: object | null | undefined;
     let evaluatorNestedPrototype: object | null | undefined;
     let evaluatorArrayPrototype: object | null | undefined;
     let evaluatorArrayParentPrototype: object | null | undefined;
+    let evaluatorArrayConstructor: unknown;
+    let evaluatorArrayMapFunctionPrototype: object | null | undefined;
+    let evaluatorMapResultPrototype: object | null | undefined;
+    let evaluatorMapResultParentPrototype: object | null | undefined;
+    let evaluatorIteratorPrototype: object | null | undefined;
+    let evaluatorIteratorNextPrototype: object | null | undefined;
     const wrapped = wrapToolWithPolicyGate(editTool, {
       evaluate: async (call) => {
         evaluatorClone = structuredClone(call.input);
@@ -663,11 +813,15 @@ describe("policy-gated zero tool registry", () => {
         for (const value of values) {
           iterated.push(value);
         }
+        const mapped = values.map((value) => value.toUpperCase());
+        const iterator = values[Symbol.iterator]();
         evaluatorArrayReads = {
           iterated,
           spread: [...values],
           includesBeta: values.includes("beta"),
-          mapped: values.map((value) => value.toUpperCase())
+          mapped,
+          pushedLength: values.push("gamma"),
+          afterPush: [...values]
         };
         evaluatorInputPrototype = Object.getPrototypeOf(call.input as object);
         evaluatorNestedPrototype = Object.getPrototypeOf(
@@ -676,6 +830,22 @@ describe("policy-gated zero tool registry", () => {
         evaluatorArrayPrototype = Object.getPrototypeOf(values);
         evaluatorArrayParentPrototype =
           evaluatorArrayPrototype === null ? null : Object.getPrototypeOf(evaluatorArrayPrototype);
+        evaluatorArrayConstructor = (values as { constructor?: unknown }).constructor;
+        evaluatorArrayMapFunctionPrototype =
+          evaluatorArrayPrototype === null
+            ? null
+            : Object.getPrototypeOf(
+                (evaluatorArrayPrototype as Record<PropertyKey, unknown>).map as object
+              );
+        evaluatorMapResultPrototype = Object.getPrototypeOf(mapped);
+        evaluatorMapResultParentPrototype =
+          evaluatorMapResultPrototype === null
+            ? null
+            : Object.getPrototypeOf(evaluatorMapResultPrototype);
+        evaluatorIteratorPrototype = Object.getPrototypeOf(iterator as object);
+        evaluatorIteratorNextPrototype = Object.getPrototypeOf(
+          (iterator as { next: () => IteratorResult<string> }).next
+        );
         return { decision: "allow" };
       }
     });
@@ -694,13 +864,22 @@ describe("policy-gated zero tool registry", () => {
       iterated: ["alpha", "beta"],
       spread: ["alpha", "beta"],
       includesBeta: true,
-      mapped: ["ALPHA", "BETA"]
+      mapped: ["ALPHA", "BETA"],
+      pushedLength: 3,
+      afterPush: ["alpha", "beta", "gamma"]
     });
     expect(evaluatorInputPrototype).toBeNull();
     expect(evaluatorNestedPrototype).toBeNull();
     expect(evaluatorArrayPrototype).not.toBeNull();
     expect(evaluatorArrayPrototype).not.toBe(Array.prototype);
     expect(evaluatorArrayParentPrototype).toBeNull();
+    expect(evaluatorArrayConstructor).toBeUndefined();
+    expect(evaluatorArrayMapFunctionPrototype).toBeNull();
+    expect(evaluatorMapResultPrototype).not.toBeNull();
+    expect(evaluatorMapResultPrototype).not.toBe(Array.prototype);
+    expect(evaluatorMapResultParentPrototype).toBeNull();
+    expect(evaluatorIteratorPrototype).toBeNull();
+    expect(evaluatorIteratorNextPrototype).toBeNull();
     expect(editTool.calls).toBe(1);
     expect((editTool.lastInput as { command?: unknown }).command).toBe("original");
     expect((editTool.lastInput as { nested?: { flag?: unknown } }).nested?.flag).toBe("original");
@@ -720,10 +899,15 @@ describe("policy-gated zero tool registry", () => {
   test("non-spawn evaluator prototype mutation paths cannot affect inner execution", async () => {
     const editTool = new RecordingTool("edit");
     const objectPrototypeSentinel = "__policyGateObjectPrototypeResidue";
-    const constructorPrototypeSentinel = "__policyGateConstructorPrototypeResidue";
+    const functionPrototypeSentinel = "__policyGateFunctionPrototypeResidue";
     const arrayPrototypeSentinel = "__policyGateArrayPrototypeResidue";
     const arrayMethodSentinel = "__policyGateArrayMethodResidue";
-    const arrayUnscopablesSentinel = "__policyGateArrayUnscopablesResidue";
+    const mapResultPrototypeSentinel = "__policyGateMapResultPrototypeResidue";
+    const iteratorPrototypeSentinel = "__policyGateIteratorPrototypeResidue";
+    let constructorPrototypePathReachable: boolean | undefined;
+    let arrayMethodFunctionPrototype: object | null | undefined;
+    let iteratorPrototype: object | null | undefined;
+    let iteratorNextFunctionPrototype: object | null | undefined;
     const input = {
       command: "original",
       nested: {
@@ -740,11 +924,16 @@ describe("policy-gated zero tool registry", () => {
           topPrototype[objectPrototypeSentinel] = "mutated";
         }
 
-        const constructorPrototype = (call.input as {
-          constructor?: { prototype?: Record<string, unknown> };
-        }).constructor?.prototype;
-        if (constructorPrototype) {
-          constructorPrototype[constructorPrototypeSentinel] = "mutated";
+        const values = (call.input as { values: unknown[] }).values;
+        const constructorValue = (values as { constructor?: unknown }).constructor;
+        constructorPrototypePathReachable = constructorValue !== undefined && constructorValue !== null;
+        if (constructorPrototypePathReachable) {
+          const constructorFunctionPrototype = Object.getPrototypeOf(constructorValue as object) as
+            | Record<string, unknown>
+            | null;
+          if (constructorFunctionPrototype) {
+            constructorFunctionPrototype[functionPrototypeSentinel] = "mutated";
+          }
         }
 
         const nestedPrototype = Object.getPrototypeOf(
@@ -754,25 +943,40 @@ describe("policy-gated zero tool registry", () => {
           nestedPrototype[objectPrototypeSentinel] = "mutated";
         }
 
-        const arrayPrototype = Object.getPrototypeOf(
-          (call.input as { values: unknown[] }).values
-        ) as Record<PropertyKey, unknown> | null;
+        const arrayPrototype = Object.getPrototypeOf(values) as Record<PropertyKey, unknown> | null;
         if (arrayPrototype) {
           arrayPrototype[arrayPrototypeSentinel] = "mutated";
-          (arrayPrototype.map as Record<string, unknown> | undefined)![arrayMethodSentinel] =
+          const mapMethod = arrayPrototype.map as Record<string, unknown> | undefined;
+          if (mapMethod) {
+            mapMethod[arrayMethodSentinel] = "mutated";
+            arrayMethodFunctionPrototype = Object.getPrototypeOf(mapMethod as object);
+            if (arrayMethodFunctionPrototype) {
+              (arrayMethodFunctionPrototype as Record<string, unknown>)[functionPrototypeSentinel] =
+                "mutated";
+            }
+          }
+        }
+
+        const mappedValues = values.map((value) => value);
+        const mappedPrototype = Object.getPrototypeOf(mappedValues) as
+          | Record<string, unknown>
+          | null;
+        if (mappedPrototype) {
+          mappedPrototype[mapResultPrototypeSentinel] = "mutated";
+        }
+
+        const iterator = values[Symbol.iterator]();
+        iteratorPrototype = Object.getPrototypeOf(iterator as object);
+        if (iteratorPrototype) {
+          (iteratorPrototype as Record<string, unknown>)[iteratorPrototypeSentinel] = "mutated";
+        }
+        iteratorNextFunctionPrototype = Object.getPrototypeOf(
+          (iterator as { next: () => IteratorResult<unknown> }).next
+        );
+        if (iteratorNextFunctionPrototype) {
+          (iteratorNextFunctionPrototype as Record<string, unknown>)[functionPrototypeSentinel] =
             "mutated";
-          (arrayPrototype[Symbol.unscopables] as Record<string, unknown> | undefined)![
-            arrayUnscopablesSentinel
-          ] = "mutated";
         }
-
-        const arrayConstructorPrototype = (call.input as {
-          values: { constructor?: { prototype?: Record<string, unknown> } };
-        }).values.constructor?.prototype;
-        if (arrayConstructorPrototype) {
-          arrayConstructorPrototype[arrayPrototypeSentinel] = "mutated";
-        }
-
         return { decision: "allow" };
       }
     });
@@ -789,25 +993,25 @@ describe("policy-gated zero tool registry", () => {
       expect((editTool.lastInput as { values?: string[] }).values?.[0]).toBe("original");
       expect((Object.prototype as Record<string, unknown>)[objectPrototypeSentinel]).toBeUndefined();
       expect(
-        (Object.prototype as Record<string, unknown>)[constructorPrototypeSentinel]
+        (Object.prototype as Record<string, unknown>)[functionPrototypeSentinel]
       ).toBeUndefined();
       expect((Array.prototype as Record<string, unknown>)[arrayPrototypeSentinel]).toBeUndefined();
-      expect((Array.prototype.map as Record<string, unknown>)[arrayMethodSentinel]).toBeUndefined();
       expect(
-        ((Array.prototype as Record<symbol, unknown>)[Symbol.unscopables] as Record<
-          string,
-          unknown
-        >)[arrayUnscopablesSentinel]
+        (Array.prototype as Record<string, unknown>)[mapResultPrototypeSentinel]
       ).toBeUndefined();
+      expect((Array.prototype.map as Record<string, unknown>)[arrayMethodSentinel]).toBeUndefined();
+      expect((Function.prototype as Record<string, unknown>)[functionPrototypeSentinel]).toBeUndefined();
+      expect(constructorPrototypePathReachable).toBe(false);
+      expect(arrayMethodFunctionPrototype).toBeNull();
+      expect(iteratorPrototype).toBeNull();
+      expect(iteratorNextFunctionPrototype).toBeNull();
     } finally {
       delete (Object.prototype as Record<string, unknown>)[objectPrototypeSentinel];
-      delete (Object.prototype as Record<string, unknown>)[constructorPrototypeSentinel];
+      delete (Object.prototype as Record<string, unknown>)[functionPrototypeSentinel];
       delete (Array.prototype as Record<string, unknown>)[arrayPrototypeSentinel];
+      delete (Array.prototype as Record<string, unknown>)[mapResultPrototypeSentinel];
       delete (Array.prototype.map as Record<string, unknown>)[arrayMethodSentinel];
-      delete ((Array.prototype as Record<symbol, unknown>)[Symbol.unscopables] as Record<
-        string,
-        unknown
-      >)[arrayUnscopablesSentinel];
+      delete (Function.prototype as Record<string, unknown>)[functionPrototypeSentinel];
     }
   });
 
@@ -3808,6 +4012,14 @@ function createNodeDensePolicyGateInput(): Record<string, unknown> {
       }))
     )
   };
+}
+
+function isExpectedNumericArrayDescriptorKey(propertyKey: PropertyKey, length: number): boolean {
+  if (typeof propertyKey !== "string") {
+    return false;
+  }
+  const index = Number(propertyKey);
+  return Number.isInteger(index) && index >= 0 && index < length && String(index) === propertyKey;
 }
 
 function createToolContext(role: string): ToolContext & { role: string } {

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -234,6 +234,208 @@ describe("policy-gated zero tool registry", () => {
     expect(bashLikeTool.calls).toBe(0);
   });
 
+  test("over-length dense arrays fail before array key or descriptor enumeration", async () => {
+    const editTool = new RecordingTool("edit");
+    let evaluatorCalls = 0;
+    let ownKeysCalls = 0;
+    let descriptorCalls = 0;
+    const input = new Proxy(Array.from({ length: 1_025 }, (_, index) => index), {
+      ownKeys(target) {
+        ownKeysCalls += 1;
+        return Reflect.ownKeys(target);
+      },
+      getOwnPropertyDescriptor(target, property) {
+        descriptorCalls += 1;
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      }
+    });
+    const wrapped = wrapToolWithPolicyGate(editTool, {
+      evaluate: async () => {
+        evaluatorCalls += 1;
+        return { decision: "allow" };
+      }
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), input);
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("policy_gate_input_preparation_failed");
+    expect(evaluatorCalls).toBe(0);
+    expect(editTool.calls).toBe(0);
+    expect(ownKeysCalls).toBe(0);
+    expect(descriptorCalls).toBe(0);
+  });
+
+  test("wide objects fail before per-key descriptor reads", async () => {
+    const editTool = new RecordingTool("edit");
+    let evaluatorCalls = 0;
+    let ownKeysCalls = 0;
+    let descriptorCalls = 0;
+    const target = createObjectWithKeyCount(257);
+    const input = new Proxy(target, {
+      ownKeys(proxyTarget) {
+        ownKeysCalls += 1;
+        return Reflect.ownKeys(proxyTarget);
+      },
+      getOwnPropertyDescriptor(proxyTarget, property) {
+        descriptorCalls += 1;
+        return Reflect.getOwnPropertyDescriptor(proxyTarget, property);
+      }
+    });
+    const wrapped = wrapToolWithPolicyGate(editTool, {
+      evaluate: async () => {
+        evaluatorCalls += 1;
+        return { decision: "allow" };
+      }
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), input);
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("policy_gate_input_preparation_failed");
+    expect(evaluatorCalls).toBe(0);
+    expect(editTool.calls).toBe(0);
+    expect(ownKeysCalls).toBe(1);
+    expect(descriptorCalls).toBe(0);
+  });
+
+  test("proxy-hostile non-spawn input fails closed without leaking trap text", async () => {
+    const editTool = new RecordingTool("edit");
+    const runningToolRegistry = new TestRunningToolRegistry();
+    const handle = runningToolRegistry.register({
+      toolUseId: "POLICY-HOSTILE-PROXY-1",
+      toolName: "edit",
+      abortable: false
+    });
+    let evaluatorCalls = 0;
+    const sentinel = "HOSTILE_PROXY_TRAP_SECRET";
+    const input = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error(sentinel);
+        }
+      }
+    );
+    const wrapped = wrapToolWithPolicyGate(editTool, {
+      evaluate: async () => {
+        evaluatorCalls += 1;
+        return { decision: "allow" };
+      }
+    });
+
+    const result = await wrapped.run(
+      {
+        ...createToolContext("worker"),
+        currentToolUseId: "POLICY-HOSTILE-PROXY-1",
+        runningToolRegistry
+      },
+      input
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("policy_gate_input_preparation_failed");
+    expect(result.output).not.toContain(sentinel);
+    expect(result.outputSummary).toBe("Policy gate input preparation failed for edit");
+    expect(result.outputSummary).not.toContain(sentinel);
+    expect(evaluatorCalls).toBe(0);
+    expect(editTool.calls).toBe(0);
+    expect(handle.getState()).toBe("finished");
+    expect(handle.getTerminalMetadata()).toMatchObject({
+      cause: "completed",
+      success: false,
+      outputSummary: result.outputSummary
+    });
+  });
+
+  test("non-spawn input preparation rejects isolated unsafe generic inputs", async () => {
+    const symbolKey = Symbol("unsafe-key");
+    const protoDataKeyInput: Record<string, unknown> = {
+      command: "original"
+    };
+    Object.defineProperty(protoDataKeyInput, "__proto__", {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: {
+        polluted: true
+      }
+    });
+    const cases: Array<{ label: string; input: unknown }> = [
+      {
+        label: "function value",
+        input: {
+          command: "original",
+          unsafe: () => "not cloneable"
+        }
+      },
+      {
+        label: "symbol value",
+        input: {
+          command: Symbol("unsafe-value")
+        }
+      },
+      {
+        label: "bigint value",
+        input: {
+          command: "original",
+          count: 1n
+        }
+      },
+      {
+        label: "symbol key",
+        input: {
+          command: "original",
+          [symbolKey]: "unsafe"
+        }
+      },
+      {
+        label: "own __proto__ data key",
+        input: protoDataKeyInput
+      },
+      {
+        label: "constructor key",
+        input: {
+          command: "original",
+          constructor: {
+            prototype: {
+              polluted: true
+            }
+          }
+        }
+      },
+      {
+        label: "prototype key",
+        input: {
+          command: "original",
+          prototype: {
+            polluted: true
+          }
+        }
+      }
+    ];
+
+    for (const testCase of cases) {
+      const editTool = new RecordingTool(`edit-${testCase.label}`);
+      let evaluatorCalls = 0;
+      const wrapped = wrapToolWithPolicyGate(editTool, {
+        toolId: "edit",
+        evaluate: async () => {
+          evaluatorCalls += 1;
+          return { decision: "allow" };
+        }
+      });
+
+      const result = await wrapped.run(createToolContext("worker"), testCase.input);
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("policy_gate_input_preparation_failed");
+      expect(result.outputSummary).toBe("Policy gate input preparation failed for edit");
+      expect(evaluatorCalls).toBe(0);
+      expect(editTool.calls).toBe(0);
+    }
+  });
+
   test("oversized non-spawn inputs fail closed before evaluator and inner tool execution", async () => {
     const tailSentinel = "STRING_BUDGET_TAIL_SENTINEL";
     const cases: Array<{ label: string; input: unknown }> = [
@@ -304,7 +506,7 @@ describe("policy-gated zero tool registry", () => {
     }
   });
 
-  test("non-spawn evaluator mutation attempts fail closed without reaching the inner tool", async () => {
+  test("non-spawn evaluator direct mutations are isolated from inner execution", async () => {
     const cases: Array<{ label: string; mutate: (input: unknown) => void }> = [
       {
         label: "top-level",
@@ -346,10 +548,12 @@ describe("policy-gated zero tool registry", () => {
 
       const result = await wrapped.run(createToolContext("worker"), input);
 
-      expect(result.success).toBe(false);
-      expect(result.output).toContain("Policy gate evaluator input is read-only");
-      expect(result.outputSummary).toContain("Error: Policy gate evaluator input is read-only");
-      expect(editTool.calls).toBe(0);
+      expect(result.success).toBe(true);
+      expect(editTool.calls).toBe(1);
+      expect((editTool.lastInput as { command?: unknown }).command).toBe("original");
+      expect((editTool.lastInput as { nested?: { flag?: unknown } }).nested?.flag).toBe(
+        "original"
+      );
       expect(input).toEqual({
         command: "original",
         nested: {
@@ -359,22 +563,25 @@ describe("policy-gated zero tool registry", () => {
     }
   });
 
-  test("non-spawn evaluator reads a readonly view while inner tool receives the execution snapshot", async () => {
+  test("honest non-spawn evaluator can structuredClone input before allowing", async () => {
     const editTool = new RecordingTool("edit");
     const input = {
       command: "original",
       nested: {
         flag: "original"
-      }
+      },
+      values: ["alpha", "beta"]
     };
-    let evaluatorInput: unknown;
-    let evaluatorSawCommand: unknown;
-    let evaluatorSawNestedFlag: unknown;
+    let evaluatorClone: unknown;
+    let evaluatorInputPrototype: object | null | undefined;
+    let evaluatorNestedPrototype: object | null | undefined;
     const wrapped = wrapToolWithPolicyGate(editTool, {
       evaluate: async (call) => {
-        evaluatorInput = call.input;
-        evaluatorSawCommand = (call.input as { command?: unknown }).command;
-        evaluatorSawNestedFlag = (call.input as { nested?: { flag?: unknown } }).nested?.flag;
+        evaluatorClone = structuredClone(call.input);
+        evaluatorInputPrototype = Object.getPrototypeOf(call.input as object);
+        evaluatorNestedPrototype = Object.getPrototypeOf(
+          (call.input as { nested: object }).nested
+        );
         return { decision: "allow" };
       }
     });
@@ -382,18 +589,100 @@ describe("policy-gated zero tool registry", () => {
     const result = await wrapped.run(createToolContext("worker"), input);
 
     expect(result.success).toBe(true);
-    expect(evaluatorSawCommand).toBe("original");
-    expect(evaluatorSawNestedFlag).toBe("original");
-    expect(editTool.calls).toBe(1);
-    expect(editTool.lastInput).toEqual({
+    expect(evaluatorClone).toEqual({
       command: "original",
       nested: {
         flag: "original"
-      }
+      },
+      values: ["alpha", "beta"]
     });
+    expect(evaluatorInputPrototype).toBeNull();
+    expect(evaluatorNestedPrototype).toBeNull();
+    expect(editTool.calls).toBe(1);
+    expect((editTool.lastInput as { command?: unknown }).command).toBe("original");
+    expect((editTool.lastInput as { nested?: { flag?: unknown } }).nested?.flag).toBe("original");
+    expect((editTool.lastInput as { values?: string[] }).values?.[0]).toBe("alpha");
+    expect(Object.getPrototypeOf(editTool.lastInput as object)).toBeNull();
+    expect(
+      Object.getPrototypeOf((editTool.lastInput as { nested: object }).nested)
+    ).toBeNull();
     expect(editTool.lastInput).not.toBe(input);
     expect((editTool.lastInput as { nested: unknown }).nested).not.toBe(input.nested);
-    expect(evaluatorInput).not.toBe(editTool.lastInput);
+  });
+
+  test("non-spawn evaluator prototype mutation paths cannot affect inner execution", async () => {
+    const editTool = new RecordingTool("edit");
+    const objectPrototypeSentinel = "__policyGateObjectPrototypeResidue";
+    const constructorPrototypeSentinel = "__policyGateConstructorPrototypeResidue";
+    const arrayPrototypeSentinel = "__policyGateArrayPrototypeResidue";
+    const input = {
+      command: "original",
+      nested: {
+        flag: "original"
+      },
+      values: ["original"]
+    };
+    const wrapped = wrapToolWithPolicyGate(editTool, {
+      evaluate: async (call) => {
+        const topPrototype = Object.getPrototypeOf(call.input as object) as
+          | Record<string, unknown>
+          | null;
+        if (topPrototype) {
+          topPrototype[objectPrototypeSentinel] = "mutated";
+        }
+
+        const constructorPrototype = (call.input as {
+          constructor?: { prototype?: Record<string, unknown> };
+        }).constructor?.prototype;
+        if (constructorPrototype) {
+          constructorPrototype[constructorPrototypeSentinel] = "mutated";
+        }
+
+        const nestedPrototype = Object.getPrototypeOf(
+          (call.input as { nested: object }).nested
+        ) as Record<string, unknown> | null;
+        if (nestedPrototype) {
+          nestedPrototype[objectPrototypeSentinel] = "mutated";
+        }
+
+        const arrayPrototype = Object.getPrototypeOf(
+          (call.input as { values: unknown[] }).values
+        ) as Record<string, unknown> | null;
+        if (arrayPrototype) {
+          arrayPrototype[arrayPrototypeSentinel] = "mutated";
+        }
+
+        const arrayConstructorPrototype = (call.input as {
+          values: { constructor?: { prototype?: Record<string, unknown> } };
+        }).values.constructor?.prototype;
+        if (arrayConstructorPrototype) {
+          arrayConstructorPrototype[arrayPrototypeSentinel] = "mutated";
+        }
+
+        return { decision: "allow" };
+      }
+    });
+
+    try {
+      const result = await wrapped.run(createToolContext("worker"), input);
+
+      expect(result.success).toBe(true);
+      expect(editTool.calls).toBe(1);
+      expect((editTool.lastInput as { command?: unknown }).command).toBe("original");
+      expect((editTool.lastInput as { nested?: { flag?: unknown } }).nested?.flag).toBe(
+        "original"
+      );
+      expect((editTool.lastInput as { values?: string[] }).values?.[0]).toBe("original");
+      expect((Object.prototype as Record<string, unknown>)[objectPrototypeSentinel]).toBeUndefined();
+      expect(
+        (Object.prototype as Record<string, unknown>)[constructorPrototypeSentinel]
+      ).toBeUndefined();
+      expect((Array.prototype as Record<string, unknown>)[arrayPrototypeSentinel]).toBeUndefined();
+    } finally {
+      delete (Object.prototype as Record<string, unknown>)[objectPrototypeSentinel];
+      delete (Object.prototype as Record<string, unknown>)[constructorPrototypeSentinel];
+      delete (Array.prototype as Record<string, unknown>)[arrayPrototypeSentinel];
+    }
   });
 
   test("malformed raw-rule deny from custom evaluator fails closed and finishes running handle", async () => {

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -931,12 +931,6 @@ describe("policy-gated zero tool registry", () => {
         mutate(input) {
           (input as { values: string[] }).values[0] = "mutated";
         }
-      },
-      {
-        label: "array-push",
-        mutate(input) {
-          (input as { values: string[] }).values.push("mutated");
-        }
       }
     ];
 
@@ -975,6 +969,44 @@ describe("policy-gated zero tool registry", () => {
     }
   });
 
+  test("unsupported non-spawn evaluator array push fails closed without inner execution", async () => {
+    const editTool = new RecordingTool("edit");
+    const runningToolRegistry = new TestRunningToolRegistry();
+    const handle = runningToolRegistry.register({
+      toolUseId: "POLICY-UNSUPPORTED-PUSH-1",
+      toolName: "edit",
+      abortable: false
+    });
+    const wrapped = wrapToolWithPolicyGate(editTool, {
+      evaluate: async (call) => {
+        (call.input as { values: string[] }).values.push("mutated");
+        return { decision: "allow" };
+      }
+    });
+
+    const result = await wrapped.run(
+      {
+        ...createToolContext("worker"),
+        currentToolUseId: "POLICY-UNSUPPORTED-PUSH-1",
+        runningToolRegistry
+      },
+      {
+        values: ["original"]
+      }
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("push");
+    expect(result.outputSummary).toContain("Error:");
+    expect(editTool.calls).toBe(0);
+    expect(handle.getState()).toBe("finished");
+    expect(handle.getTerminalMetadata()).toMatchObject({
+      cause: "completed",
+      success: false,
+      outputSummary: result.outputSummary
+    });
+  });
+
   test("honest non-spawn evaluator can structuredClone input before allowing", async () => {
     const editTool = new RecordingTool("edit");
     const input = {
@@ -991,8 +1023,8 @@ describe("policy-gated zero tool registry", () => {
           spread: string[];
           includesBeta: boolean;
           mapped: string[];
-          pushedLength: number;
-          afterPush: string[];
+          pushValue: unknown;
+          filterValue: unknown;
         }
       | undefined;
     let evaluatorInputPrototype: object | null | undefined;
@@ -1007,6 +1039,8 @@ describe("policy-gated zero tool registry", () => {
     let evaluatorIteratorNextPrototype: object | null | undefined;
     let evaluatorInputExtensible: boolean | undefined;
     let evaluatorNestedExtensible: boolean | undefined;
+    let evaluatorArrayExtensible: boolean | undefined;
+    let evaluatorMapResultExtensible: boolean | undefined;
     let evaluatorArrayPrototypeFrozen: boolean | undefined;
     let evaluatorArrayMapFunctionFrozen: boolean | undefined;
     let evaluatorIteratorFrozen: boolean | undefined;
@@ -1026,8 +1060,8 @@ describe("policy-gated zero tool registry", () => {
           spread: [...values],
           includesBeta: values.includes("beta"),
           mapped,
-          pushedLength: values.push("gamma"),
-          afterPush: [...values]
+          pushValue: (values as { push?: unknown }).push,
+          filterValue: (values as { filter?: unknown }).filter
         };
         evaluatorInputPrototype = Object.getPrototypeOf(call.input as object);
         evaluatorNestedPrototype = Object.getPrototypeOf(
@@ -1035,6 +1069,8 @@ describe("policy-gated zero tool registry", () => {
         );
         evaluatorInputExtensible = Object.isExtensible(call.input as object);
         evaluatorNestedExtensible = Object.isExtensible((call.input as { nested: object }).nested);
+        evaluatorArrayExtensible = Object.isExtensible(values);
+        evaluatorMapResultExtensible = Object.isExtensible(mapped);
         evaluatorArrayPrototype = Object.getPrototypeOf(values);
         evaluatorArrayPrototypeFrozen =
           evaluatorArrayPrototype === null ? undefined : Object.isFrozen(evaluatorArrayPrototype);
@@ -1085,13 +1121,15 @@ describe("policy-gated zero tool registry", () => {
       spread: ["alpha", "beta"],
       includesBeta: true,
       mapped: ["ALPHA", "BETA"],
-      pushedLength: 3,
-      afterPush: ["alpha", "beta", "gamma"]
+      pushValue: undefined,
+      filterValue: undefined
     });
     expect(evaluatorInputPrototype).toBeNull();
     expect(evaluatorNestedPrototype).toBeNull();
     expect(evaluatorInputExtensible).toBe(false);
     expect(evaluatorNestedExtensible).toBe(false);
+    expect(evaluatorArrayExtensible).toBe(false);
+    expect(evaluatorMapResultExtensible).toBe(false);
     expect(evaluatorArrayPrototype).not.toBeNull();
     expect(evaluatorArrayPrototype).not.toBe(Array.prototype);
     expect(evaluatorArrayPrototypeFrozen).toBe(true);
@@ -1332,12 +1370,12 @@ describe("policy-gated zero tool registry", () => {
       expect(constructorPrototypePathReachable).toBe(false);
       expect(topReparentSucceeded).toBe(false);
       expect(nestedReparentSucceeded).toBe(false);
-      expect(arrayReparentSucceeded).toBe(true);
+      expect(arrayReparentSucceeded).toBe(false);
       expect(arrayPrototypeReparentSucceeded).toBe(false);
       expect(arrayMethodFunctionReparentSucceeded).toBe(false);
       expect(iteratorReparentSucceeded).toBe(false);
       expect(iteratorNextFunctionReparentSucceeded).toBe(false);
-      expect(mapResultArrayReparentSucceeded).toBe(true);
+      expect(mapResultArrayReparentSucceeded).toBe(false);
       expect(mapResultPrototypeReparentSucceeded).toBe(false);
       expect(mapResultMethodFunctionReparentSucceeded).toBe(false);
       expect(arrayMethodFunctionPrototype).toBeNull();
@@ -1352,6 +1390,56 @@ describe("policy-gated zero tool registry", () => {
       delete (Array.prototype.map as Record<string, unknown>)[arrayMethodSentinel];
       delete (Array as unknown as Record<string, unknown>)[arrayConstructorSentinel];
       delete (Function.prototype as Record<string, unknown>)[functionPrototypeSentinel];
+    }
+  });
+
+  test("non-spawn evaluator arrays cannot create Array.prototype residue through reparenting", async () => {
+    const editTool = new RecordingTool("edit");
+    const arrayPrototypeSentinel = "__policyGateInputDerivedArrayPrototypeResidue";
+    let valuesReparentSucceeded: boolean | undefined;
+    let mapResultReparentSucceeded: boolean | undefined;
+    const wrapped = wrapToolWithPolicyGate(editTool, {
+      evaluate: async (call) => {
+        const values = (call.input as { values: string[] }).values;
+        valuesReparentSucceeded = attemptMutation(() => {
+          Object.setPrototypeOf(values, Array.prototype);
+        });
+        const valuesPrototype = Object.getPrototypeOf(values) as Record<PropertyKey, unknown> | null;
+        if (valuesPrototype) {
+          attemptMutation(() => {
+            valuesPrototype[arrayPrototypeSentinel] = "mutated";
+          });
+        }
+
+        const mappedValues = values.map((value) => value);
+        mapResultReparentSucceeded = attemptMutation(() => {
+          Object.setPrototypeOf(mappedValues, Array.prototype);
+        });
+        const mappedPrototype = Object.getPrototypeOf(mappedValues) as
+          | Record<PropertyKey, unknown>
+          | null;
+        if (mappedPrototype) {
+          attemptMutation(() => {
+            mappedPrototype[arrayPrototypeSentinel] = "mutated";
+          });
+        }
+
+        return { decision: "allow" };
+      }
+    });
+
+    try {
+      const result = await wrapped.run(createToolContext("worker"), { values: ["original"] });
+
+      expect(result.success).toBe(true);
+      expect(editTool.calls).toBe(1);
+      expect(valuesReparentSucceeded).toBe(false);
+      expect(mapResultReparentSucceeded).toBe(false);
+      expect(
+        (Array.prototype as Record<string, unknown>)[arrayPrototypeSentinel]
+      ).toBeUndefined();
+    } finally {
+      delete (Array.prototype as Record<string, unknown>)[arrayPrototypeSentinel];
     }
   });
 

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -234,7 +234,7 @@ describe("policy-gated zero tool registry", () => {
     expect(bashLikeTool.calls).toBe(0);
   });
 
-  test("over-length dense arrays fail before array key or descriptor enumeration", async () => {
+  test("proxy array inputs fail before array key or descriptor traps", async () => {
     const editTool = new RecordingTool("edit");
     let evaluatorCalls = 0;
     let ownKeysCalls = 0;
@@ -266,20 +266,18 @@ describe("policy-gated zero tool registry", () => {
     expect(descriptorCalls).toBe(0);
   });
 
-  test("wide objects fail before per-key descriptor reads", async () => {
+  test("wide ordinary objects fail before per-key value reads", async () => {
     const editTool = new RecordingTool("edit");
     let evaluatorCalls = 0;
-    let ownKeysCalls = 0;
-    let descriptorCalls = 0;
-    const target = createObjectWithKeyCount(257);
-    const input = new Proxy(target, {
-      ownKeys(proxyTarget) {
-        ownKeysCalls += 1;
-        return Reflect.ownKeys(proxyTarget);
-      },
-      getOwnPropertyDescriptor(proxyTarget, property) {
-        descriptorCalls += 1;
-        return Reflect.getOwnPropertyDescriptor(proxyTarget, property);
+    let hostileGetterReads = 0;
+    const sentinel = "WIDE_OBJECT_HOSTILE_GETTER_SECRET";
+    const input = createObjectWithKeyCount(257);
+    Object.defineProperty(input, "hostile", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        hostileGetterReads += 1;
+        throw new Error(sentinel);
       }
     });
     const wrapped = wrapToolWithPolicyGate(editTool, {
@@ -293,10 +291,10 @@ describe("policy-gated zero tool registry", () => {
 
     expect(result.success).toBe(false);
     expect(result.output).toContain("policy_gate_input_preparation_failed");
+    expect(result.output).not.toContain(sentinel);
     expect(evaluatorCalls).toBe(0);
     expect(editTool.calls).toBe(0);
-    expect(ownKeysCalls).toBe(1);
-    expect(descriptorCalls).toBe(0);
+    expect(hostileGetterReads).toBe(0);
   });
 
   test("proxy-hostile non-spawn input fails closed without leaking trap text", async () => {
@@ -309,11 +307,18 @@ describe("policy-gated zero tool registry", () => {
     });
     let evaluatorCalls = 0;
     const sentinel = "HOSTILE_PROXY_TRAP_SECRET";
+    let ownKeysCalls = 0;
+    let descriptorCalls = 0;
     const input = new Proxy(
       {},
       {
         ownKeys() {
+          ownKeysCalls += 1;
           throw new Error(sentinel);
+        },
+        getOwnPropertyDescriptor(target, property) {
+          descriptorCalls += 1;
+          return Reflect.getOwnPropertyDescriptor(target, property);
         }
       }
     );
@@ -340,12 +345,62 @@ describe("policy-gated zero tool registry", () => {
     expect(result.outputSummary).not.toContain(sentinel);
     expect(evaluatorCalls).toBe(0);
     expect(editTool.calls).toBe(0);
+    expect(ownKeysCalls).toBe(0);
+    expect(descriptorCalls).toBe(0);
     expect(handle.getState()).toBe("finished");
     expect(handle.getTerminalMetadata()).toMatchObject({
       cause: "completed",
       success: false,
       outputSummary: result.outputSummary
     });
+  });
+
+  test("drifting proxy descriptors fail closed before evaluator or inner execution", async () => {
+    const editTool = new RecordingTool("edit");
+    let evaluatorCalls = 0;
+    let ownKeysCalls = 0;
+    let descriptorCalls = 0;
+    const sentinel = "DRIFTING_PROXY_DANGER_SECRET";
+    const input = new Proxy(
+      {
+        command: "safe"
+      },
+      {
+        ownKeys(target) {
+          ownKeysCalls += 1;
+          return Reflect.ownKeys(target);
+        },
+        getOwnPropertyDescriptor(_target, property) {
+          descriptorCalls += 1;
+          if (property === "command") {
+            return {
+              configurable: true,
+              enumerable: true,
+              writable: true,
+              value: descriptorCalls === 1 ? "safe" : sentinel
+            };
+          }
+          return undefined;
+        }
+      }
+    );
+    const wrapped = wrapToolWithPolicyGate(editTool, {
+      evaluate: async () => {
+        evaluatorCalls += 1;
+        return { decision: "allow" };
+      }
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), input);
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("policy_gate_input_preparation_failed");
+    expect(result.output).not.toContain(sentinel);
+    expect(result.outputSummary).toBe("Policy gate input preparation failed for edit");
+    expect(evaluatorCalls).toBe(0);
+    expect(editTool.calls).toBe(0);
+    expect(ownKeysCalls).toBe(0);
+    expect(descriptorCalls).toBe(0);
   });
 
   test("non-spawn input preparation rejects isolated unsafe generic inputs", async () => {
@@ -528,6 +583,18 @@ describe("policy-gated zero tool registry", () => {
           };
           nested.flag = "mutated";
         }
+      },
+      {
+        label: "array-element",
+        mutate(input) {
+          (input as { values: string[] }).values[0] = "mutated";
+        }
+      },
+      {
+        label: "array-push",
+        mutate(input) {
+          (input as { values: string[] }).values.push("mutated");
+        }
       }
     ];
 
@@ -537,7 +604,8 @@ describe("policy-gated zero tool registry", () => {
         command: "original",
         nested: {
           flag: "original"
-        }
+        },
+        values: ["original"]
       };
       const wrapped = wrapToolWithPolicyGate(editTool, {
         evaluate: async (call) => {
@@ -554,11 +622,13 @@ describe("policy-gated zero tool registry", () => {
       expect((editTool.lastInput as { nested?: { flag?: unknown } }).nested?.flag).toBe(
         "original"
       );
+      expect((editTool.lastInput as { values?: string[] }).values).toEqual(["original"]);
       expect(input).toEqual({
         command: "original",
         nested: {
           flag: "original"
-        }
+        },
+        values: ["original"]
       });
     }
   });
@@ -573,15 +643,39 @@ describe("policy-gated zero tool registry", () => {
       values: ["alpha", "beta"]
     };
     let evaluatorClone: unknown;
+    let evaluatorArrayReads:
+      | {
+          iterated: string[];
+          spread: string[];
+          includesBeta: boolean;
+          mapped: string[];
+        }
+      | undefined;
     let evaluatorInputPrototype: object | null | undefined;
     let evaluatorNestedPrototype: object | null | undefined;
+    let evaluatorArrayPrototype: object | null | undefined;
+    let evaluatorArrayParentPrototype: object | null | undefined;
     const wrapped = wrapToolWithPolicyGate(editTool, {
       evaluate: async (call) => {
         evaluatorClone = structuredClone(call.input);
+        const values = (call.input as { values: string[] }).values;
+        const iterated: string[] = [];
+        for (const value of values) {
+          iterated.push(value);
+        }
+        evaluatorArrayReads = {
+          iterated,
+          spread: [...values],
+          includesBeta: values.includes("beta"),
+          mapped: values.map((value) => value.toUpperCase())
+        };
         evaluatorInputPrototype = Object.getPrototypeOf(call.input as object);
         evaluatorNestedPrototype = Object.getPrototypeOf(
           (call.input as { nested: object }).nested
         );
+        evaluatorArrayPrototype = Object.getPrototypeOf(values);
+        evaluatorArrayParentPrototype =
+          evaluatorArrayPrototype === null ? null : Object.getPrototypeOf(evaluatorArrayPrototype);
         return { decision: "allow" };
       }
     });
@@ -596,12 +690,25 @@ describe("policy-gated zero tool registry", () => {
       },
       values: ["alpha", "beta"]
     });
+    expect(evaluatorArrayReads).toEqual({
+      iterated: ["alpha", "beta"],
+      spread: ["alpha", "beta"],
+      includesBeta: true,
+      mapped: ["ALPHA", "BETA"]
+    });
     expect(evaluatorInputPrototype).toBeNull();
     expect(evaluatorNestedPrototype).toBeNull();
+    expect(evaluatorArrayPrototype).not.toBeNull();
+    expect(evaluatorArrayPrototype).not.toBe(Array.prototype);
+    expect(evaluatorArrayParentPrototype).toBeNull();
     expect(editTool.calls).toBe(1);
     expect((editTool.lastInput as { command?: unknown }).command).toBe("original");
     expect((editTool.lastInput as { nested?: { flag?: unknown } }).nested?.flag).toBe("original");
-    expect((editTool.lastInput as { values?: string[] }).values?.[0]).toBe("alpha");
+    const executionValues = (editTool.lastInput as { values?: string[] }).values;
+    expect(executionValues?.[0]).toBe("alpha");
+    expect(Array.isArray(executionValues)).toBe(true);
+    expect(executionValues?.includes("beta")).toBe(true);
+    expect(executionValues?.map((value) => value.toUpperCase())).toEqual(["ALPHA", "BETA"]);
     expect(Object.getPrototypeOf(editTool.lastInput as object)).toBeNull();
     expect(
       Object.getPrototypeOf((editTool.lastInput as { nested: object }).nested)
@@ -615,6 +722,8 @@ describe("policy-gated zero tool registry", () => {
     const objectPrototypeSentinel = "__policyGateObjectPrototypeResidue";
     const constructorPrototypeSentinel = "__policyGateConstructorPrototypeResidue";
     const arrayPrototypeSentinel = "__policyGateArrayPrototypeResidue";
+    const arrayMethodSentinel = "__policyGateArrayMethodResidue";
+    const arrayUnscopablesSentinel = "__policyGateArrayUnscopablesResidue";
     const input = {
       command: "original",
       nested: {
@@ -647,9 +756,14 @@ describe("policy-gated zero tool registry", () => {
 
         const arrayPrototype = Object.getPrototypeOf(
           (call.input as { values: unknown[] }).values
-        ) as Record<string, unknown> | null;
+        ) as Record<PropertyKey, unknown> | null;
         if (arrayPrototype) {
           arrayPrototype[arrayPrototypeSentinel] = "mutated";
+          (arrayPrototype.map as Record<string, unknown> | undefined)![arrayMethodSentinel] =
+            "mutated";
+          (arrayPrototype[Symbol.unscopables] as Record<string, unknown> | undefined)![
+            arrayUnscopablesSentinel
+          ] = "mutated";
         }
 
         const arrayConstructorPrototype = (call.input as {
@@ -678,10 +792,22 @@ describe("policy-gated zero tool registry", () => {
         (Object.prototype as Record<string, unknown>)[constructorPrototypeSentinel]
       ).toBeUndefined();
       expect((Array.prototype as Record<string, unknown>)[arrayPrototypeSentinel]).toBeUndefined();
+      expect((Array.prototype.map as Record<string, unknown>)[arrayMethodSentinel]).toBeUndefined();
+      expect(
+        ((Array.prototype as Record<symbol, unknown>)[Symbol.unscopables] as Record<
+          string,
+          unknown
+        >)[arrayUnscopablesSentinel]
+      ).toBeUndefined();
     } finally {
       delete (Object.prototype as Record<string, unknown>)[objectPrototypeSentinel];
       delete (Object.prototype as Record<string, unknown>)[constructorPrototypeSentinel];
       delete (Array.prototype as Record<string, unknown>)[arrayPrototypeSentinel];
+      delete (Array.prototype.map as Record<string, unknown>)[arrayMethodSentinel];
+      delete ((Array.prototype as Record<symbol, unknown>)[Symbol.unscopables] as Record<
+        string,
+        unknown
+      >)[arrayUnscopablesSentinel];
     }
   });
 

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -266,6 +266,55 @@ describe("policy-gated zero tool registry", () => {
     expect(descriptorCalls).toBe(0);
   });
 
+  test("over-length ordinary arrays fail before array key discovery or numeric descriptor reads", async () => {
+    const editTool = new RecordingTool("edit");
+    const input = Array.from({ length: 1_025 }, (_, index) => index);
+    let evaluatorCalls = 0;
+    let arrayOwnKeysCalls = 0;
+    let arrayNumericDescriptorReads = 0;
+    const originalOwnKeys = Reflect.ownKeys;
+    const originalGetOwnPropertyDescriptor = Reflect.getOwnPropertyDescriptor;
+    Reflect.ownKeys = ((target: object): (string | symbol)[] => {
+      if (Array.isArray(target)) {
+        arrayOwnKeysCalls += 1;
+        throw new Error("array ownKeys must not be called");
+      }
+      return originalOwnKeys(target);
+    }) as typeof Reflect.ownKeys;
+    Reflect.getOwnPropertyDescriptor = ((
+      target: object,
+      propertyKey: PropertyKey
+    ): PropertyDescriptor | undefined => {
+      if (Array.isArray(target) && isExpectedNumericArrayDescriptorKey(propertyKey, target.length)) {
+        arrayNumericDescriptorReads += 1;
+        throw new Error(`array numeric descriptor must not be read: ${String(propertyKey)}`);
+      }
+      return originalGetOwnPropertyDescriptor(target, propertyKey);
+    }) as typeof Reflect.getOwnPropertyDescriptor;
+
+    try {
+      const wrapped = wrapToolWithPolicyGate(editTool, {
+        evaluate: async () => {
+          evaluatorCalls += 1;
+          return { decision: "allow" };
+        }
+      });
+
+      const result = await wrapped.run(createToolContext("worker"), input);
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("policy_gate_input_preparation_failed");
+    } finally {
+      Reflect.ownKeys = originalOwnKeys;
+      Reflect.getOwnPropertyDescriptor = originalGetOwnPropertyDescriptor;
+    }
+
+    expect(arrayOwnKeysCalls).toBe(0);
+    expect(arrayNumericDescriptorReads).toBe(0);
+    expect(evaluatorCalls).toBe(0);
+    expect(editTool.calls).toBe(0);
+  });
+
   test("ordinary arrays ignore over-budget non-index own properties without array key discovery", async () => {
     const editTool = new RecordingTool("edit");
     const sentinel = "ARRAY_NON_INDEX_PROPERTY_SENTINEL";
@@ -633,6 +682,106 @@ describe("policy-gated zero tool registry", () => {
     }
   });
 
+  test("non-spawn input preparation rejects non-ordinary non-array inputs", async () => {
+    class ClassBackedInput {
+      command = "original";
+    }
+    const customPrototypeInput = Object.create({ inherited: true }) as Record<string, unknown>;
+    customPrototypeInput.command = "original";
+    const cases: Array<{ label: string; input: unknown }> = [
+      {
+        label: "class instance",
+        input: new ClassBackedInput()
+      },
+      {
+        label: "date",
+        input: new Date("2026-07-06T00:00:00.000Z")
+      },
+      {
+        label: "map",
+        input: new Map([["command", "original"]])
+      },
+      {
+        label: "custom prototype",
+        input: customPrototypeInput
+      }
+    ];
+
+    for (const testCase of cases) {
+      const editTool = new RecordingTool(`edit-${testCase.label}`);
+      let evaluatorCalls = 0;
+      const wrapped = wrapToolWithPolicyGate(editTool, {
+        toolId: "edit",
+        evaluate: async () => {
+          evaluatorCalls += 1;
+          return { decision: "allow" };
+        }
+      });
+
+      const result = await wrapped.run(createToolContext("worker"), testCase.input);
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("policy_gate_input_preparation_failed");
+      expect(result.outputSummary).toBe("Policy gate input preparation failed for edit");
+      expect(evaluatorCalls).toBe(0);
+      expect(editTool.calls).toBe(0);
+    }
+  });
+
+  test("non-spawn input preparation rejects non-ordinary arrays", async () => {
+    class ArrayBackedInput extends Array<string> {}
+    const topLevelCustomPrototype = ["original"];
+    Object.setPrototypeOf(topLevelCustomPrototype, {
+      marker: "custom-array-prototype"
+    });
+    const nestedCustomPrototype = ["original"];
+    Object.setPrototypeOf(nestedCustomPrototype, {
+      marker: "nested-custom-array-prototype"
+    });
+    const cases: Array<{ label: string; input: unknown }> = [
+      {
+        label: "array subclass top-level",
+        input: new ArrayBackedInput("original")
+      },
+      {
+        label: "custom prototype top-level",
+        input: topLevelCustomPrototype
+      },
+      {
+        label: "array subclass nested",
+        input: {
+          values: new ArrayBackedInput("original")
+        }
+      },
+      {
+        label: "custom prototype nested",
+        input: {
+          values: nestedCustomPrototype
+        }
+      }
+    ];
+
+    for (const testCase of cases) {
+      const editTool = new RecordingTool(`edit-${testCase.label}`);
+      let evaluatorCalls = 0;
+      const wrapped = wrapToolWithPolicyGate(editTool, {
+        toolId: "edit",
+        evaluate: async () => {
+          evaluatorCalls += 1;
+          return { decision: "allow" };
+        }
+      });
+
+      const result = await wrapped.run(createToolContext("worker"), testCase.input);
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("policy_gate_input_preparation_failed");
+      expect(result.outputSummary).toBe("Policy gate input preparation failed for edit");
+      expect(evaluatorCalls).toBe(0);
+      expect(editTool.calls).toBe(0);
+    }
+  });
+
   test("oversized non-spawn inputs fail closed before evaluator and inner tool execution", async () => {
     const tailSentinel = "STRING_BUDGET_TAIL_SENTINEL";
     const cases: Array<{ label: string; input: unknown }> = [
@@ -701,6 +850,57 @@ describe("policy-gated zero tool registry", () => {
         outputSummary: result.outputSummary
       });
     }
+  });
+
+  test("non-spawn execution snapshots preserve ordinary plain-object compatibility", async () => {
+    const editTool = new RecordingTool("edit");
+    const input = {
+      command: "original",
+      nested: {
+        flag: "original"
+      },
+      values: ["alpha", "beta"]
+    };
+    let evaluatorInputPrototype: object | null | undefined;
+    let evaluatorNestedPrototype: object | null | undefined;
+    let evaluatorInputExtensible: boolean | undefined;
+    let evaluatorNestedExtensible: boolean | undefined;
+    let evaluatorArrayPrototype: object | null | undefined;
+    const wrapped = wrapToolWithPolicyGate(editTool, {
+      evaluate: async (call) => {
+        const evaluatorInput = call.input as { nested: object; values: unknown[] };
+        evaluatorInputPrototype = Object.getPrototypeOf(evaluatorInput);
+        evaluatorNestedPrototype = Object.getPrototypeOf(evaluatorInput.nested);
+        evaluatorInputExtensible = Object.isExtensible(evaluatorInput);
+        evaluatorNestedExtensible = Object.isExtensible(evaluatorInput.nested);
+        evaluatorArrayPrototype = Object.getPrototypeOf(evaluatorInput.values);
+        return { decision: "allow" };
+      }
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), input);
+
+    expect(result.success).toBe(true);
+    expect(editTool.calls).toBe(1);
+    const executionInput = editTool.lastInput as {
+      command?: unknown;
+      nested?: { flag?: unknown; hasOwnProperty?: (key: string) => boolean };
+      values?: string[];
+      hasOwnProperty?: (key: string) => boolean;
+    };
+    expect(Object.getPrototypeOf(executionInput)).toBe(Object.prototype);
+    expect(executionInput instanceof Object).toBe(true);
+    expect(executionInput.hasOwnProperty?.("command")).toBe(true);
+    expect(Object.getPrototypeOf(executionInput.nested as object)).toBe(Object.prototype);
+    expect(executionInput.nested instanceof Object).toBe(true);
+    expect(executionInput.nested?.hasOwnProperty?.("flag")).toBe(true);
+    expect(Array.isArray(executionInput.values)).toBe(true);
+    expect(Object.getPrototypeOf(executionInput.values as object)).toBe(Array.prototype);
+    expect(evaluatorInputPrototype).toBeNull();
+    expect(evaluatorNestedPrototype).toBeNull();
+    expect(evaluatorInputExtensible).toBe(false);
+    expect(evaluatorNestedExtensible).toBe(false);
+    expect(evaluatorArrayPrototype).not.toBe(Array.prototype);
   });
 
   test("non-spawn evaluator direct mutations are isolated from inner execution", async () => {
@@ -805,6 +1005,12 @@ describe("policy-gated zero tool registry", () => {
     let evaluatorMapResultParentPrototype: object | null | undefined;
     let evaluatorIteratorPrototype: object | null | undefined;
     let evaluatorIteratorNextPrototype: object | null | undefined;
+    let evaluatorInputExtensible: boolean | undefined;
+    let evaluatorNestedExtensible: boolean | undefined;
+    let evaluatorArrayPrototypeFrozen: boolean | undefined;
+    let evaluatorArrayMapFunctionFrozen: boolean | undefined;
+    let evaluatorIteratorFrozen: boolean | undefined;
+    let evaluatorIteratorNextFunctionFrozen: boolean | undefined;
     const wrapped = wrapToolWithPolicyGate(editTool, {
       evaluate: async (call) => {
         evaluatorClone = structuredClone(call.input);
@@ -827,7 +1033,11 @@ describe("policy-gated zero tool registry", () => {
         evaluatorNestedPrototype = Object.getPrototypeOf(
           (call.input as { nested: object }).nested
         );
+        evaluatorInputExtensible = Object.isExtensible(call.input as object);
+        evaluatorNestedExtensible = Object.isExtensible((call.input as { nested: object }).nested);
         evaluatorArrayPrototype = Object.getPrototypeOf(values);
+        evaluatorArrayPrototypeFrozen =
+          evaluatorArrayPrototype === null ? undefined : Object.isFrozen(evaluatorArrayPrototype);
         evaluatorArrayParentPrototype =
           evaluatorArrayPrototype === null ? null : Object.getPrototypeOf(evaluatorArrayPrototype);
         evaluatorArrayConstructor = (values as { constructor?: unknown }).constructor;
@@ -837,13 +1047,23 @@ describe("policy-gated zero tool registry", () => {
             : Object.getPrototypeOf(
                 (evaluatorArrayPrototype as Record<PropertyKey, unknown>).map as object
               );
+        evaluatorArrayMapFunctionFrozen =
+          evaluatorArrayPrototype === null
+            ? undefined
+            : Object.isFrozen(
+                (evaluatorArrayPrototype as Record<PropertyKey, unknown>).map as object
+              );
         evaluatorMapResultPrototype = Object.getPrototypeOf(mapped);
         evaluatorMapResultParentPrototype =
           evaluatorMapResultPrototype === null
             ? null
             : Object.getPrototypeOf(evaluatorMapResultPrototype);
         evaluatorIteratorPrototype = Object.getPrototypeOf(iterator as object);
+        evaluatorIteratorFrozen = Object.isFrozen(iterator as object);
         evaluatorIteratorNextPrototype = Object.getPrototypeOf(
+          (iterator as { next: () => IteratorResult<string> }).next
+        );
+        evaluatorIteratorNextFunctionFrozen = Object.isFrozen(
           (iterator as { next: () => IteratorResult<string> }).next
         );
         return { decision: "allow" };
@@ -870,16 +1090,22 @@ describe("policy-gated zero tool registry", () => {
     });
     expect(evaluatorInputPrototype).toBeNull();
     expect(evaluatorNestedPrototype).toBeNull();
+    expect(evaluatorInputExtensible).toBe(false);
+    expect(evaluatorNestedExtensible).toBe(false);
     expect(evaluatorArrayPrototype).not.toBeNull();
     expect(evaluatorArrayPrototype).not.toBe(Array.prototype);
+    expect(evaluatorArrayPrototypeFrozen).toBe(true);
     expect(evaluatorArrayParentPrototype).toBeNull();
     expect(evaluatorArrayConstructor).toBeUndefined();
     expect(evaluatorArrayMapFunctionPrototype).toBeNull();
+    expect(evaluatorArrayMapFunctionFrozen).toBe(true);
     expect(evaluatorMapResultPrototype).not.toBeNull();
     expect(evaluatorMapResultPrototype).not.toBe(Array.prototype);
     expect(evaluatorMapResultParentPrototype).toBeNull();
     expect(evaluatorIteratorPrototype).toBeNull();
+    expect(evaluatorIteratorFrozen).toBe(true);
     expect(evaluatorIteratorNextPrototype).toBeNull();
+    expect(evaluatorIteratorNextFunctionFrozen).toBe(true);
     expect(editTool.calls).toBe(1);
     expect((editTool.lastInput as { command?: unknown }).command).toBe("original");
     expect((editTool.lastInput as { nested?: { flag?: unknown } }).nested?.flag).toBe("original");
@@ -888,10 +1114,10 @@ describe("policy-gated zero tool registry", () => {
     expect(Array.isArray(executionValues)).toBe(true);
     expect(executionValues?.includes("beta")).toBe(true);
     expect(executionValues?.map((value) => value.toUpperCase())).toEqual(["ALPHA", "BETA"]);
-    expect(Object.getPrototypeOf(editTool.lastInput as object)).toBeNull();
+    expect(Object.getPrototypeOf(editTool.lastInput as object)).toBe(Object.prototype);
     expect(
       Object.getPrototypeOf((editTool.lastInput as { nested: object }).nested)
-    ).toBeNull();
+    ).toBe(Object.prototype);
     expect(editTool.lastInput).not.toBe(input);
     expect((editTool.lastInput as { nested: unknown }).nested).not.toBe(input.nested);
   });
@@ -904,7 +1130,19 @@ describe("policy-gated zero tool registry", () => {
     const arrayMethodSentinel = "__policyGateArrayMethodResidue";
     const mapResultPrototypeSentinel = "__policyGateMapResultPrototypeResidue";
     const iteratorPrototypeSentinel = "__policyGateIteratorPrototypeResidue";
+    const iteratorFunctionSentinel = "__policyGateIteratorFunctionResidue";
+    const arrayConstructorSentinel = "__policyGateArrayConstructorResidue";
     let constructorPrototypePathReachable: boolean | undefined;
+    let topReparentSucceeded: boolean | undefined;
+    let nestedReparentSucceeded: boolean | undefined;
+    let arrayReparentSucceeded: boolean | undefined;
+    let arrayPrototypeReparentSucceeded: boolean | undefined;
+    let arrayMethodFunctionReparentSucceeded: boolean | undefined;
+    let iteratorReparentSucceeded: boolean | undefined;
+    let iteratorNextFunctionReparentSucceeded: boolean | undefined;
+    let mapResultArrayReparentSucceeded: boolean | undefined;
+    let mapResultPrototypeReparentSucceeded: boolean | undefined;
+    let mapResultMethodFunctionReparentSucceeded: boolean | undefined;
     let arrayMethodFunctionPrototype: object | null | undefined;
     let iteratorPrototype: object | null | undefined;
     let iteratorNextFunctionPrototype: object | null | undefined;
@@ -915,8 +1153,12 @@ describe("policy-gated zero tool registry", () => {
       },
       values: ["original"]
     };
+    const originalArrayPrototypeMapPrototype = Object.getPrototypeOf(Array.prototype.map);
     const wrapped = wrapToolWithPolicyGate(editTool, {
       evaluate: async (call) => {
+        topReparentSucceeded = attemptMutation(() => {
+          Object.setPrototypeOf(call.input as object, Object.prototype);
+        });
         const topPrototype = Object.getPrototypeOf(call.input as object) as
           | Record<string, unknown>
           | null;
@@ -939,21 +1181,37 @@ describe("policy-gated zero tool registry", () => {
         const nestedPrototype = Object.getPrototypeOf(
           (call.input as { nested: object }).nested
         ) as Record<string, unknown> | null;
+        nestedReparentSucceeded = attemptMutation(() => {
+          Object.setPrototypeOf((call.input as { nested: object }).nested, Object.prototype);
+        });
         if (nestedPrototype) {
           nestedPrototype[objectPrototypeSentinel] = "mutated";
         }
 
         const arrayPrototype = Object.getPrototypeOf(values) as Record<PropertyKey, unknown> | null;
         if (arrayPrototype) {
-          arrayPrototype[arrayPrototypeSentinel] = "mutated";
+          arrayPrototypeReparentSucceeded = attemptMutation(() => {
+            Object.setPrototypeOf(arrayPrototype, Array.prototype);
+          });
+          attemptMutation(() => {
+            arrayPrototype[arrayPrototypeSentinel] = "mutated";
+          });
           const mapMethod = arrayPrototype.map as Record<string, unknown> | undefined;
           if (mapMethod) {
-            mapMethod[arrayMethodSentinel] = "mutated";
+            attemptMutation(() => {
+              mapMethod[arrayMethodSentinel] = "mutated";
+            });
             arrayMethodFunctionPrototype = Object.getPrototypeOf(mapMethod as object);
-            if (arrayMethodFunctionPrototype) {
-              (arrayMethodFunctionPrototype as Record<string, unknown>)[functionPrototypeSentinel] =
-                "mutated";
-            }
+            arrayMethodFunctionReparentSucceeded = attemptMutation(() => {
+              Object.setPrototypeOf(mapMethod as object, Function.prototype);
+            });
+            attemptMutation(() => {
+              if (arrayMethodFunctionPrototype) {
+                (arrayMethodFunctionPrototype as Record<string, unknown>)[
+                  functionPrototypeSentinel
+                ] = "mutated";
+              }
+            });
           }
         }
 
@@ -961,21 +1219,90 @@ describe("policy-gated zero tool registry", () => {
         const mappedPrototype = Object.getPrototypeOf(mappedValues) as
           | Record<string, unknown>
           | null;
+        mapResultArrayReparentSucceeded = attemptMutation(() => {
+          Object.setPrototypeOf(mappedValues, Array.prototype);
+        });
         if (mappedPrototype) {
-          mappedPrototype[mapResultPrototypeSentinel] = "mutated";
+          mapResultPrototypeReparentSucceeded = attemptMutation(() => {
+            Object.setPrototypeOf(mappedPrototype, Array.prototype);
+          });
+          attemptMutation(() => {
+            mappedPrototype[mapResultPrototypeSentinel] = "mutated";
+          });
+          const mappedMapMethod = mappedPrototype.map as object | undefined;
+          if (mappedMapMethod) {
+            mapResultMethodFunctionReparentSucceeded = attemptMutation(() => {
+              Object.setPrototypeOf(mappedMapMethod, Function.prototype);
+            });
+            attemptMutation(() => {
+              (mappedMapMethod as Record<string, unknown>)[arrayMethodSentinel] = "mutated";
+            });
+          }
         }
 
         const iterator = values[Symbol.iterator]();
         iteratorPrototype = Object.getPrototypeOf(iterator as object);
+        iteratorReparentSucceeded = attemptMutation(() => {
+          Object.setPrototypeOf(iterator as object, Object.prototype);
+        });
         if (iteratorPrototype) {
-          (iteratorPrototype as Record<string, unknown>)[iteratorPrototypeSentinel] = "mutated";
+          attemptMutation(() => {
+            (iteratorPrototype as Record<string, unknown>)[iteratorPrototypeSentinel] = "mutated";
+          });
         }
         iteratorNextFunctionPrototype = Object.getPrototypeOf(
           (iterator as { next: () => IteratorResult<unknown> }).next
         );
-        if (iteratorNextFunctionPrototype) {
-          (iteratorNextFunctionPrototype as Record<string, unknown>)[functionPrototypeSentinel] =
-            "mutated";
+        iteratorNextFunctionReparentSucceeded = attemptMutation(() => {
+          Object.setPrototypeOf(
+            (iterator as { next: () => IteratorResult<unknown> }).next,
+            Function.prototype
+          );
+        });
+        attemptMutation(() => {
+          (iterator as Record<PropertyKey, unknown>)[iteratorPrototypeSentinel] = "mutated";
+        });
+        attemptMutation(() => {
+          ((iterator as { next: () => IteratorResult<unknown> }).next as unknown as Record<
+            string,
+            unknown
+          >)[iteratorFunctionSentinel] = "mutated";
+        });
+        attemptMutation(() => {
+          if (iteratorNextFunctionPrototype) {
+            (iteratorNextFunctionPrototype as Record<string, unknown>)[
+              functionPrototypeSentinel
+            ] = "mutated";
+          }
+        });
+        arrayReparentSucceeded = attemptMutation(() => {
+          Object.setPrototypeOf(values, Array.prototype);
+        });
+        const reparentedArrayPrototype = Object.getPrototypeOf(values) as Record<
+          PropertyKey,
+          unknown
+        > | null;
+        if (reparentedArrayPrototype) {
+          attemptMutation(() => {
+            reparentedArrayPrototype[arrayPrototypeSentinel] = "mutated";
+          });
+          attemptMutation(() => {
+            (reparentedArrayPrototype.map as Record<string, unknown>)[arrayMethodSentinel] =
+              "mutated";
+          });
+        }
+        const reparentedConstructor = (values as { constructor?: unknown }).constructor;
+        if (typeof reparentedConstructor === "function") {
+          attemptMutation(() => {
+            (reparentedConstructor as unknown as Record<string, unknown>)[
+              arrayConstructorSentinel
+            ] = "mutated";
+          });
+          attemptMutation(() => {
+            (Object.getPrototypeOf(reparentedConstructor) as Record<string, unknown>)[
+              functionPrototypeSentinel
+            ] = "mutated";
+          });
         }
         return { decision: "allow" };
       }
@@ -1000,19 +1327,111 @@ describe("policy-gated zero tool registry", () => {
         (Array.prototype as Record<string, unknown>)[mapResultPrototypeSentinel]
       ).toBeUndefined();
       expect((Array.prototype.map as Record<string, unknown>)[arrayMethodSentinel]).toBeUndefined();
+      expect((Array as unknown as Record<string, unknown>)[arrayConstructorSentinel]).toBeUndefined();
       expect((Function.prototype as Record<string, unknown>)[functionPrototypeSentinel]).toBeUndefined();
       expect(constructorPrototypePathReachable).toBe(false);
+      expect(topReparentSucceeded).toBe(false);
+      expect(nestedReparentSucceeded).toBe(false);
+      expect(arrayReparentSucceeded).toBe(true);
+      expect(arrayPrototypeReparentSucceeded).toBe(false);
+      expect(arrayMethodFunctionReparentSucceeded).toBe(false);
+      expect(iteratorReparentSucceeded).toBe(false);
+      expect(iteratorNextFunctionReparentSucceeded).toBe(false);
+      expect(mapResultArrayReparentSucceeded).toBe(true);
+      expect(mapResultPrototypeReparentSucceeded).toBe(false);
+      expect(mapResultMethodFunctionReparentSucceeded).toBe(false);
       expect(arrayMethodFunctionPrototype).toBeNull();
       expect(iteratorPrototype).toBeNull();
       expect(iteratorNextFunctionPrototype).toBeNull();
+      expect(Object.getPrototypeOf(Array.prototype.map)).toBe(originalArrayPrototypeMapPrototype);
     } finally {
       delete (Object.prototype as Record<string, unknown>)[objectPrototypeSentinel];
       delete (Object.prototype as Record<string, unknown>)[functionPrototypeSentinel];
       delete (Array.prototype as Record<string, unknown>)[arrayPrototypeSentinel];
       delete (Array.prototype as Record<string, unknown>)[mapResultPrototypeSentinel];
       delete (Array.prototype.map as Record<string, unknown>)[arrayMethodSentinel];
+      delete (Array as unknown as Record<string, unknown>)[arrayConstructorSentinel];
       delete (Function.prototype as Record<string, unknown>)[functionPrototypeSentinel];
     }
+  });
+
+  test("non-spawn evaluator exposed methods and prototypes do not retain cross-call residue", async () => {
+    const editTool = new RecordingTool("edit");
+    const prototypeSentinel = "__policyGateCrossCallPrototypeResidue";
+    const methodSentinel = "__policyGateCrossCallMethodResidue";
+    const iteratorSentinel = "__policyGateCrossCallIteratorResidue";
+    let evaluatorCalls = 0;
+    let secondObservation:
+      | {
+          arrayPrototypeResidue: unknown;
+          arrayMethodResidue: unknown;
+          mapResultPrototypeResidue: unknown;
+          mapResultMethodResidue: unknown;
+          iteratorResidue: unknown;
+          iteratorNextResidue: unknown;
+        }
+      | undefined;
+    const wrapped = wrapToolWithPolicyGate(editTool, {
+      evaluate: async (call) => {
+        evaluatorCalls += 1;
+        const values = (call.input as { values: unknown[] }).values;
+        const arrayPrototype = Object.getPrototypeOf(values) as Record<PropertyKey, unknown>;
+        const arrayMapMethod = arrayPrototype.map as Record<string, unknown>;
+        const mapped = values.map((value) => value);
+        const mapResultPrototype = Object.getPrototypeOf(mapped) as Record<PropertyKey, unknown>;
+        const mapResultMapMethod = mapResultPrototype.map as Record<string, unknown>;
+        const iterator = values[Symbol.iterator]() as IterableIterator<unknown> &
+          Record<string, unknown>;
+        const iteratorNext = iterator.next as unknown as Record<string, unknown>;
+
+        if (evaluatorCalls === 1) {
+          attemptMutation(() => {
+            arrayPrototype[prototypeSentinel] = "mutated";
+          });
+          attemptMutation(() => {
+            arrayMapMethod[methodSentinel] = "mutated";
+          });
+          attemptMutation(() => {
+            mapResultPrototype[prototypeSentinel] = "mutated";
+          });
+          attemptMutation(() => {
+            mapResultMapMethod[methodSentinel] = "mutated";
+          });
+          attemptMutation(() => {
+            iterator[iteratorSentinel] = "mutated";
+          });
+          attemptMutation(() => {
+            iteratorNext[iteratorSentinel] = "mutated";
+          });
+        } else {
+          secondObservation = {
+            arrayPrototypeResidue: arrayPrototype[prototypeSentinel],
+            arrayMethodResidue: arrayMapMethod[methodSentinel],
+            mapResultPrototypeResidue: mapResultPrototype[prototypeSentinel],
+            mapResultMethodResidue: mapResultMapMethod[methodSentinel],
+            iteratorResidue: iterator[iteratorSentinel],
+            iteratorNextResidue: iteratorNext[iteratorSentinel]
+          };
+        }
+
+        return { decision: "allow" };
+      }
+    });
+
+    const firstResult = await wrapped.run(createToolContext("worker"), { values: ["first"] });
+    const secondResult = await wrapped.run(createToolContext("worker"), { values: ["second"] });
+
+    expect(firstResult.success).toBe(true);
+    expect(secondResult.success).toBe(true);
+    expect(editTool.calls).toBe(2);
+    expect(secondObservation).toEqual({
+      arrayPrototypeResidue: undefined,
+      arrayMethodResidue: undefined,
+      mapResultPrototypeResidue: undefined,
+      mapResultMethodResidue: undefined,
+      iteratorResidue: undefined,
+      iteratorNextResidue: undefined
+    });
   });
 
   test("malformed raw-rule deny from custom evaluator fails closed and finishes running handle", async () => {
@@ -4020,6 +4439,15 @@ function isExpectedNumericArrayDescriptorKey(propertyKey: PropertyKey, length: n
   }
   const index = Number(propertyKey);
   return Number.isInteger(index) && index >= 0 && index < length && String(index) === propertyKey;
+}
+
+function attemptMutation(mutator: () => void): boolean {
+  try {
+    mutator();
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function createToolContext(role: string): ToolContext & { role: string } {

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -1041,6 +1041,8 @@ describe("policy-gated zero tool registry", () => {
     let evaluatorNestedExtensible: boolean | undefined;
     let evaluatorArrayExtensible: boolean | undefined;
     let evaluatorMapResultExtensible: boolean | undefined;
+    let evaluatorArrayLengthWritable: boolean | undefined;
+    let evaluatorMapResultLengthWritable: boolean | undefined;
     let evaluatorArrayPrototypeFrozen: boolean | undefined;
     let evaluatorArrayMapFunctionFrozen: boolean | undefined;
     let evaluatorIteratorFrozen: boolean | undefined;
@@ -1071,6 +1073,11 @@ describe("policy-gated zero tool registry", () => {
         evaluatorNestedExtensible = Object.isExtensible((call.input as { nested: object }).nested);
         evaluatorArrayExtensible = Object.isExtensible(values);
         evaluatorMapResultExtensible = Object.isExtensible(mapped);
+        evaluatorArrayLengthWritable = Object.getOwnPropertyDescriptor(values, "length")?.writable;
+        evaluatorMapResultLengthWritable = Object.getOwnPropertyDescriptor(
+          mapped,
+          "length"
+        )?.writable;
         evaluatorArrayPrototype = Object.getPrototypeOf(values);
         evaluatorArrayPrototypeFrozen =
           evaluatorArrayPrototype === null ? undefined : Object.isFrozen(evaluatorArrayPrototype);
@@ -1130,6 +1137,8 @@ describe("policy-gated zero tool registry", () => {
     expect(evaluatorNestedExtensible).toBe(false);
     expect(evaluatorArrayExtensible).toBe(false);
     expect(evaluatorMapResultExtensible).toBe(false);
+    expect(evaluatorArrayLengthWritable).toBe(false);
+    expect(evaluatorMapResultLengthWritable).toBe(false);
     expect(evaluatorArrayPrototype).not.toBeNull();
     expect(evaluatorArrayPrototype).not.toBe(Array.prototype);
     expect(evaluatorArrayPrototypeFrozen).toBe(true);
@@ -1158,6 +1167,109 @@ describe("policy-gated zero tool registry", () => {
     ).toBe(Object.prototype);
     expect(editTool.lastInput).not.toBe(input);
     expect((editTool.lastInput as { nested: unknown }).nested).not.toBe(input.nested);
+  });
+
+  test("non-spawn evaluator array length growth attempts keep supported reads bounded", async () => {
+    const editTool = new RecordingTool("edit");
+    const inflatedLength = 2_048;
+    let observation:
+      | {
+          valuesLengthSetSucceeded: boolean;
+          mappedLengthSetSucceeded: boolean;
+          valuesLength: number;
+          mappedLength: number;
+          valuesLengthWritable: boolean | undefined;
+          mappedLengthWritable: boolean | undefined;
+          valuesIncludesMissing: boolean;
+          mappedIncludesMissing: boolean;
+          valuesMapLength: number;
+          mappedMapLength: number;
+          valuesSpreadLength: number;
+          mappedSpreadLength: number;
+          valuesIteratorCount: number;
+          mappedIteratorCount: number;
+          valuesMapCallbacks: number;
+          mappedMapCallbacks: number;
+        }
+      | undefined;
+    const wrapped = wrapToolWithPolicyGate(editTool, {
+      evaluate: async (call) => {
+        const values = (call.input as { values: string[] }).values;
+        const mapped = values.map((value) => value);
+        values[0] = "evaluator-local";
+        mapped[0] = "mapped-local";
+
+        const valuesLengthSetSucceeded = attemptMutation(() => {
+          values.length = inflatedLength;
+        });
+        const mappedLengthSetSucceeded = attemptMutation(() => {
+          mapped.length = inflatedLength;
+        });
+
+        let valuesMapCallbacks = 0;
+        const valuesMappedAfterGrowth = values.map((value) => {
+          valuesMapCallbacks += 1;
+          return value;
+        });
+        let mappedMapCallbacks = 0;
+        const mappedAfterGrowth = mapped.map((value) => {
+          mappedMapCallbacks += 1;
+          return value;
+        });
+        let valuesIteratorCount = 0;
+        for (const _value of values) {
+          valuesIteratorCount += 1;
+        }
+        let mappedIteratorCount = 0;
+        for (const _value of mapped) {
+          mappedIteratorCount += 1;
+        }
+
+        observation = {
+          valuesLengthSetSucceeded,
+          mappedLengthSetSucceeded,
+          valuesLength: values.length,
+          mappedLength: mapped.length,
+          valuesLengthWritable: Object.getOwnPropertyDescriptor(values, "length")?.writable,
+          mappedLengthWritable: Object.getOwnPropertyDescriptor(mapped, "length")?.writable,
+          valuesIncludesMissing: values.includes("missing-after-growth"),
+          mappedIncludesMissing: mapped.includes("missing-after-growth"),
+          valuesMapLength: valuesMappedAfterGrowth.length,
+          mappedMapLength: mappedAfterGrowth.length,
+          valuesSpreadLength: [...values].length,
+          mappedSpreadLength: [...mapped].length,
+          valuesIteratorCount,
+          mappedIteratorCount,
+          valuesMapCallbacks,
+          mappedMapCallbacks
+        };
+        return { decision: "allow" };
+      }
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), { values: ["alpha", "beta"] });
+
+    expect(result.success).toBe(true);
+    expect(editTool.calls).toBe(1);
+    expect(observation).toEqual({
+      valuesLengthSetSucceeded: expect.any(Boolean),
+      mappedLengthSetSucceeded: expect.any(Boolean),
+      valuesLength: 2,
+      mappedLength: 2,
+      valuesLengthWritable: false,
+      mappedLengthWritable: false,
+      valuesIncludesMissing: false,
+      mappedIncludesMissing: false,
+      valuesMapLength: 2,
+      mappedMapLength: 2,
+      valuesSpreadLength: 2,
+      mappedSpreadLength: 2,
+      valuesIteratorCount: 2,
+      mappedIteratorCount: 2,
+      valuesMapCallbacks: 2,
+      mappedMapCallbacks: 2
+    });
+    expect((editTool.lastInput as { values?: string[] }).values).toEqual(["alpha", "beta"]);
   });
 
   test("non-spawn evaluator prototype mutation paths cannot affect inner execution", async () => {
@@ -1393,6 +1505,108 @@ describe("policy-gated zero tool registry", () => {
     }
   });
 
+  test("non-spawn evaluator iterator result objects cannot create global prototype residue", async () => {
+    const editTool = new RecordingTool("edit");
+    const iteratorResultSentinel = "__policyGateIteratorResultGlobalResidue";
+    const blockedReparents = {
+      object: false,
+      array: false,
+      function: false
+    };
+    let observation:
+      | {
+          valuesYieldedReparents: GlobalPrototypeReparentOutcomes;
+          valuesDoneReparents: GlobalPrototypeReparentOutcomes;
+          mappedYieldedReparents: GlobalPrototypeReparentOutcomes;
+          mappedDoneReparents: GlobalPrototypeReparentOutcomes;
+          valuesYieldedFrozen: boolean;
+          valuesDoneFrozen: boolean;
+          mappedYieldedFrozen: boolean;
+          mappedDoneFrozen: boolean;
+          valuesYieldedValue: unknown;
+          valuesDoneDone: boolean | undefined;
+          mappedYieldedValue: unknown;
+          mappedDoneDone: boolean | undefined;
+          residueBeforeAllow: GlobalPrototypeResidueObservation;
+        }
+      | undefined;
+    const wrapped = wrapToolWithPolicyGate(editTool, {
+      evaluate: async (call) => {
+        const values = (call.input as { values: string[] }).values;
+        const mapped = values.map((value) => value);
+        const valuesIterator = values[Symbol.iterator]();
+        const valuesYieldedResult = valuesIterator.next();
+        const valuesDoneResult = valuesIterator.next();
+        const mappedIterator = mapped[Symbol.iterator]();
+        const mappedYieldedResult = mappedIterator.next();
+        const mappedDoneResult = mappedIterator.next();
+
+        observation = {
+          valuesYieldedReparents: attemptGlobalPrototypeReparents(
+            valuesYieldedResult as object,
+            iteratorResultSentinel
+          ),
+          valuesDoneReparents: attemptGlobalPrototypeReparents(
+            valuesDoneResult as object,
+            iteratorResultSentinel
+          ),
+          mappedYieldedReparents: attemptGlobalPrototypeReparents(
+            mappedYieldedResult as object,
+            iteratorResultSentinel
+          ),
+          mappedDoneReparents: attemptGlobalPrototypeReparents(
+            mappedDoneResult as object,
+            iteratorResultSentinel
+          ),
+          valuesYieldedFrozen: Object.isFrozen(valuesYieldedResult as object),
+          valuesDoneFrozen: Object.isFrozen(valuesDoneResult as object),
+          mappedYieldedFrozen: Object.isFrozen(mappedYieldedResult as object),
+          mappedDoneFrozen: Object.isFrozen(mappedDoneResult as object),
+          valuesYieldedValue: valuesYieldedResult.value,
+          valuesDoneDone: valuesDoneResult.done,
+          mappedYieldedValue: mappedYieldedResult.value,
+          mappedDoneDone: mappedDoneResult.done,
+          residueBeforeAllow: readGlobalPrototypeResidue(iteratorResultSentinel)
+        };
+        return { decision: "allow" };
+      }
+    });
+
+    try {
+      const result = await wrapped.run(createToolContext("worker"), { values: ["original"] });
+
+      expect(result.success).toBe(true);
+      expect(editTool.calls).toBe(1);
+      expect(observation).toEqual({
+        valuesYieldedReparents: blockedReparents,
+        valuesDoneReparents: blockedReparents,
+        mappedYieldedReparents: blockedReparents,
+        mappedDoneReparents: blockedReparents,
+        valuesYieldedFrozen: true,
+        valuesDoneFrozen: true,
+        mappedYieldedFrozen: true,
+        mappedDoneFrozen: true,
+        valuesYieldedValue: "original",
+        valuesDoneDone: true,
+        mappedYieldedValue: "original",
+        mappedDoneDone: true,
+        residueBeforeAllow: {
+          object: undefined,
+          array: undefined,
+          function: undefined
+        }
+      });
+      expect(readGlobalPrototypeResidue(iteratorResultSentinel)).toEqual({
+        object: undefined,
+        array: undefined,
+        function: undefined
+      });
+      expect((editTool.lastInput as { values?: string[] }).values).toEqual(["original"]);
+    } finally {
+      deleteGlobalPrototypeResidue(iteratorResultSentinel);
+    }
+  });
+
   test("non-spawn evaluator arrays cannot create Array.prototype residue through reparenting", async () => {
     const editTool = new RecordingTool("edit");
     const arrayPrototypeSentinel = "__policyGateInputDerivedArrayPrototypeResidue";
@@ -1448,6 +1662,7 @@ describe("policy-gated zero tool registry", () => {
     const prototypeSentinel = "__policyGateCrossCallPrototypeResidue";
     const methodSentinel = "__policyGateCrossCallMethodResidue";
     const iteratorSentinel = "__policyGateCrossCallIteratorResidue";
+    const iteratorResultSentinel = "__policyGateCrossCallIteratorResultResidue";
     let evaluatorCalls = 0;
     let secondObservation:
       | {
@@ -1457,6 +1672,11 @@ describe("policy-gated zero tool registry", () => {
           mapResultMethodResidue: unknown;
           iteratorResidue: unknown;
           iteratorNextResidue: unknown;
+          iteratorResultResidue: unknown;
+          iteratorDoneResultResidue: unknown;
+          mapResultIteratorResultResidue: unknown;
+          mapResultIteratorDoneResultResidue: unknown;
+          globalIteratorResultResidue: GlobalPrototypeResidueObservation;
         }
       | undefined;
     const wrapped = wrapToolWithPolicyGate(editTool, {
@@ -1471,6 +1691,15 @@ describe("policy-gated zero tool registry", () => {
         const iterator = values[Symbol.iterator]() as IterableIterator<unknown> &
           Record<string, unknown>;
         const iteratorNext = iterator.next as unknown as Record<string, unknown>;
+        const iteratorYieldedResult = iterator.next() as IteratorResult<unknown> &
+          Record<string, unknown>;
+        const iteratorDoneResult = iterator.next() as IteratorResult<unknown> &
+          Record<string, unknown>;
+        const mapResultIterator = mapped[Symbol.iterator]() as IterableIterator<unknown>;
+        const mapResultIteratorYieldedResult = mapResultIterator.next() as IteratorResult<unknown> &
+          Record<string, unknown>;
+        const mapResultIteratorDoneResult = mapResultIterator.next() as IteratorResult<unknown> &
+          Record<string, unknown>;
 
         if (evaluatorCalls === 1) {
           attemptMutation(() => {
@@ -1491,6 +1720,28 @@ describe("policy-gated zero tool registry", () => {
           attemptMutation(() => {
             iteratorNext[iteratorSentinel] = "mutated";
           });
+          attemptMutation(() => {
+            iteratorYieldedResult[iteratorResultSentinel] = "mutated";
+          });
+          attemptMutation(() => {
+            iteratorDoneResult[iteratorResultSentinel] = "mutated";
+          });
+          attemptMutation(() => {
+            mapResultIteratorYieldedResult[iteratorResultSentinel] = "mutated";
+          });
+          attemptMutation(() => {
+            mapResultIteratorDoneResult[iteratorResultSentinel] = "mutated";
+          });
+          attemptGlobalPrototypeReparents(iteratorYieldedResult as object, iteratorResultSentinel);
+          attemptGlobalPrototypeReparents(iteratorDoneResult as object, iteratorResultSentinel);
+          attemptGlobalPrototypeReparents(
+            mapResultIteratorYieldedResult as object,
+            iteratorResultSentinel
+          );
+          attemptGlobalPrototypeReparents(
+            mapResultIteratorDoneResult as object,
+            iteratorResultSentinel
+          );
         } else {
           secondObservation = {
             arrayPrototypeResidue: arrayPrototype[prototypeSentinel],
@@ -1498,7 +1749,14 @@ describe("policy-gated zero tool registry", () => {
             mapResultPrototypeResidue: mapResultPrototype[prototypeSentinel],
             mapResultMethodResidue: mapResultMapMethod[methodSentinel],
             iteratorResidue: iterator[iteratorSentinel],
-            iteratorNextResidue: iteratorNext[iteratorSentinel]
+            iteratorNextResidue: iteratorNext[iteratorSentinel],
+            iteratorResultResidue: iteratorYieldedResult[iteratorResultSentinel],
+            iteratorDoneResultResidue: iteratorDoneResult[iteratorResultSentinel],
+            mapResultIteratorResultResidue:
+              mapResultIteratorYieldedResult[iteratorResultSentinel],
+            mapResultIteratorDoneResultResidue:
+              mapResultIteratorDoneResult[iteratorResultSentinel],
+            globalIteratorResultResidue: readGlobalPrototypeResidue(iteratorResultSentinel)
           };
         }
 
@@ -1506,20 +1764,33 @@ describe("policy-gated zero tool registry", () => {
       }
     });
 
-    const firstResult = await wrapped.run(createToolContext("worker"), { values: ["first"] });
-    const secondResult = await wrapped.run(createToolContext("worker"), { values: ["second"] });
+    try {
+      const firstResult = await wrapped.run(createToolContext("worker"), { values: ["first"] });
+      const secondResult = await wrapped.run(createToolContext("worker"), { values: ["second"] });
 
-    expect(firstResult.success).toBe(true);
-    expect(secondResult.success).toBe(true);
-    expect(editTool.calls).toBe(2);
-    expect(secondObservation).toEqual({
-      arrayPrototypeResidue: undefined,
-      arrayMethodResidue: undefined,
-      mapResultPrototypeResidue: undefined,
-      mapResultMethodResidue: undefined,
-      iteratorResidue: undefined,
-      iteratorNextResidue: undefined
-    });
+      expect(firstResult.success).toBe(true);
+      expect(secondResult.success).toBe(true);
+      expect(editTool.calls).toBe(2);
+      expect(secondObservation).toEqual({
+        arrayPrototypeResidue: undefined,
+        arrayMethodResidue: undefined,
+        mapResultPrototypeResidue: undefined,
+        mapResultMethodResidue: undefined,
+        iteratorResidue: undefined,
+        iteratorNextResidue: undefined,
+        iteratorResultResidue: undefined,
+        iteratorDoneResultResidue: undefined,
+        mapResultIteratorResultResidue: undefined,
+        mapResultIteratorDoneResultResidue: undefined,
+        globalIteratorResultResidue: {
+          object: undefined,
+          array: undefined,
+          function: undefined
+        }
+      });
+    } finally {
+      deleteGlobalPrototypeResidue(iteratorResultSentinel);
+    }
   });
 
   test("malformed raw-rule deny from custom evaluator fails closed and finishes running handle", async () => {
@@ -4527,6 +4798,62 @@ function isExpectedNumericArrayDescriptorKey(propertyKey: PropertyKey, length: n
   }
   const index = Number(propertyKey);
   return Number.isInteger(index) && index >= 0 && index < length && String(index) === propertyKey;
+}
+
+type GlobalPrototypeReparentOutcomes = {
+  object: boolean;
+  array: boolean;
+  function: boolean;
+};
+
+type GlobalPrototypeResidueObservation = {
+  object: unknown;
+  array: unknown;
+  function: unknown;
+};
+
+function attemptGlobalPrototypeReparents(
+  value: object,
+  sentinel: string
+): GlobalPrototypeReparentOutcomes {
+  const outcomes: GlobalPrototypeReparentOutcomes = {
+    object: false,
+    array: false,
+    function: false
+  };
+  const probes: Array<[keyof GlobalPrototypeReparentOutcomes, object]> = [
+    ["object", Object.prototype],
+    ["array", Array.prototype],
+    ["function", Function.prototype]
+  ];
+
+  for (const [label, prototype] of probes) {
+    const succeeded = attemptMutation(() => {
+      Object.setPrototypeOf(value, prototype);
+    });
+    outcomes[label] = succeeded;
+    if (succeeded && Object.getPrototypeOf(value) === prototype) {
+      attemptMutation(() => {
+        (prototype as Record<string, unknown>)[sentinel] = "mutated";
+      });
+    }
+  }
+
+  return outcomes;
+}
+
+function readGlobalPrototypeResidue(sentinel: string): GlobalPrototypeResidueObservation {
+  return {
+    object: (Object.prototype as Record<string, unknown>)[sentinel],
+    array: (Array.prototype as Record<string, unknown>)[sentinel],
+    function: (Function.prototype as Record<string, unknown>)[sentinel]
+  };
+}
+
+function deleteGlobalPrototypeResidue(sentinel: string): void {
+  delete (Object.prototype as Record<string, unknown>)[sentinel];
+  delete (Array.prototype as Record<string, unknown>)[sentinel];
+  delete (Function.prototype as Record<string, unknown>)[sentinel];
 }
 
 function attemptMutation(mutator: () => void): boolean {

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -457,12 +457,11 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       };
     }
 
-    assertGenericPolicyGateInputCanBeSafelyPrepared(input);
-    const executionInput = clonePolicyGateInput(input);
+    const { executionInput, evaluatorInput } = prepareGenericPolicyGateInputSnapshots(input);
     return {
       decision: "allow",
       executionInput,
-      evaluatorInput: createReadOnlyPolicyGateInputView(executionInput)
+      evaluatorInput
     };
   }
 }
@@ -733,7 +732,28 @@ interface GenericPolicyGateInputBudgetState {
   seenObjects: WeakSet<object>;
 }
 
-type GenericPolicyGateDescriptorRecord = Record<PropertyKey, PropertyDescriptor | undefined>;
+interface GenericPolicyGateSnapshotState extends GenericPolicyGateInputBudgetState {
+  snapshots: WeakMap<object, unknown>;
+}
+
+type GenericPolicyGateDataDescriptor = PropertyDescriptor & {
+  value: unknown;
+};
+
+function prepareGenericPolicyGateInputSnapshots(value: unknown): {
+  executionInput: unknown;
+  evaluatorInput: unknown;
+} {
+  assertGenericPolicyGateInputCanBeSafelyPrepared(value);
+  return {
+    executionInput: createGenericPolicyGateInputSnapshot(value, {
+      nullPrototypeArrays: false
+    }),
+    evaluatorInput: createGenericPolicyGateInputSnapshot(value, {
+      nullPrototypeArrays: true
+    })
+  };
+}
 
 function assertGenericPolicyGateInputCanBeSafelyPrepared(value: unknown): void {
   inspectGenericPolicyGateInput(value, {
@@ -791,15 +811,18 @@ function inspectGenericPolicyGateInput(
     throw new Error("Policy gate input must be plain structured data.");
   }
 
-  const descriptors = getGenericPolicyGateDescriptors(objectValue);
-  const keys = Reflect.ownKeys(descriptors);
+  const keys = getBoundedGenericPolicyGateObjectKeys(objectValue);
   if (keys.length > GENERIC_POLICY_GATE_INPUT_MAX_OBJECT_KEYS) {
     throw new Error("Policy gate input exceeds object key budget.");
   }
 
   for (const key of keys) {
     assertSafeGenericPolicyGatePropertyKey(key, state, true);
-    inspectGenericPolicyGateDescriptorValue(getDescriptorForKey(descriptors, key), state, depth);
+    inspectGenericPolicyGateDescriptorValue(
+      readGenericPolicyGateDataDescriptor(objectValue, key),
+      state,
+      depth
+    );
   }
 }
 
@@ -808,28 +831,21 @@ function inspectGenericPolicyGateArray(
   state: GenericPolicyGateInputBudgetState,
   depth: number
 ): void {
-  const descriptors = getGenericPolicyGateDescriptors(value);
-  const lengthDescriptor = descriptors.length;
-  if (
-    !lengthDescriptor ||
-    !("value" in lengthDescriptor) ||
-    typeof lengthDescriptor.value !== "number" ||
-    !Number.isSafeInteger(lengthDescriptor.value) ||
-    lengthDescriptor.value < 0
-  ) {
-    throw new Error("Policy gate input contains an unsafe array length.");
-  }
-  if (lengthDescriptor.value > GENERIC_POLICY_GATE_INPUT_MAX_ARRAY_LENGTH) {
+  const length = readGenericPolicyGateArrayLength(value);
+  if (length > GENERIC_POLICY_GATE_INPUT_MAX_ARRAY_LENGTH) {
     throw new Error("Policy gate input exceeds array length budget.");
   }
 
   let extraKeyCount = 0;
-  for (const key of Reflect.ownKeys(descriptors)) {
+  for (const key of Reflect.ownKeys(value)) {
     if (key === "length") {
       continue;
     }
 
     if (typeof key === "string" && isArrayIndexPropertyKey(key)) {
+      if (Number(key) >= length) {
+        throw new Error("Policy gate input contains an unsafe array length.");
+      }
       assertSafeGenericPolicyGatePropertyKey(key, state, false);
     } else {
       extraKeyCount += 1;
@@ -839,15 +855,48 @@ function inspectGenericPolicyGateArray(
       assertSafeGenericPolicyGatePropertyKey(key, state, true);
     }
 
-    inspectGenericPolicyGateDescriptorValue(getDescriptorForKey(descriptors, key), state, depth);
+    inspectGenericPolicyGateDescriptorValue(
+      readGenericPolicyGateDataDescriptor(value, key),
+      state,
+      depth
+    );
   }
 }
 
 function inspectGenericPolicyGateDescriptorValue(
-  descriptor: PropertyDescriptor | undefined,
+  descriptor: GenericPolicyGateDataDescriptor,
   state: GenericPolicyGateInputBudgetState,
   depth: number
 ): void {
+  inspectGenericPolicyGateInput(descriptor.value, state, depth + 1);
+}
+
+function readGenericPolicyGateArrayLength(value: readonly unknown[]): number {
+  const length = Reflect.get(value, "length");
+  if (
+    typeof length !== "number" ||
+    !Number.isSafeInteger(length) ||
+    length < 0 ||
+    length > 4_294_967_295
+  ) {
+    throw new Error("Policy gate input contains an unsafe array length.");
+  }
+  return length;
+}
+
+function getBoundedGenericPolicyGateObjectKeys(value: object): (string | symbol)[] {
+  const keys = Reflect.ownKeys(value);
+  if (keys.length > GENERIC_POLICY_GATE_INPUT_MAX_OBJECT_KEYS) {
+    throw new Error("Policy gate input exceeds object key budget.");
+  }
+  return keys;
+}
+
+function readGenericPolicyGateDataDescriptor(
+  value: object,
+  key: string | symbol
+): GenericPolicyGateDataDescriptor {
+  const descriptor = Reflect.getOwnPropertyDescriptor(value, key);
   if (
     !descriptor ||
     !("value" in descriptor) ||
@@ -856,19 +905,7 @@ function inspectGenericPolicyGateDescriptorValue(
   ) {
     throw new Error("Policy gate input contains unsafe accessors.");
   }
-
-  inspectGenericPolicyGateInput(descriptor.value, state, depth + 1);
-}
-
-function getDescriptorForKey(
-  descriptors: GenericPolicyGateDescriptorRecord,
-  key: string | symbol
-): PropertyDescriptor | undefined {
-  return descriptors[key];
-}
-
-function getGenericPolicyGateDescriptors(value: object): GenericPolicyGateDescriptorRecord {
-  return Object.getOwnPropertyDescriptors(value) as unknown as GenericPolicyGateDescriptorRecord;
+  return descriptor as GenericPolicyGateDataDescriptor;
 }
 
 function assertSafeGenericPolicyGatePropertyKey(
@@ -905,60 +942,166 @@ function isArrayIndexPropertyKey(key: string): boolean {
   return Number.isInteger(index) && index >= 0 && index < 4_294_967_295 && String(index) === key;
 }
 
-const READ_ONLY_POLICY_GATE_INPUT_ERROR = "Policy gate evaluator input is read-only.";
-
-function createReadOnlyPolicyGateInputView(
+function createGenericPolicyGateInputSnapshot(
   value: unknown,
-  seenObjects = new WeakMap<object, unknown>()
+  options: { nullPrototypeArrays: boolean }
 ): unknown {
-  if (value === null || typeof value !== "object") {
+  return snapshotGenericPolicyGateInput(
+    value,
+    {
+      nodes: 0,
+      stringChars: 0,
+      seenObjects: new WeakSet<object>(),
+      snapshots: new WeakMap<object, unknown>()
+    },
+    options
+  );
+}
+
+function snapshotGenericPolicyGateInput(
+  value: unknown,
+  state: GenericPolicyGateSnapshotState,
+  options: { nullPrototypeArrays: boolean },
+  depth = 0
+): unknown {
+  if (depth > GENERIC_POLICY_GATE_INPUT_MAX_DEPTH) {
+    throw new Error("Policy gate input exceeds depth budget.");
+  }
+
+  state.nodes += 1;
+  if (state.nodes > GENERIC_POLICY_GATE_INPUT_MAX_NODES) {
+    throw new Error("Policy gate input exceeds node budget.");
+  }
+
+  if (value === null) {
+    return null;
+  }
+  if (typeof value === "string") {
+    addGenericPolicyGateStringBudget(value.length, state);
     return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "undefined") {
+    return value;
+  }
+  if (typeof value === "function" || typeof value === "symbol" || typeof value === "bigint") {
+    throw new Error("Policy gate input contains unsafe value types.");
+  }
+  if (typeof value !== "object") {
+    throw new Error("Policy gate input contains unsupported value types.");
   }
 
   const objectValue = value as object;
-  const existingView = seenObjects.get(objectValue);
-  if (existingView) {
-    return existingView;
+  const existingSnapshot = state.snapshots.get(objectValue);
+  if (existingSnapshot) {
+    return existingSnapshot;
+  }
+  state.seenObjects.add(objectValue);
+
+  if (Array.isArray(objectValue)) {
+    return snapshotGenericPolicyGateArray(objectValue, state, options, depth);
   }
 
-  const proxy = new Proxy(objectValue, {
-    get(target, property, receiver) {
-      return createReadOnlyPolicyGateInputView(Reflect.get(target, property, receiver), seenObjects);
-    },
-    getOwnPropertyDescriptor(target, property) {
-      const descriptor = Reflect.getOwnPropertyDescriptor(target, property);
-      if (!descriptor || !("value" in descriptor)) {
-        return descriptor;
-      }
+  const prototype = Object.getPrototypeOf(objectValue);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error("Policy gate input must be plain structured data.");
+  }
 
-      const readOnlyValue = createReadOnlyPolicyGateInputView(descriptor.value, seenObjects);
-      if (!descriptor.configurable && !descriptor.writable && readOnlyValue !== descriptor.value) {
-        return descriptor;
-      }
+  return snapshotGenericPolicyGatePlainObject(objectValue, state, options, depth);
+}
 
-      return {
-        ...descriptor,
-        value: readOnlyValue
-      };
-    },
-    set() {
-      throw new Error(READ_ONLY_POLICY_GATE_INPUT_ERROR);
-    },
-    deleteProperty() {
-      throw new Error(READ_ONLY_POLICY_GATE_INPUT_ERROR);
-    },
-    defineProperty() {
-      throw new Error(READ_ONLY_POLICY_GATE_INPUT_ERROR);
-    },
-    setPrototypeOf() {
-      throw new Error(READ_ONLY_POLICY_GATE_INPUT_ERROR);
-    },
-    preventExtensions() {
-      throw new Error(READ_ONLY_POLICY_GATE_INPUT_ERROR);
+function snapshotGenericPolicyGateArray(
+  value: readonly unknown[],
+  state: GenericPolicyGateSnapshotState,
+  options: { nullPrototypeArrays: boolean },
+  depth: number
+): unknown[] {
+  const length = readGenericPolicyGateArrayLength(value);
+  if (length > GENERIC_POLICY_GATE_INPUT_MAX_ARRAY_LENGTH) {
+    throw new Error("Policy gate input exceeds array length budget.");
+  }
+
+  const snapshot = new Array<unknown>(length);
+  if (options.nullPrototypeArrays) {
+    Object.setPrototypeOf(snapshot, null);
+  }
+  state.snapshots.set(value, snapshot);
+
+  let extraKeyCount = 0;
+  for (const key of Reflect.ownKeys(value)) {
+    if (key === "length") {
+      continue;
     }
-  });
-  seenObjects.set(objectValue, proxy);
-  return proxy;
+
+    const isArrayIndex = typeof key === "string" && isArrayIndexPropertyKey(key);
+    if (isArrayIndex) {
+      if (Number(key) >= length) {
+        throw new Error("Policy gate input contains an unsafe array length.");
+      }
+      assertSafeGenericPolicyGatePropertyKey(key, state, false);
+    } else {
+      extraKeyCount += 1;
+      if (extraKeyCount > GENERIC_POLICY_GATE_INPUT_MAX_OBJECT_KEYS) {
+        throw new Error("Policy gate input exceeds object key budget.");
+      }
+      assertSafeGenericPolicyGatePropertyKey(key, state, true);
+    }
+
+    const descriptor = readGenericPolicyGateDataDescriptor(value, key);
+    const snapshotValue = snapshotGenericPolicyGateInput(
+      descriptor.value,
+      state,
+      options,
+      depth + 1
+    );
+    if (!descriptor.enumerable) {
+      continue;
+    }
+    if (isArrayIndex) {
+      snapshot[Number(key)] = snapshotValue;
+    } else {
+      Object.defineProperty(snapshot, key, {
+        value: snapshotValue,
+        enumerable: true,
+        configurable: true,
+        writable: true
+      });
+    }
+  }
+
+  return snapshot;
+}
+
+function snapshotGenericPolicyGatePlainObject(
+  value: object,
+  state: GenericPolicyGateSnapshotState,
+  options: { nullPrototypeArrays: boolean },
+  depth: number
+): Record<string, unknown> {
+  const snapshot = Object.create(null) as Record<string, unknown>;
+  state.snapshots.set(value, snapshot);
+  const keys = getBoundedGenericPolicyGateObjectKeys(value);
+
+  for (const key of keys) {
+    assertSafeGenericPolicyGatePropertyKey(key, state, true);
+    const descriptor = readGenericPolicyGateDataDescriptor(value, key);
+    const snapshotValue = snapshotGenericPolicyGateInput(
+      descriptor.value,
+      state,
+      options,
+      depth + 1
+    );
+    if (!descriptor.enumerable) {
+      continue;
+    }
+    Object.defineProperty(snapshot, key, {
+      value: snapshotValue,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  }
+
+  return snapshot;
 }
 
 function clonePolicyGateInput(value: unknown): unknown {

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -826,41 +826,13 @@ function materializeGenericPolicyGateArray(
   const snapshot = new Array<unknown>(length);
   state.snapshots.set(value, snapshot);
 
-  let extraKeyCount = 0;
-  for (const key of Reflect.ownKeys(value)) {
-    if (key === "length") {
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = readGenericPolicyGateArrayIndexDataDescriptor(value, index);
+    if (!descriptor) {
       continue;
     }
 
-    const isArrayIndex = typeof key === "string" && isArrayIndexPropertyKey(key);
-    if (isArrayIndex) {
-      if (Number(key) >= length) {
-        throw new Error("Policy gate input contains an unsafe array length.");
-      }
-      assertSafeGenericPolicyGatePropertyKey(key, state, false);
-    } else {
-      extraKeyCount += 1;
-      if (extraKeyCount > GENERIC_POLICY_GATE_INPUT_MAX_OBJECT_KEYS) {
-        throw new Error("Policy gate input exceeds object key budget.");
-      }
-      assertSafeGenericPolicyGatePropertyKey(key, state, true);
-    }
-
-    const descriptor = readGenericPolicyGateDataDescriptor(value, key);
-    const snapshotValue = materializeGenericPolicyGateInput(descriptor.value, state, depth + 1);
-    if (!descriptor.enumerable) {
-      continue;
-    }
-    if (isArrayIndex) {
-      snapshot[Number(key)] = snapshotValue;
-    } else {
-      Object.defineProperty(snapshot, key, {
-        value: snapshotValue,
-        enumerable: true,
-        configurable: true,
-        writable: true
-      });
-    }
+    snapshot[index] = materializeGenericPolicyGateInput(descriptor.value, state, depth + 1);
   }
 
   return snapshot;
@@ -930,6 +902,24 @@ function readGenericPolicyGateDataDescriptor(
   return descriptor as GenericPolicyGateDataDescriptor;
 }
 
+function readGenericPolicyGateArrayIndexDataDescriptor(
+  value: readonly unknown[],
+  index: number
+): GenericPolicyGateDataDescriptor | undefined {
+  const descriptor = Reflect.getOwnPropertyDescriptor(value, String(index));
+  if (!descriptor) {
+    return undefined;
+  }
+  if (
+    !("value" in descriptor) ||
+    descriptor.get !== undefined ||
+    descriptor.set !== undefined
+  ) {
+    throw new Error("Policy gate input contains unsafe accessors.");
+  }
+  return descriptor as GenericPolicyGateDataDescriptor;
+}
+
 function assertSafeGenericPolicyGatePropertyKey(
   key: string | symbol,
   state: GenericPolicyGateInputBudgetState,
@@ -954,14 +944,6 @@ function addGenericPolicyGateStringBudget(
   if (state.stringChars > GENERIC_POLICY_GATE_INPUT_MAX_STRING_CHARS) {
     throw new Error("Policy gate input exceeds string budget.");
   }
-}
-
-function isArrayIndexPropertyKey(key: string): boolean {
-  if (key.trim() === "" || key === "4294967295") {
-    return false;
-  }
-  const index = Number(key);
-  return Number.isInteger(index) && index >= 0 && index < 4_294_967_295 && String(index) === key;
 }
 
 function cloneGenericPolicyGateMaterializedInput(
@@ -1046,46 +1028,19 @@ function cloneGenericPolicyGateMaterializedArray(
   }
   state.snapshots.set(value, snapshot);
 
-  let extraKeyCount = 0;
-  for (const key of Reflect.ownKeys(value)) {
-    if (key === "length") {
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = readGenericPolicyGateArrayIndexDataDescriptor(value, index);
+    if (!descriptor) {
       continue;
     }
 
-    const isArrayIndex = typeof key === "string" && isArrayIndexPropertyKey(key);
-    if (isArrayIndex) {
-      if (Number(key) >= length) {
-        throw new Error("Policy gate input contains an unsafe array length.");
-      }
-      assertSafeGenericPolicyGatePropertyKey(key, state, false);
-    } else {
-      extraKeyCount += 1;
-      if (extraKeyCount > GENERIC_POLICY_GATE_INPUT_MAX_OBJECT_KEYS) {
-        throw new Error("Policy gate input exceeds object key budget.");
-      }
-      assertSafeGenericPolicyGatePropertyKey(key, state, true);
-    }
-
-    const descriptor = readGenericPolicyGateDataDescriptor(value, key);
     const snapshotValue = cloneGenericPolicyGateMaterializedValue(
       descriptor.value,
       state,
       options,
       depth + 1
     );
-    if (!descriptor.enumerable) {
-      continue;
-    }
-    if (isArrayIndex) {
-      snapshot[Number(key)] = snapshotValue;
-    } else {
-      Object.defineProperty(snapshot, key, {
-        value: snapshotValue,
-        enumerable: true,
-        configurable: true,
-        writable: true
-      });
-    }
+    snapshot[index] = snapshotValue;
   }
 
   return snapshot;
@@ -1126,45 +1081,178 @@ function cloneGenericPolicyGateMaterializedPlainObject(
 
 function createIsolatedArrayPrototype(): object {
   const prototype = Object.create(null) as Record<PropertyKey, unknown>;
-  for (const key of Reflect.ownKeys(Array.prototype)) {
-    const descriptor = Object.getOwnPropertyDescriptor(Array.prototype, key);
-    if (!descriptor) {
-      continue;
-    }
-    if ("value" in descriptor) {
-      Object.defineProperty(prototype, key, {
-        ...descriptor,
-        value: createIsolatedArrayPrototypeValue(descriptor.value)
-      });
-      continue;
-    }
-    Object.defineProperty(prototype, key, descriptor);
-  }
-  function PolicyGateEvaluatorArray(): void {}
-  Object.defineProperty(PolicyGateEvaluatorArray, "prototype", {
-    value: prototype,
-    configurable: false,
-    writable: false
-  });
-  Object.defineProperty(prototype, "constructor", {
-    value: PolicyGateEvaluatorArray,
+  defineIsolatedArrayPrototypeMethod(prototype, Symbol.iterator, isolatedArrayIterator);
+  defineIsolatedArrayPrototypeMethod(prototype, "includes", isolatedArrayIncludes);
+  defineIsolatedArrayPrototypeMethod(prototype, "map", isolatedArrayMap);
+  defineIsolatedArrayPrototypeMethod(prototype, "push", isolatedArrayPush);
+  return prototype;
+}
+
+function defineIsolatedArrayPrototypeMethod(
+  prototype: Record<PropertyKey, unknown>,
+  key: PropertyKey,
+  method: (...args: unknown[]) => unknown
+): void {
+  Object.defineProperty(prototype, key, {
+    value: method,
     enumerable: false,
     configurable: true,
     writable: true
   });
-  return prototype;
 }
 
-function createIsolatedArrayPrototypeValue(value: unknown): unknown {
-  if (typeof value === "function") {
-    const arrayMethod = value;
-    return function isolatedArrayMethod(this: unknown, ...args: unknown[]): unknown {
-      return Reflect.apply(arrayMethod, this, args);
-    };
+const isolatedArrayIncludes = isolateFunction(
+  {
+    includes(this: unknown, searchElement: unknown, fromIndex?: unknown): boolean {
+      const receiver = requireIsolatedArrayReceiver(this);
+      const length = readGenericPolicyGateArrayLength(receiver);
+      const start = normalizeArrayStartIndex(length, fromIndex);
+      for (let index = start; index < length; index += 1) {
+        if (sameValueZero(receiver[index], searchElement)) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }.includes
+);
+
+const isolatedArrayMap = isolateFunction(
+  {
+    map(this: unknown, callback: unknown, thisArg?: unknown): unknown[] {
+      const receiver = requireIsolatedArrayReceiver(this);
+      if (typeof callback !== "function") {
+        throw new TypeError("Array map callback must be a function.");
+      }
+      const length = readGenericPolicyGateArrayLength(receiver);
+      const result = createIsolatedEvaluatorArray(length);
+      for (let index = 0; index < length; index += 1) {
+        if (!Object.prototype.hasOwnProperty.call(receiver, index)) {
+          continue;
+        }
+        result[index] = Reflect.apply(callback, thisArg, [receiver[index], index, receiver]);
+      }
+      return result;
+    }
+  }.map
+);
+
+const isolatedArrayPush = isolateFunction(
+  {
+    push(this: unknown, ...items: unknown[]): number {
+      const receiver = requireIsolatedArrayReceiver(this);
+      const length = readGenericPolicyGateArrayLength(receiver);
+      const newLength = length + items.length;
+      if (newLength > 4_294_967_295) {
+        throw new RangeError("Invalid array length.");
+      }
+      for (let offset = 0; offset < items.length; offset += 1) {
+        receiver[length + offset] = items[offset];
+      }
+      receiver.length = newLength;
+      return newLength;
+    }
+  }.push
+);
+
+const isolatedArrayIterator = isolateFunction(
+  {
+    [Symbol.iterator](this: unknown): IterableIterator<unknown> {
+      return createIsolatedArrayIterator(requireIsolatedArrayReceiver(this));
+    }
+  }[Symbol.iterator]
+);
+
+function createIsolatedEvaluatorArray(length: number): unknown[] {
+  const array = new Array<unknown>(length);
+  Object.setPrototypeOf(array, createIsolatedArrayPrototype());
+  return array;
+}
+
+function createIsolatedArrayIterator(receiver: unknown[]): IterableIterator<unknown> {
+  let index = 0;
+  const iterator = Object.create(null) as IterableIterator<unknown>;
+  Object.defineProperty(iterator, "next", {
+    value: isolateFunction({
+      next(): IteratorResult<unknown> {
+        const length = readGenericPolicyGateArrayLength(receiver);
+        if (index >= length) {
+          return createIsolatedArrayIteratorResult(undefined, true);
+        }
+        const valueAtIndex = receiver[index];
+        index += 1;
+        return createIsolatedArrayIteratorResult(valueAtIndex, false);
+      }
+    }.next),
+    enumerable: false,
+    configurable: true,
+    writable: true
+  });
+  Object.defineProperty(iterator, Symbol.iterator, {
+    value: isolateFunction({
+      [Symbol.iterator](this: IterableIterator<unknown>): IterableIterator<unknown> {
+        return this;
+      }
+    }[Symbol.iterator]),
+    enumerable: false,
+    configurable: true,
+    writable: true
+  });
+  return iterator;
+}
+
+function createIsolatedArrayIteratorResult(value: unknown, done: boolean): IteratorResult<unknown> {
+  const result = Object.create(null) as IteratorResult<unknown>;
+  Object.defineProperty(result, "value", {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true
+  });
+  Object.defineProperty(result, "done", {
+    value: done,
+    enumerable: true,
+    configurable: true,
+    writable: true
+  });
+  return result;
+}
+
+function requireIsolatedArrayReceiver(value: unknown): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new TypeError("Policy gate evaluator array method called on incompatible receiver.");
   }
-  if (value !== null && typeof value === "object") {
-    return Object.assign(Object.create(null), value);
+  return value;
+}
+
+function normalizeArrayStartIndex(length: number, fromIndex: unknown): number {
+  const integer = toIntegerOrInfinity(fromIndex);
+  if (integer === Number.POSITIVE_INFINITY) {
+    return length;
   }
+  if (integer >= 0) {
+    return Math.min(integer, length);
+  }
+  return Math.max(length + integer, 0);
+}
+
+function toIntegerOrInfinity(value: unknown): number {
+  const number = value === undefined ? 0 : Number(value);
+  if (Number.isNaN(number) || number === 0) {
+    return 0;
+  }
+  if (!Number.isFinite(number)) {
+    return number;
+  }
+  return Math.trunc(number);
+}
+
+function sameValueZero(left: unknown, right: unknown): boolean {
+  return left === right || (left !== left && right !== right);
+}
+
+function isolateFunction<T extends (...args: unknown[]) => unknown>(value: T): T {
+  Object.setPrototypeOf(value, null);
   return value;
 }
 

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -1053,7 +1053,7 @@ function cloneGenericPolicyGateMaterializedArray(
   }
 
   if (options.mode === "evaluator") {
-    Object.preventExtensions(snapshot);
+    finalizeIsolatedEvaluatorArray(snapshot);
   }
   return snapshot;
 }
@@ -1150,8 +1150,7 @@ const isolatedArrayMap = isolateFunction(
         }
         result[index] = Reflect.apply(callback, thisArg, [receiver[index], index, receiver]);
       }
-      Object.preventExtensions(result);
-      return result;
+      return finalizeIsolatedEvaluatorArray(result);
     }
   }.map
 );
@@ -1167,6 +1166,14 @@ const isolatedArrayIterator = isolateFunction(
 function createIsolatedEvaluatorArray(length: number): unknown[] {
   const array = new Array<unknown>(length);
   Object.setPrototypeOf(array, createIsolatedArrayPrototype());
+  return array;
+}
+
+function finalizeIsolatedEvaluatorArray<T extends unknown[]>(array: T): T {
+  Object.preventExtensions(array);
+  Object.defineProperty(array, "length", {
+    writable: false
+  });
   return array;
 }
 
@@ -1217,6 +1224,7 @@ function createIsolatedArrayIteratorResult(value: unknown, done: boolean): Itera
     configurable: true,
     writable: true
   });
+  Object.freeze(result);
   return result;
 }
 

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -340,28 +340,18 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
     }
 
     try {
-      const intrinsicResidueGuard =
-        this.policyGateToolId === "spawn_agent"
-          ? undefined
-          : createPolicyGateIntrinsicResidueGuard();
-      const candidate = await (async () => {
-        try {
-          return await this.options.evaluate(
-            {
-              toolId: this.policyGateToolId,
-              role,
-              input: preparedInput.evaluatorInput,
-              workDir: toolContext.workDir
-            },
-            {
-              tool: this.innerTool,
-              toolContext
-            }
-          );
-        } finally {
-          intrinsicResidueGuard?.restore();
+      const candidate = await this.options.evaluate(
+        {
+          toolId: this.policyGateToolId,
+          role,
+          input: preparedInput.evaluatorInput,
+          workDir: toolContext.workDir
+        },
+        {
+          tool: this.innerTool,
+          toolContext
         }
-      })();
+      );
       decision = validatePolicyGateDecision(this.policyGateToolId, candidate);
     } catch (error) {
       const durationMs = Date.now() - startTime;
@@ -1062,6 +1052,9 @@ function cloneGenericPolicyGateMaterializedArray(
     snapshot[index] = snapshotValue;
   }
 
+  if (options.mode === "evaluator") {
+    Object.preventExtensions(snapshot);
+  }
   return snapshot;
 }
 
@@ -1109,7 +1102,6 @@ function createIsolatedArrayPrototype(): object {
   defineIsolatedArrayPrototypeMethod(prototype, Symbol.iterator, isolatedArrayIterator);
   defineIsolatedArrayPrototypeMethod(prototype, "includes", isolatedArrayIncludes);
   defineIsolatedArrayPrototypeMethod(prototype, "map", isolatedArrayMap);
-  defineIsolatedArrayPrototypeMethod(prototype, "push", isolatedArrayPush);
   Object.freeze(prototype);
   return prototype;
 }
@@ -1158,27 +1150,10 @@ const isolatedArrayMap = isolateFunction(
         }
         result[index] = Reflect.apply(callback, thisArg, [receiver[index], index, receiver]);
       }
+      Object.preventExtensions(result);
       return result;
     }
   }.map
-);
-
-const isolatedArrayPush = isolateFunction(
-  {
-    push(this: unknown, ...items: unknown[]): number {
-      const receiver = requireIsolatedArrayReceiver(this);
-      const length = readGenericPolicyGateArrayLength(receiver);
-      const newLength = length + items.length;
-      if (newLength > 4_294_967_295) {
-        throw new RangeError("Invalid array length.");
-      }
-      for (let offset = 0; offset < items.length; offset += 1) {
-        receiver[length + offset] = items[offset];
-      }
-      receiver.length = newLength;
-      return newLength;
-    }
-  }.push
 );
 
 const isolatedArrayIterator = isolateFunction(
@@ -1282,102 +1257,6 @@ function isolateFunction<T extends (...args: unknown[]) => unknown>(value: T): T
   Object.setPrototypeOf(value, null);
   Object.freeze(value);
   return value;
-}
-
-interface PolicyGateIntrinsicResidueSnapshot {
-  target: object;
-  prototype: object | null;
-  descriptors: Map<PropertyKey, PropertyDescriptor>;
-}
-
-function createPolicyGateIntrinsicResidueGuard(): { restore: () => void } {
-  const snapshots = collectPolicyGateIntrinsicResidueTargets().map(
-    capturePolicyGateIntrinsicResidueSnapshot
-  );
-  return {
-    restore() {
-      const errors: unknown[] = [];
-      for (const snapshot of snapshots) {
-        try {
-          restorePolicyGateIntrinsicResidueSnapshot(snapshot);
-        } catch (error) {
-          errors.push(error);
-        }
-      }
-      if (errors.length > 0) {
-        throw new Error("Policy gate evaluator could not restore intrinsic prototype state.");
-      }
-    }
-  };
-}
-
-function collectPolicyGateIntrinsicResidueTargets(): object[] {
-  const arrayIteratorPrototype = Object.getPrototypeOf([][Symbol.iterator]());
-  const candidates = [
-    Object,
-    Array,
-    Function,
-    Object.prototype,
-    Array.prototype,
-    Function.prototype,
-    Array.prototype.includes,
-    Array.prototype.map,
-    Array.prototype.push,
-    Array.prototype[Symbol.iterator],
-    arrayIteratorPrototype,
-    arrayIteratorPrototype
-      ? (arrayIteratorPrototype as { next?: unknown }).next
-      : undefined
-  ];
-  const targets: object[] = [];
-  const seen = new Set<object>();
-  for (const candidate of candidates) {
-    if ((typeof candidate === "object" && candidate !== null) || typeof candidate === "function") {
-      if (!seen.has(candidate)) {
-        seen.add(candidate);
-        targets.push(candidate);
-      }
-    }
-  }
-  return targets;
-}
-
-function capturePolicyGateIntrinsicResidueSnapshot(
-  target: object
-): PolicyGateIntrinsicResidueSnapshot {
-  return {
-    target,
-    prototype: Object.getPrototypeOf(target),
-    descriptors: new Map(
-      getPolicyGateIntrinsicOwnKeys(target).map((key) => [
-        key,
-        Object.getOwnPropertyDescriptor(target, key) as PropertyDescriptor
-      ])
-    )
-  };
-}
-
-function restorePolicyGateIntrinsicResidueSnapshot(
-  snapshot: PolicyGateIntrinsicResidueSnapshot
-): void {
-  const expectedKeys = new Set(snapshot.descriptors.keys());
-  for (const key of getPolicyGateIntrinsicOwnKeys(snapshot.target)) {
-    if (!expectedKeys.has(key)) {
-      delete (snapshot.target as Record<PropertyKey, unknown>)[key];
-    }
-  }
-
-  for (const [key, descriptor] of snapshot.descriptors) {
-    Object.defineProperty(snapshot.target, key, descriptor);
-  }
-
-  if (Object.getPrototypeOf(snapshot.target) !== snapshot.prototype) {
-    Object.setPrototypeOf(snapshot.target, snapshot.prototype);
-  }
-}
-
-function getPolicyGateIntrinsicOwnKeys(target: object): PropertyKey[] {
-  return [...Object.getOwnPropertyNames(target), ...Object.getOwnPropertySymbols(target)];
 }
 
 function clonePolicyGateInput(value: unknown): unknown {

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -97,6 +97,13 @@ const ZERO_SUB_AGENT_BLOCKED_TOOL_IDS = new Set([
   "send_input"
 ]);
 
+const GENERIC_POLICY_GATE_INPUT_MAX_DEPTH = 32;
+const GENERIC_POLICY_GATE_INPUT_MAX_NODES = 10_000;
+const GENERIC_POLICY_GATE_INPUT_MAX_ARRAY_LENGTH = 1_024;
+const GENERIC_POLICY_GATE_INPUT_MAX_OBJECT_KEYS = 256;
+const GENERIC_POLICY_GATE_INPUT_MAX_STRING_CHARS = 131_072;
+const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 export function createShudPolicyGateEvaluator(
   customEvaluate?: PolicyGateEvaluator
 ): PolicyGateEvaluator {
@@ -450,11 +457,12 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       };
     }
 
+    assertGenericPolicyGateInputCanBeSafelyPrepared(input);
     const executionInput = clonePolicyGateInput(input);
     return {
       decision: "allow",
       executionInput,
-      evaluatorInput: clonePolicyGateInput(executionInput)
+      evaluatorInput: createReadOnlyPolicyGateInputView(executionInput)
     };
   }
 }
@@ -719,8 +727,242 @@ function cloneFuseRules(rules: readonly FuseRule[]): FuseRule[] {
   }));
 }
 
+interface GenericPolicyGateInputBudgetState {
+  nodes: number;
+  stringChars: number;
+  seenObjects: WeakSet<object>;
+}
+
+type GenericPolicyGateDescriptorRecord = Record<PropertyKey, PropertyDescriptor | undefined>;
+
+function assertGenericPolicyGateInputCanBeSafelyPrepared(value: unknown): void {
+  inspectGenericPolicyGateInput(value, {
+    nodes: 0,
+    stringChars: 0,
+    seenObjects: new WeakSet<object>()
+  });
+}
+
+function inspectGenericPolicyGateInput(
+  value: unknown,
+  state: GenericPolicyGateInputBudgetState,
+  depth = 0
+): void {
+  if (depth > GENERIC_POLICY_GATE_INPUT_MAX_DEPTH) {
+    throw new Error("Policy gate input exceeds depth budget.");
+  }
+
+  state.nodes += 1;
+  if (state.nodes > GENERIC_POLICY_GATE_INPUT_MAX_NODES) {
+    throw new Error("Policy gate input exceeds node budget.");
+  }
+
+  if (value === null) {
+    return;
+  }
+
+  if (typeof value === "string") {
+    addGenericPolicyGateStringBudget(value.length, state);
+    return;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "undefined") {
+    return;
+  }
+  if (typeof value === "function" || typeof value === "symbol" || typeof value === "bigint") {
+    throw new Error("Policy gate input contains unsafe value types.");
+  }
+  if (typeof value !== "object") {
+    throw new Error("Policy gate input contains unsupported value types.");
+  }
+
+  const objectValue = value as object;
+  if (state.seenObjects.has(objectValue)) {
+    return;
+  }
+  state.seenObjects.add(objectValue);
+
+  if (Array.isArray(objectValue)) {
+    inspectGenericPolicyGateArray(objectValue, state, depth);
+    return;
+  }
+
+  const prototype = Object.getPrototypeOf(objectValue);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error("Policy gate input must be plain structured data.");
+  }
+
+  const descriptors = getGenericPolicyGateDescriptors(objectValue);
+  const keys = Reflect.ownKeys(descriptors);
+  if (keys.length > GENERIC_POLICY_GATE_INPUT_MAX_OBJECT_KEYS) {
+    throw new Error("Policy gate input exceeds object key budget.");
+  }
+
+  for (const key of keys) {
+    assertSafeGenericPolicyGatePropertyKey(key, state, true);
+    inspectGenericPolicyGateDescriptorValue(getDescriptorForKey(descriptors, key), state, depth);
+  }
+}
+
+function inspectGenericPolicyGateArray(
+  value: readonly unknown[],
+  state: GenericPolicyGateInputBudgetState,
+  depth: number
+): void {
+  const descriptors = getGenericPolicyGateDescriptors(value);
+  const lengthDescriptor = descriptors.length;
+  if (
+    !lengthDescriptor ||
+    !("value" in lengthDescriptor) ||
+    typeof lengthDescriptor.value !== "number" ||
+    !Number.isSafeInteger(lengthDescriptor.value) ||
+    lengthDescriptor.value < 0
+  ) {
+    throw new Error("Policy gate input contains an unsafe array length.");
+  }
+  if (lengthDescriptor.value > GENERIC_POLICY_GATE_INPUT_MAX_ARRAY_LENGTH) {
+    throw new Error("Policy gate input exceeds array length budget.");
+  }
+
+  let extraKeyCount = 0;
+  for (const key of Reflect.ownKeys(descriptors)) {
+    if (key === "length") {
+      continue;
+    }
+
+    if (typeof key === "string" && isArrayIndexPropertyKey(key)) {
+      assertSafeGenericPolicyGatePropertyKey(key, state, false);
+    } else {
+      extraKeyCount += 1;
+      if (extraKeyCount > GENERIC_POLICY_GATE_INPUT_MAX_OBJECT_KEYS) {
+        throw new Error("Policy gate input exceeds object key budget.");
+      }
+      assertSafeGenericPolicyGatePropertyKey(key, state, true);
+    }
+
+    inspectGenericPolicyGateDescriptorValue(getDescriptorForKey(descriptors, key), state, depth);
+  }
+}
+
+function inspectGenericPolicyGateDescriptorValue(
+  descriptor: PropertyDescriptor | undefined,
+  state: GenericPolicyGateInputBudgetState,
+  depth: number
+): void {
+  if (
+    !descriptor ||
+    !("value" in descriptor) ||
+    descriptor.get !== undefined ||
+    descriptor.set !== undefined
+  ) {
+    throw new Error("Policy gate input contains unsafe accessors.");
+  }
+
+  inspectGenericPolicyGateInput(descriptor.value, state, depth + 1);
+}
+
+function getDescriptorForKey(
+  descriptors: GenericPolicyGateDescriptorRecord,
+  key: string | symbol
+): PropertyDescriptor | undefined {
+  return descriptors[key];
+}
+
+function getGenericPolicyGateDescriptors(value: object): GenericPolicyGateDescriptorRecord {
+  return Object.getOwnPropertyDescriptors(value) as unknown as GenericPolicyGateDescriptorRecord;
+}
+
+function assertSafeGenericPolicyGatePropertyKey(
+  key: string | symbol,
+  state: GenericPolicyGateInputBudgetState,
+  countStringBudget: boolean
+): asserts key is string {
+  if (typeof key === "symbol") {
+    throw new Error("Policy gate input contains unsafe symbol keys.");
+  }
+  if (countStringBudget) {
+    addGenericPolicyGateStringBudget(key.length, state);
+  }
+  if (PROTOTYPE_POLLUTION_KEYS.has(key)) {
+    throw new Error("Policy gate input contains prototype-polluting keys.");
+  }
+}
+
+function addGenericPolicyGateStringBudget(
+  length: number,
+  state: GenericPolicyGateInputBudgetState
+): void {
+  state.stringChars += length;
+  if (state.stringChars > GENERIC_POLICY_GATE_INPUT_MAX_STRING_CHARS) {
+    throw new Error("Policy gate input exceeds string budget.");
+  }
+}
+
+function isArrayIndexPropertyKey(key: string): boolean {
+  if (key.trim() === "" || key === "4294967295") {
+    return false;
+  }
+  const index = Number(key);
+  return Number.isInteger(index) && index >= 0 && index < 4_294_967_295 && String(index) === key;
+}
+
+const READ_ONLY_POLICY_GATE_INPUT_ERROR = "Policy gate evaluator input is read-only.";
+
+function createReadOnlyPolicyGateInputView(
+  value: unknown,
+  seenObjects = new WeakMap<object, unknown>()
+): unknown {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  const objectValue = value as object;
+  const existingView = seenObjects.get(objectValue);
+  if (existingView) {
+    return existingView;
+  }
+
+  const proxy = new Proxy(objectValue, {
+    get(target, property, receiver) {
+      return createReadOnlyPolicyGateInputView(Reflect.get(target, property, receiver), seenObjects);
+    },
+    getOwnPropertyDescriptor(target, property) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(target, property);
+      if (!descriptor || !("value" in descriptor)) {
+        return descriptor;
+      }
+
+      const readOnlyValue = createReadOnlyPolicyGateInputView(descriptor.value, seenObjects);
+      if (!descriptor.configurable && !descriptor.writable && readOnlyValue !== descriptor.value) {
+        return descriptor;
+      }
+
+      return {
+        ...descriptor,
+        value: readOnlyValue
+      };
+    },
+    set() {
+      throw new Error(READ_ONLY_POLICY_GATE_INPUT_ERROR);
+    },
+    deleteProperty() {
+      throw new Error(READ_ONLY_POLICY_GATE_INPUT_ERROR);
+    },
+    defineProperty() {
+      throw new Error(READ_ONLY_POLICY_GATE_INPUT_ERROR);
+    },
+    setPrototypeOf() {
+      throw new Error(READ_ONLY_POLICY_GATE_INPUT_ERROR);
+    },
+    preventExtensions() {
+      throw new Error(READ_ONLY_POLICY_GATE_INPUT_ERROR);
+    }
+  });
+  seenObjects.set(objectValue, proxy);
+  return proxy;
+}
+
 function clonePolicyGateInput(value: unknown): unknown {
-  if (typeof value === "function" || typeof value === "symbol") {
+  if (typeof value === "function" || typeof value === "symbol" || typeof value === "bigint") {
     throw new Error("Policy gate input must be structured-cloneable data.");
   }
 

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -1,6 +1,7 @@
 import { BaseTool, SpawnAgentTool, ToolRegistry, loadFuseList } from "@zero-os/core";
 import { toErrorMessage } from "@zero-os/shared";
 import type { FuseRule, ToolContext, ToolDefinition, ToolResult } from "@zero-os/shared";
+import { types as nodeUtilTypes } from "node:util";
 import {
   evaluatePolicyGate,
   normalizeSpawnAgentInput,
@@ -729,7 +730,6 @@ function cloneFuseRules(rules: readonly FuseRule[]): FuseRule[] {
 interface GenericPolicyGateInputBudgetState {
   nodes: number;
   stringChars: number;
-  seenObjects: WeakSet<object>;
 }
 
 interface GenericPolicyGateSnapshotState extends GenericPolicyGateInputBudgetState {
@@ -744,30 +744,26 @@ function prepareGenericPolicyGateInputSnapshots(value: unknown): {
   executionInput: unknown;
   evaluatorInput: unknown;
 } {
-  assertGenericPolicyGateInputCanBeSafelyPrepared(value);
+  const canonicalInput = materializeGenericPolicyGateInput(value, {
+    nodes: 0,
+    stringChars: 0,
+    snapshots: new WeakMap<object, unknown>()
+  });
   return {
-    executionInput: createGenericPolicyGateInputSnapshot(value, {
-      nullPrototypeArrays: false
+    executionInput: cloneGenericPolicyGateMaterializedInput(canonicalInput, {
+      isolateArrayPrototype: false
     }),
-    evaluatorInput: createGenericPolicyGateInputSnapshot(value, {
-      nullPrototypeArrays: true
+    evaluatorInput: cloneGenericPolicyGateMaterializedInput(canonicalInput, {
+      isolateArrayPrototype: true
     })
   };
 }
 
-function assertGenericPolicyGateInputCanBeSafelyPrepared(value: unknown): void {
-  inspectGenericPolicyGateInput(value, {
-    nodes: 0,
-    stringChars: 0,
-    seenObjects: new WeakSet<object>()
-  });
-}
-
-function inspectGenericPolicyGateInput(
+function materializeGenericPolicyGateInput(
   value: unknown,
-  state: GenericPolicyGateInputBudgetState,
+  state: GenericPolicyGateSnapshotState,
   depth = 0
-): void {
+): unknown {
   if (depth > GENERIC_POLICY_GATE_INPUT_MAX_DEPTH) {
     throw new Error("Policy gate input exceeds depth budget.");
   }
@@ -778,15 +774,15 @@ function inspectGenericPolicyGateInput(
   }
 
   if (value === null) {
-    return;
+    return null;
   }
 
   if (typeof value === "string") {
     addGenericPolicyGateStringBudget(value.length, state);
-    return;
+    return value;
   }
   if (typeof value === "number" || typeof value === "boolean" || typeof value === "undefined") {
-    return;
+    return value;
   }
   if (typeof value === "function" || typeof value === "symbol" || typeof value === "bigint") {
     throw new Error("Policy gate input contains unsafe value types.");
@@ -796,14 +792,17 @@ function inspectGenericPolicyGateInput(
   }
 
   const objectValue = value as object;
-  if (state.seenObjects.has(objectValue)) {
-    return;
+  const existingSnapshot = state.snapshots.get(objectValue);
+  if (existingSnapshot) {
+    return existingSnapshot;
   }
-  state.seenObjects.add(objectValue);
+
+  if (nodeUtilTypes.isProxy(objectValue)) {
+    throw new Error("Policy gate input must be stable ordinary structured data.");
+  }
 
   if (Array.isArray(objectValue)) {
-    inspectGenericPolicyGateArray(objectValue, state, depth);
-    return;
+    return materializeGenericPolicyGateArray(objectValue, state, depth);
   }
 
   const prototype = Object.getPrototypeOf(objectValue);
@@ -811,30 +810,21 @@ function inspectGenericPolicyGateInput(
     throw new Error("Policy gate input must be plain structured data.");
   }
 
-  const keys = getBoundedGenericPolicyGateObjectKeys(objectValue);
-  if (keys.length > GENERIC_POLICY_GATE_INPUT_MAX_OBJECT_KEYS) {
-    throw new Error("Policy gate input exceeds object key budget.");
-  }
-
-  for (const key of keys) {
-    assertSafeGenericPolicyGatePropertyKey(key, state, true);
-    inspectGenericPolicyGateDescriptorValue(
-      readGenericPolicyGateDataDescriptor(objectValue, key),
-      state,
-      depth
-    );
-  }
+  return materializeGenericPolicyGatePlainObject(objectValue, state, depth);
 }
 
-function inspectGenericPolicyGateArray(
+function materializeGenericPolicyGateArray(
   value: readonly unknown[],
-  state: GenericPolicyGateInputBudgetState,
+  state: GenericPolicyGateSnapshotState,
   depth: number
-): void {
+): unknown[] {
   const length = readGenericPolicyGateArrayLength(value);
   if (length > GENERIC_POLICY_GATE_INPUT_MAX_ARRAY_LENGTH) {
     throw new Error("Policy gate input exceeds array length budget.");
   }
+
+  const snapshot = new Array<unknown>(length);
+  state.snapshots.set(value, snapshot);
 
   let extraKeyCount = 0;
   for (const key of Reflect.ownKeys(value)) {
@@ -842,7 +832,8 @@ function inspectGenericPolicyGateArray(
       continue;
     }
 
-    if (typeof key === "string" && isArrayIndexPropertyKey(key)) {
+    const isArrayIndex = typeof key === "string" && isArrayIndexPropertyKey(key);
+    if (isArrayIndex) {
       if (Number(key) >= length) {
         throw new Error("Policy gate input contains an unsafe array length.");
       }
@@ -855,20 +846,51 @@ function inspectGenericPolicyGateArray(
       assertSafeGenericPolicyGatePropertyKey(key, state, true);
     }
 
-    inspectGenericPolicyGateDescriptorValue(
-      readGenericPolicyGateDataDescriptor(value, key),
-      state,
-      depth
-    );
+    const descriptor = readGenericPolicyGateDataDescriptor(value, key);
+    const snapshotValue = materializeGenericPolicyGateInput(descriptor.value, state, depth + 1);
+    if (!descriptor.enumerable) {
+      continue;
+    }
+    if (isArrayIndex) {
+      snapshot[Number(key)] = snapshotValue;
+    } else {
+      Object.defineProperty(snapshot, key, {
+        value: snapshotValue,
+        enumerable: true,
+        configurable: true,
+        writable: true
+      });
+    }
   }
+
+  return snapshot;
 }
 
-function inspectGenericPolicyGateDescriptorValue(
-  descriptor: GenericPolicyGateDataDescriptor,
-  state: GenericPolicyGateInputBudgetState,
+function materializeGenericPolicyGatePlainObject(
+  value: object,
+  state: GenericPolicyGateSnapshotState,
   depth: number
-): void {
-  inspectGenericPolicyGateInput(descriptor.value, state, depth + 1);
+): Record<string, unknown> {
+  const snapshot = Object.create(null) as Record<string, unknown>;
+  state.snapshots.set(value, snapshot);
+  const keys = getBoundedGenericPolicyGateObjectKeys(value);
+
+  for (const key of keys) {
+    assertSafeGenericPolicyGatePropertyKey(key, state, true);
+    const descriptor = readGenericPolicyGateDataDescriptor(value, key);
+    const snapshotValue = materializeGenericPolicyGateInput(descriptor.value, state, depth + 1);
+    if (!descriptor.enumerable) {
+      continue;
+    }
+    Object.defineProperty(snapshot, key, {
+      value: snapshotValue,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  }
+
+  return snapshot;
 }
 
 function readGenericPolicyGateArrayLength(value: readonly unknown[]): number {
@@ -942,26 +964,25 @@ function isArrayIndexPropertyKey(key: string): boolean {
   return Number.isInteger(index) && index >= 0 && index < 4_294_967_295 && String(index) === key;
 }
 
-function createGenericPolicyGateInputSnapshot(
+function cloneGenericPolicyGateMaterializedInput(
   value: unknown,
-  options: { nullPrototypeArrays: boolean }
+  options: { isolateArrayPrototype: boolean }
 ): unknown {
-  return snapshotGenericPolicyGateInput(
+  return cloneGenericPolicyGateMaterializedValue(
     value,
     {
       nodes: 0,
       stringChars: 0,
-      seenObjects: new WeakSet<object>(),
       snapshots: new WeakMap<object, unknown>()
     },
     options
   );
 }
 
-function snapshotGenericPolicyGateInput(
+function cloneGenericPolicyGateMaterializedValue(
   value: unknown,
   state: GenericPolicyGateSnapshotState,
-  options: { nullPrototypeArrays: boolean },
+  options: { isolateArrayPrototype: boolean },
   depth = 0
 ): unknown {
   if (depth > GENERIC_POLICY_GATE_INPUT_MAX_DEPTH) {
@@ -995,10 +1016,9 @@ function snapshotGenericPolicyGateInput(
   if (existingSnapshot) {
     return existingSnapshot;
   }
-  state.seenObjects.add(objectValue);
 
   if (Array.isArray(objectValue)) {
-    return snapshotGenericPolicyGateArray(objectValue, state, options, depth);
+    return cloneGenericPolicyGateMaterializedArray(objectValue, state, options, depth);
   }
 
   const prototype = Object.getPrototypeOf(objectValue);
@@ -1006,13 +1026,13 @@ function snapshotGenericPolicyGateInput(
     throw new Error("Policy gate input must be plain structured data.");
   }
 
-  return snapshotGenericPolicyGatePlainObject(objectValue, state, options, depth);
+  return cloneGenericPolicyGateMaterializedPlainObject(objectValue, state, options, depth);
 }
 
-function snapshotGenericPolicyGateArray(
+function cloneGenericPolicyGateMaterializedArray(
   value: readonly unknown[],
   state: GenericPolicyGateSnapshotState,
-  options: { nullPrototypeArrays: boolean },
+  options: { isolateArrayPrototype: boolean },
   depth: number
 ): unknown[] {
   const length = readGenericPolicyGateArrayLength(value);
@@ -1021,8 +1041,8 @@ function snapshotGenericPolicyGateArray(
   }
 
   const snapshot = new Array<unknown>(length);
-  if (options.nullPrototypeArrays) {
-    Object.setPrototypeOf(snapshot, null);
+  if (options.isolateArrayPrototype) {
+    Object.setPrototypeOf(snapshot, createIsolatedArrayPrototype());
   }
   state.snapshots.set(value, snapshot);
 
@@ -1047,7 +1067,7 @@ function snapshotGenericPolicyGateArray(
     }
 
     const descriptor = readGenericPolicyGateDataDescriptor(value, key);
-    const snapshotValue = snapshotGenericPolicyGateInput(
+    const snapshotValue = cloneGenericPolicyGateMaterializedValue(
       descriptor.value,
       state,
       options,
@@ -1071,10 +1091,10 @@ function snapshotGenericPolicyGateArray(
   return snapshot;
 }
 
-function snapshotGenericPolicyGatePlainObject(
+function cloneGenericPolicyGateMaterializedPlainObject(
   value: object,
   state: GenericPolicyGateSnapshotState,
-  options: { nullPrototypeArrays: boolean },
+  options: { isolateArrayPrototype: boolean },
   depth: number
 ): Record<string, unknown> {
   const snapshot = Object.create(null) as Record<string, unknown>;
@@ -1084,7 +1104,7 @@ function snapshotGenericPolicyGatePlainObject(
   for (const key of keys) {
     assertSafeGenericPolicyGatePropertyKey(key, state, true);
     const descriptor = readGenericPolicyGateDataDescriptor(value, key);
-    const snapshotValue = snapshotGenericPolicyGateInput(
+    const snapshotValue = cloneGenericPolicyGateMaterializedValue(
       descriptor.value,
       state,
       options,
@@ -1102,6 +1122,50 @@ function snapshotGenericPolicyGatePlainObject(
   }
 
   return snapshot;
+}
+
+function createIsolatedArrayPrototype(): object {
+  const prototype = Object.create(null) as Record<PropertyKey, unknown>;
+  for (const key of Reflect.ownKeys(Array.prototype)) {
+    const descriptor = Object.getOwnPropertyDescriptor(Array.prototype, key);
+    if (!descriptor) {
+      continue;
+    }
+    if ("value" in descriptor) {
+      Object.defineProperty(prototype, key, {
+        ...descriptor,
+        value: createIsolatedArrayPrototypeValue(descriptor.value)
+      });
+      continue;
+    }
+    Object.defineProperty(prototype, key, descriptor);
+  }
+  function PolicyGateEvaluatorArray(): void {}
+  Object.defineProperty(PolicyGateEvaluatorArray, "prototype", {
+    value: prototype,
+    configurable: false,
+    writable: false
+  });
+  Object.defineProperty(prototype, "constructor", {
+    value: PolicyGateEvaluatorArray,
+    enumerable: false,
+    configurable: true,
+    writable: true
+  });
+  return prototype;
+}
+
+function createIsolatedArrayPrototypeValue(value: unknown): unknown {
+  if (typeof value === "function") {
+    const arrayMethod = value;
+    return function isolatedArrayMethod(this: unknown, ...args: unknown[]): unknown {
+      return Reflect.apply(arrayMethod, this, args);
+    };
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.assign(Object.create(null), value);
+  }
+  return value;
 }
 
 function clonePolicyGateInput(value: unknown): unknown {

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -340,18 +340,28 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
     }
 
     try {
-      const candidate = await this.options.evaluate(
-        {
-          toolId: this.policyGateToolId,
-          role,
-          input: preparedInput.evaluatorInput,
-          workDir: toolContext.workDir
-        },
-        {
-          tool: this.innerTool,
-          toolContext
+      const intrinsicResidueGuard =
+        this.policyGateToolId === "spawn_agent"
+          ? undefined
+          : createPolicyGateIntrinsicResidueGuard();
+      const candidate = await (async () => {
+        try {
+          return await this.options.evaluate(
+            {
+              toolId: this.policyGateToolId,
+              role,
+              input: preparedInput.evaluatorInput,
+              workDir: toolContext.workDir
+            },
+            {
+              tool: this.innerTool,
+              toolContext
+            }
+          );
+        } finally {
+          intrinsicResidueGuard?.restore();
         }
-      );
+      })();
       decision = validatePolicyGateDecision(this.policyGateToolId, candidate);
     } catch (error) {
       const durationMs = Date.now() - startTime;
@@ -740,6 +750,8 @@ type GenericPolicyGateDataDescriptor = PropertyDescriptor & {
   value: unknown;
 };
 
+type GenericPolicyGateCloneMode = "execution" | "evaluator";
+
 function prepareGenericPolicyGateInputSnapshots(value: unknown): {
   executionInput: unknown;
   evaluatorInput: unknown;
@@ -751,10 +763,10 @@ function prepareGenericPolicyGateInputSnapshots(value: unknown): {
   });
   return {
     executionInput: cloneGenericPolicyGateMaterializedInput(canonicalInput, {
-      isolateArrayPrototype: false
+      mode: "execution"
     }),
     evaluatorInput: cloneGenericPolicyGateMaterializedInput(canonicalInput, {
-      isolateArrayPrototype: true
+      mode: "evaluator"
     })
   };
 }
@@ -802,6 +814,7 @@ function materializeGenericPolicyGateInput(
   }
 
   if (Array.isArray(objectValue)) {
+    assertOrdinaryGenericPolicyGateArray(objectValue);
     return materializeGenericPolicyGateArray(objectValue, state, depth);
   }
 
@@ -811,6 +824,12 @@ function materializeGenericPolicyGateInput(
   }
 
   return materializeGenericPolicyGatePlainObject(objectValue, state, depth);
+}
+
+function assertOrdinaryGenericPolicyGateArray(value: readonly unknown[]): void {
+  if (Object.getPrototypeOf(value) !== Array.prototype) {
+    throw new Error("Policy gate input arrays must be ordinary structured data.");
+  }
 }
 
 function materializeGenericPolicyGateArray(
@@ -948,7 +967,7 @@ function addGenericPolicyGateStringBudget(
 
 function cloneGenericPolicyGateMaterializedInput(
   value: unknown,
-  options: { isolateArrayPrototype: boolean }
+  options: { mode: GenericPolicyGateCloneMode }
 ): unknown {
   return cloneGenericPolicyGateMaterializedValue(
     value,
@@ -964,7 +983,7 @@ function cloneGenericPolicyGateMaterializedInput(
 function cloneGenericPolicyGateMaterializedValue(
   value: unknown,
   state: GenericPolicyGateSnapshotState,
-  options: { isolateArrayPrototype: boolean },
+  options: { mode: GenericPolicyGateCloneMode },
   depth = 0
 ): unknown {
   if (depth > GENERIC_POLICY_GATE_INPUT_MAX_DEPTH) {
@@ -1014,7 +1033,7 @@ function cloneGenericPolicyGateMaterializedValue(
 function cloneGenericPolicyGateMaterializedArray(
   value: readonly unknown[],
   state: GenericPolicyGateSnapshotState,
-  options: { isolateArrayPrototype: boolean },
+  options: { mode: GenericPolicyGateCloneMode },
   depth: number
 ): unknown[] {
   const length = readGenericPolicyGateArrayLength(value);
@@ -1023,7 +1042,7 @@ function cloneGenericPolicyGateMaterializedArray(
   }
 
   const snapshot = new Array<unknown>(length);
-  if (options.isolateArrayPrototype) {
+  if (options.mode === "evaluator") {
     Object.setPrototypeOf(snapshot, createIsolatedArrayPrototype());
   }
   state.snapshots.set(value, snapshot);
@@ -1049,10 +1068,13 @@ function cloneGenericPolicyGateMaterializedArray(
 function cloneGenericPolicyGateMaterializedPlainObject(
   value: object,
   state: GenericPolicyGateSnapshotState,
-  options: { isolateArrayPrototype: boolean },
+  options: { mode: GenericPolicyGateCloneMode },
   depth: number
 ): Record<string, unknown> {
-  const snapshot = Object.create(null) as Record<string, unknown>;
+  const snapshot =
+    options.mode === "execution"
+      ? ({} as Record<string, unknown>)
+      : (Object.create(null) as Record<string, unknown>);
   state.snapshots.set(value, snapshot);
   const keys = getBoundedGenericPolicyGateObjectKeys(value);
 
@@ -1076,6 +1098,9 @@ function cloneGenericPolicyGateMaterializedPlainObject(
     });
   }
 
+  if (options.mode === "evaluator") {
+    Object.preventExtensions(snapshot);
+  }
   return snapshot;
 }
 
@@ -1085,6 +1110,7 @@ function createIsolatedArrayPrototype(): object {
   defineIsolatedArrayPrototypeMethod(prototype, "includes", isolatedArrayIncludes);
   defineIsolatedArrayPrototypeMethod(prototype, "map", isolatedArrayMap);
   defineIsolatedArrayPrototypeMethod(prototype, "push", isolatedArrayPush);
+  Object.freeze(prototype);
   return prototype;
 }
 
@@ -1198,6 +1224,7 @@ function createIsolatedArrayIterator(receiver: unknown[]): IterableIterator<unkn
     configurable: true,
     writable: true
   });
+  Object.freeze(iterator);
   return iterator;
 }
 
@@ -1253,7 +1280,104 @@ function sameValueZero(left: unknown, right: unknown): boolean {
 
 function isolateFunction<T extends (...args: unknown[]) => unknown>(value: T): T {
   Object.setPrototypeOf(value, null);
+  Object.freeze(value);
   return value;
+}
+
+interface PolicyGateIntrinsicResidueSnapshot {
+  target: object;
+  prototype: object | null;
+  descriptors: Map<PropertyKey, PropertyDescriptor>;
+}
+
+function createPolicyGateIntrinsicResidueGuard(): { restore: () => void } {
+  const snapshots = collectPolicyGateIntrinsicResidueTargets().map(
+    capturePolicyGateIntrinsicResidueSnapshot
+  );
+  return {
+    restore() {
+      const errors: unknown[] = [];
+      for (const snapshot of snapshots) {
+        try {
+          restorePolicyGateIntrinsicResidueSnapshot(snapshot);
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      if (errors.length > 0) {
+        throw new Error("Policy gate evaluator could not restore intrinsic prototype state.");
+      }
+    }
+  };
+}
+
+function collectPolicyGateIntrinsicResidueTargets(): object[] {
+  const arrayIteratorPrototype = Object.getPrototypeOf([][Symbol.iterator]());
+  const candidates = [
+    Object,
+    Array,
+    Function,
+    Object.prototype,
+    Array.prototype,
+    Function.prototype,
+    Array.prototype.includes,
+    Array.prototype.map,
+    Array.prototype.push,
+    Array.prototype[Symbol.iterator],
+    arrayIteratorPrototype,
+    arrayIteratorPrototype
+      ? (arrayIteratorPrototype as { next?: unknown }).next
+      : undefined
+  ];
+  const targets: object[] = [];
+  const seen = new Set<object>();
+  for (const candidate of candidates) {
+    if ((typeof candidate === "object" && candidate !== null) || typeof candidate === "function") {
+      if (!seen.has(candidate)) {
+        seen.add(candidate);
+        targets.push(candidate);
+      }
+    }
+  }
+  return targets;
+}
+
+function capturePolicyGateIntrinsicResidueSnapshot(
+  target: object
+): PolicyGateIntrinsicResidueSnapshot {
+  return {
+    target,
+    prototype: Object.getPrototypeOf(target),
+    descriptors: new Map(
+      getPolicyGateIntrinsicOwnKeys(target).map((key) => [
+        key,
+        Object.getOwnPropertyDescriptor(target, key) as PropertyDescriptor
+      ])
+    )
+  };
+}
+
+function restorePolicyGateIntrinsicResidueSnapshot(
+  snapshot: PolicyGateIntrinsicResidueSnapshot
+): void {
+  const expectedKeys = new Set(snapshot.descriptors.keys());
+  for (const key of getPolicyGateIntrinsicOwnKeys(snapshot.target)) {
+    if (!expectedKeys.has(key)) {
+      delete (snapshot.target as Record<PropertyKey, unknown>)[key];
+    }
+  }
+
+  for (const [key, descriptor] of snapshot.descriptors) {
+    Object.defineProperty(snapshot.target, key, descriptor);
+  }
+
+  if (Object.getPrototypeOf(snapshot.target) !== snapshot.prototype) {
+    Object.setPrototypeOf(snapshot.target, snapshot.prototype);
+  }
+}
+
+function getPolicyGateIntrinsicOwnKeys(target: object): PropertyKey[] {
+  return [...Object.getOwnPropertyNames(target), ...Object.getOwnPropertySymbols(target)];
 }
 
 function clonePolicyGateInput(value: unknown): unknown {


### PR DESCRIPTION
## Summary

Fixes #51.

This PR hardens the generic non-spawn policy-gate wrapper by bounding input preparation before evaluator or inner tool execution, preserving one canonical execution snapshot, and giving custom evaluators a mutation-isolated view. The `spawn_agent` preparation path and raw-data sandbox behavior remain unchanged.

## Changes

- Adds descriptor-safe generic non-spawn input preparation budgets for depth, node count, array length, object key count, and string budget.
- Rejects proxy and non-ordinary live inputs before evaluator/inner execution.
- Uses one canonical materialization, then derives separate execution and evaluator snapshots.
- Keeps execution snapshots ordinary-object/ordinary-array compatible while hardening evaluator-visible objects and arrays.
- Seals evaluator-visible arrays/map results against length growth and freezes iterator result objects to close input-derived prototype residue paths.
- Adds regression coverage for oversized inputs, hostile inputs, sparse arrays, non-index array properties, evaluator mutation isolation, honest evaluator reads, iterator/result hardening, cross-call residue, and existing spawn/raw-data compatibility.
- Adds and validates the OpenSpec fixture `m1-policy-gate-non-spawn-input-bounds`.

## Validation

- `npx --yes bun@1.2.19 test packages/core/src/tools/policy-gate-registry.test.ts` -> pass, `78 pass`, `860 expect()`.
- `npx --yes bun@1.2.19 run check` -> pass; typecheck plus `288 + 11 + 9 + 6` tests.
- `openspec validate m1-policy-gate-non-spawn-input-bounds --strict --no-interactive` -> pass.
- `git diff --check` -> pass.
- `git -C zero diff --quiet` -> pass; Zero submodule remains `13e25c116c62411e6ee8a0ad67a6c53dc7c376c6`.
- GitHub CI on `253866967ae2fcaa0eafbad56ecfbc721b05ae40` -> `linux-base`, `macos-seatbelt`, and `check` all pass.

## Agent Review

- Reviewed head SHA: `253866967ae2fcaa0eafbad56ecfbc721b05ae40`.
- Cross-review fixture: high/broad-expanded.
- Comprehensive review rounds: 7 (`round-1` plus `follow-up-1` through `follow-up-6`).
- Phase 4.5 verified merge-blocking findings caught and closed: 19 confirmed, 0 plausible, 0 refuted.
- Latest comprehensive review: `follow-up-6` clean across correctness, integration, security/performance, test/evidence, spec-compliance, and invariant/state.
- Final clean-context review: READY; no actionable findings.
- Residual deferred items: 0.
- Pre-merge skip blocks: 0.

Evidence is tracked locally under `.workplans/issue-51/review/`, including `follow-up-6/verdict-table.md` and `final-review.md`.
