### PR TITLE
M1-1.3 readiness-gates: initial dependency lock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,529 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "shud-harness",
+      "devDependencies": {
+        "typescript": "5.8.3",
+      },
+    },
+    "packages/backend": {
+      "name": "@shud-harness/backend",
+      "dependencies": {
+        "@shud-harness/core": "workspace:*",
+      },
+    },
+    "packages/core": {
+      "name": "@shud-harness/core",
+      "dependencies": {
+        "@zero-os/core": "workspace:*",
+        "@zero-os/shared": "workspace:*",
+        "zod": "4.0.1",
+      },
+    },
+    "packages/frontend": {
+      "name": "@shud-harness/frontend",
+      "dependencies": {
+        "@shud-harness/core": "workspace:*",
+      },
+    },
+    "zero/packages/channel": {
+      "name": "@zero-os/channel",
+      "version": "0.1.0",
+      "dependencies": {
+        "@larksuiteoapi/node-sdk": "^1.59.0",
+        "@zero-os/core": "workspace:*",
+        "@zero-os/observe": "workspace:*",
+        "@zero-os/shared": "workspace:*",
+        "dingtalk-stream": "2.1.6-beta.1",
+        "hono": "^4.7.0",
+        "telegraf": "^4.16.3",
+      },
+      "devDependencies": {
+        "bun-types": "latest",
+      },
+    },
+    "zero/packages/core": {
+      "name": "@zero-os/core",
+      "version": "0.1.0",
+      "dependencies": {
+        "@mozilla/readability": "^0.5.0",
+        "@zero-os/model": "workspace:*",
+        "@zero-os/observe": "workspace:*",
+        "@zero-os/secrets": "workspace:*",
+        "@zero-os/shared": "workspace:*",
+        "gray-matter": "^4.0.3",
+        "linkedom": "^0.18.9",
+        "proper-lockfile": "^4.1.2",
+        "simple-git": "^3.27.0",
+        "turndown": "^7.2.0",
+      },
+      "devDependencies": {
+        "@types/proper-lockfile": "^4.1.4",
+        "@types/turndown": "^5.0.5",
+        "bun-types": "latest",
+      },
+    },
+    "zero/packages/memory": {
+      "name": "@zero-os/memory",
+      "version": "0.1.0",
+      "dependencies": {
+        "@zero-os/observe": "workspace:*",
+        "@zero-os/shared": "workspace:*",
+        "gray-matter": "^4.0.3",
+        "vectra": "^0.9.0",
+      },
+      "devDependencies": {
+        "bun-types": "latest",
+      },
+    },
+    "zero/packages/model": {
+      "name": "@zero-os/model",
+      "version": "0.1.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.81.0",
+        "@zero-os/observe": "workspace:*",
+        "@zero-os/secrets": "workspace:*",
+        "@zero-os/shared": "workspace:*",
+        "openai": "^4.82.0",
+      },
+      "devDependencies": {
+        "bun-types": "latest",
+      },
+    },
+    "zero/packages/observe": {
+      "name": "@zero-os/observe",
+      "version": "0.1.0",
+      "dependencies": {
+        "@zero-os/shared": "workspace:*",
+      },
+      "devDependencies": {
+        "bun-types": "latest",
+      },
+    },
+    "zero/packages/scheduler": {
+      "name": "@zero-os/scheduler",
+      "version": "0.1.0",
+      "dependencies": {
+        "@zero-os/core": "workspace:*",
+        "@zero-os/observe": "workspace:*",
+        "@zero-os/shared": "workspace:*",
+        "cron-parser": "^4.9.0",
+      },
+      "devDependencies": {
+        "bun-types": "latest",
+      },
+    },
+    "zero/packages/secrets": {
+      "name": "@zero-os/secrets",
+      "version": "0.1.0",
+      "dependencies": {
+        "@zero-os/shared": "workspace:*",
+      },
+      "devDependencies": {
+        "bun-types": "latest",
+      },
+    },
+    "zero/packages/shared": {
+      "name": "@zero-os/shared",
+      "version": "0.1.0",
+      "dependencies": {
+        "proper-lockfile": "^4.1.2",
+        "yaml": "^2.7.0",
+      },
+      "devDependencies": {
+        "@types/proper-lockfile": "^4.1.4",
+        "bun-types": "latest",
+      },
+    },
+    "zero/packages/supervisor": {
+      "name": "@zero-os/supervisor",
+      "version": "0.1.0",
+      "dependencies": {
+        "@zero-os/observe": "workspace:*",
+        "@zero-os/shared": "workspace:*",
+        "simple-git": "^3.27.0",
+      },
+      "devDependencies": {
+        "bun-types": "latest",
+      },
+    },
+  },
+  "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
+
+    "@kwsites/promise-deferred": ["@kwsites/promise-deferred@1.1.1", "", {}, "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="],
+
+    "@larksuiteoapi/node-sdk": ["@larksuiteoapi/node-sdk@1.68.0", "", { "dependencies": { "axios": "~1.13.3", "lodash.identity": "^3.0.0", "lodash.merge": "^4.6.2", "lodash.pickby": "^4.6.0", "protobufjs": "^7.2.6", "qs": "^6.14.2", "ws": "^8.19.0" } }, "sha512-ip14+pWAv2La3bss4oDDtee2P5xBLDXuvmzhTvkxQMcPA5jCffFsler1TvNt4MyW6pexscj72AEWektyZwU9Yw=="],
+
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
+    "@mozilla/readability": ["@mozilla/readability@0.5.0", "", {}, "sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
+
+    "@shud-harness/backend": ["@shud-harness/backend@workspace:packages/backend"],
+
+    "@shud-harness/core": ["@shud-harness/core@workspace:packages/core"],
+
+    "@shud-harness/frontend": ["@shud-harness/frontend@workspace:packages/frontend"],
+
+    "@simple-git/args-pathspec": ["@simple-git/args-pathspec@1.0.3", "", {}, "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA=="],
+
+    "@simple-git/argv-parser": ["@simple-git/argv-parser@1.1.1", "", { "dependencies": { "@simple-git/args-pathspec": "^1.0.3" } }, "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw=="],
+
+    "@telegraf/types": ["@telegraf/types@7.1.0", "", {}, "sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw=="],
+
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
+
+    "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
+
+    "@types/proper-lockfile": ["@types/proper-lockfile@4.1.4", "", { "dependencies": { "@types/retry": "*" } }, "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ=="],
+
+    "@types/retry": ["@types/retry@0.12.5", "", {}, "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw=="],
+
+    "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
+
+    "@zero-os/channel": ["@zero-os/channel@workspace:zero/packages/channel"],
+
+    "@zero-os/core": ["@zero-os/core@workspace:zero/packages/core"],
+
+    "@zero-os/memory": ["@zero-os/memory@workspace:zero/packages/memory"],
+
+    "@zero-os/model": ["@zero-os/model@workspace:zero/packages/model"],
+
+    "@zero-os/observe": ["@zero-os/observe@workspace:zero/packages/observe"],
+
+    "@zero-os/scheduler": ["@zero-os/scheduler@workspace:zero/packages/scheduler"],
+
+    "@zero-os/secrets": ["@zero-os/secrets@workspace:zero/packages/secrets"],
+
+    "@zero-os/shared": ["@zero-os/shared@workspace:zero/packages/shared"],
+
+    "@zero-os/supervisor": ["@zero-os/supervisor@workspace:zero/packages/supervisor"],
+
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
+
+    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "axios": ["axios@1.13.6", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ=="],
+
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "buffer-alloc": ["buffer-alloc@1.2.0", "", { "dependencies": { "buffer-alloc-unsafe": "^1.1.0", "buffer-fill": "^1.0.0" } }, "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow=="],
+
+    "buffer-alloc-unsafe": ["buffer-alloc-unsafe@1.1.0", "", {}, "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="],
+
+    "buffer-fill": ["buffer-fill@1.0.0", "", {}, "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
+
+    "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
+
+    "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
+
+    "color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "cron-parser": ["cron-parser@4.9.0", "", { "dependencies": { "luxon": "^3.2.1" } }, "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q=="],
+
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "cssom": ["cssom@0.5.0", "", {}, "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "dingtalk-stream": ["dingtalk-stream@2.1.6-beta.1", "", { "dependencies": { "axios": "^1.4.0", "debug": "^4.3.4", "ws": "^8.13.0" } }, "sha512-uYcBnf0Z4rfHHyN1ae4YnAFA6hUW2DmGVb0OZ53r/A272kuHnZynylE5pEJIJHkNIer6R9PCqpnsfsk9IuvglQ=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "dotenv": ["dotenv@8.6.0", "", {}, "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
+
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
+
+    "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
+
+    "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "gpt-3-encoder": ["gpt-3-encoder@1.1.4", "", {}, "sha512-fSQRePV+HUAhCn7+7HL7lNIXNm6eaFWFbNLOOGtmSJ0qJycyQvj60OvRlH7mee8xAMjBDNRdMXlMwjAbMTDjkg=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
+    "has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.12.28", "", {}, "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA=="],
+
+    "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
+    "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "js-yaml": ["js-yaml@3.15.0", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog=="],
+
+    "json-colorizer": ["json-colorizer@2.2.2", "", { "dependencies": { "chalk": "^2.4.1", "lodash.get": "^4.4.2" } }, "sha512-56oZtwV1piXrQnRNTtJeqRv+B9Y/dXAYLqBBaYl/COcUdoZxgLBLAO88+CnkbT6MxNs0c5E9mPBIb2sFcNz3vw=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
+
+    "linkedom": ["linkedom@0.18.12", "", { "dependencies": { "css-select": "^5.1.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.0.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q=="],
+
+    "lodash.get": ["lodash.get@4.4.2", "", {}, "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="],
+
+    "lodash.identity": ["lodash.identity@3.0.0", "", {}, "sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "lodash.pickby": ["lodash.pickby@4.6.0", "", {}, "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "openai": ["openai@4.104.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA=="],
+
+    "p-timeout": ["p-timeout@4.1.0", "", {}, "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
+
+    "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
+
+    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
+
+    "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
+    "safe-compare": ["safe-compare@1.1.4", "", { "dependencies": { "buffer-alloc": "^1.2.0" } }, "sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "sandwich-stream": ["sandwich-stream@2.0.2", "", {}, "sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ=="],
+
+    "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "simple-git": ["simple-git@3.36.0", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "@kwsites/promise-deferred": "^1.1.1", "@simple-git/args-pathspec": "^1.0.3", "@simple-git/argv-parser": "^1.1.0", "debug": "^4.4.0" } }, "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q=="],
+
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
+
+    "supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
+
+    "telegraf": ["telegraf@4.16.3", "", { "dependencies": { "@telegraf/types": "^7.1.0", "abort-controller": "^3.0.0", "debug": "^4.3.4", "mri": "^1.2.0", "node-fetch": "^2.7.0", "p-timeout": "^4.1.0", "safe-compare": "^1.1.4", "sandwich-stream": "^2.0.2" }, "bin": { "telegraf": "lib/cli.mjs" } }, "sha512-yjEu2NwkHlXu0OARWoNhJlIjX09dRktiMQFsM678BAH/PEPVwctzL67+tvXqLCRQQvm3SDtki2saGO9hLlz68w=="],
+
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
+    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "uhyphen": ["uhyphen@0.2.0", "", {}, "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="],
+
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "vectra": ["vectra@0.9.0", "", { "dependencies": { "axios": "^1.3.4", "cheerio": "^1.0.0-rc.12", "dotenv": "^8.2.0", "gpt-3-encoder": "1.1.4", "json-colorizer": "^2.2.2", "openai": "^3.2.1", "turndown": "^7.1.2", "uuid": "^9.0.0", "yargs": "^17.7.2" }, "bin": { "vectra": "bin/vectra.js" } }, "sha512-Ynt+es19854syZJKgCFTEiWP3CrUZepi4xeIhEpVgeWmFV38XXwgrh8WvPhEyw7WqPJ/ze56JkR4+eUOTyPzNA=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
+
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "zod": ["zod@4.0.1", "", {}, "sha512-3ayMCwqt0I18sfM+jC4t06mieo1n5B7jeH7GtPvCmzSfnecxO8+qBLtD56wOLccc3TJOMHUhiaG36ck6dtmKeQ=="],
+
+    "dingtalk-stream/axios": ["axios@1.18.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "openai/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "vectra/axios": ["axios@1.18.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g=="],
+
+    "vectra/openai": ["openai@3.3.0", "", { "dependencies": { "axios": "^0.26.0", "form-data": "^4.0.0" } }, "sha512-uqxI/Au+aPRnsaQRe8CojU0eCR7I0mBiKjD3sNMzY6DaC1ZVrc85u98mtJW6voDug8fgGN+DIZmTDxTthxb7dQ=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "dingtalk-stream/axios/proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+
+    "openai/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "vectra/axios/proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+
+    "vectra/openai/axios": ["axios@0.26.1", "", { "dependencies": { "follow-redirects": "^1.14.8" } }, "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA=="],
+
+    "wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+  }
+}

--- a/dependency-lock.initial.json
+++ b/dependency-lock.initial.json
@@ -1,0 +1,154 @@
+{
+  "lock_id": "dependency-lock-initial-2026-07-06",
+  "created_at": "2026-07-06T13:06:38Z",
+  "package_manager": {
+    "name": "bun",
+    "version": "1.2.19",
+    "lockfile_path": "bun.lock",
+    "lockfile_sha256": "cd5c9b60b977ad6debd0c23634a9c49753ac06c522f0f2dc1f76db269bd66abb"
+  },
+  "packages": [
+    {
+      "name": "@anthropic-ai/sdk",
+      "version": "0.81.0",
+      "dependency_type": "runtime",
+      "source": "npm"
+    },
+    {
+      "name": "@larksuiteoapi/node-sdk",
+      "version": "1.68.0",
+      "dependency_type": "runtime",
+      "source": "npm"
+    },
+    {
+      "name": "@mozilla/readability",
+      "version": "0.5.0",
+      "dependency_type": "runtime",
+      "source": "npm"
+    },
+    {
+      "name": "@types/proper-lockfile",
+      "version": "4.1.4",
+      "dependency_type": "dev",
+      "source": "npm"
+    },
+    {
+      "name": "@types/turndown",
+      "version": "5.0.6",
+      "dependency_type": "dev",
+      "source": "npm"
+    },
+    {
+      "name": "bun-types",
+      "version": "1.3.14",
+      "dependency_type": "dev",
+      "source": "npm"
+    },
+    {
+      "name": "cron-parser",
+      "version": "4.9.0",
+      "dependency_type": "runtime",
+      "source": "npm"
+    },
+    {
+      "name": "dingtalk-stream",
+      "version": "2.1.6-beta.1",
+      "dependency_type": "runtime",
+      "source": "npm"
+    },
+    {
+      "name": "gray-matter",
+      "version": "4.0.3",
+      "dependency_type": "runtime",
+      "source": "npm"
+    },
+    {
+      "name": "hono",
+      "version": "4.12.28",
+      "dependency_type": "runtime",
+      "source": "npm"
+    },
+    {
+      "name": "linkedom",
+      "version": "0.18.12",
+      "dependency_type": "runtime",
+      "source": "npm"
+    },
+    {
+      "name": "openai",
+      "version": "4.104.0",
+      "dependency_type": "runtime",
+      "source": "npm"
+    },
+    {
+      "name": "proper-lockfile",
+      "version": "4.1.2",
+      "dependency_type": "runtime",
+      "source": "npm"
+    },
+    {
+      "name": "simple-git",
+      "version": "3.36.0",
+      "dependency_type": "runtime",
+      "source": "npm"
+    },
+    {
+      "name": "telegraf",
+      "version": "4.16.3",
+      "dependency_type": "runtime",
+      "source": "npm"
+    },
+    {
+      "name": "turndown",
+      "version": "7.2.4",
+      "dependency_type": "runtime",
+      "source": "npm"
+    },
+    {
+      "name": "typescript",
+      "version": "5.8.3",
+      "dependency_type": "dev",
+      "source": "npm"
+    },
+    {
+      "name": "vectra",
+      "version": "0.9.0",
+      "dependency_type": "runtime",
+      "source": "npm"
+    },
+    {
+      "name": "yaml",
+      "version": "2.9.0",
+      "dependency_type": "runtime",
+      "source": "npm"
+    },
+    {
+      "name": "zod",
+      "version": "4.0.1",
+      "dependency_type": "runtime",
+      "source": "npm"
+    }
+  ],
+  "submodules": [
+    {
+      "name": "SHUD",
+      "commit": "3aec65755926c478e13ca7d4fea80715e4e90345",
+      "dirty": false
+    },
+    {
+      "name": "rSHUD",
+      "commit": "2b7742e32ea323a57fd0a947dc2cea67bfd0afd1",
+      "dirty": false
+    },
+    {
+      "name": "AutoSHUD",
+      "commit": "f421445340f70b8cb160ce58cefb066751628593",
+      "dirty": false
+    },
+    {
+      "name": "zero",
+      "commit": "13e25c116c62411e6ee8a0ad67a6c53dc7c376c6",
+      "dirty": false
+    }
+  ]
+}

--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -144,8 +144,8 @@ Must preserve:
 Must add/change:
 - Root `package.json` declares a fixed Bun `packageManager`.
 - Root Bun lockfile is committed and supports frozen install without drift.
-- Initial DependencyLock records package manager version, lockfile path and sha256, direct runtime/dev dependency versions, and four submodule commits.
-- Deterministic package-list validation under `scripts/dependency-lock/` derives direct external dependencies from root `bun.lock` workspace dependency sections, requires a non-empty DependencyLock `packages` array, and compares `name`, resolved `version`, `dependency_type`, and `source` without registry/network access.
+- Initial DependencyLock records package manager version, lockfile path and sha256, direct runtime/dev dependency versions, and the exact SHUD/rSHUD/AutoSHUD/zero submodule commit + dirty state set.
+- Deterministic validation under `scripts/dependency-lock/` derives direct external dependencies from root `bun.lock` workspace dependency sections, requires a non-empty DependencyLock `packages` array, compares `name`, resolved `version`, `dependency_type`, and `source` without registry/network access, validates package-manager identity against `package.json#packageManager` and the inspected root lockfile, and validates submodule evidence against `.gitmodules` plus `git submodule status`.
 
 Risk packs considered:
 - Public API / CLI / script entry: not selected - no runtime entrypoint behavior changes.
@@ -165,10 +165,10 @@ Domain packs:
 - Zero adapter / tool registry / agent role governance: selected - zero remains pinned and source-clean for ADR-0001 Trial work.
 
 Invariant Matrix:
-- Governing invariant: The initial DependencyLock must describe exactly the package-manager lockfile and submodule state inspected for this checkout, without changing source packages or submodules.
+- Governing invariant: The initial DependencyLock must describe exactly the inspected root package-manager lockfile, direct external dependency graph, and SHUD/rSHUD/AutoSHUD/zero submodule state for this checkout, without changing source packages or submodules.
 - Source-of-truth identity/contract: `package.json#packageManager`, root `bun.lock` sha256, Dependency_Versioning_Policy §6, `.gitmodules`, `git submodule status`, and zero commit `13e25c1`.
 - Producers: Bun lockfile generation and DependencyLock record generation.
-- Validators/preflight: frozen install, lockfile sha check, DependencyLock JSON validation, package-list validation against the root Bun lock graph, `.gitmodules` parser check, submodule status check, zero diff/pin check.
+- Validators/preflight: frozen install, lockfile sha check, DependencyLock JSON validation, package-list validation against the root Bun lock graph, package-manager identity validation, `.gitmodules` parser check, submodule exact-set/status/dirty validation, zero diff/pin check.
 - Storage/cache/query: committed root `bun.lock` and `dependency-lock.initial.json`; no runtime workspace state.
 - Public routes/entrypoints: none - #14 has no backend/API surface.
 - Frontend/downstream consumers: future release/readiness evidence consumes the DependencyLock file, not a runtime API.
@@ -178,7 +178,9 @@ Invariant Matrix:
   - Clean checkout with `bun@1.2.19` -> `bun install --frozen-lockfile` succeeds and `bun.lock` sha256 remains equal to DependencyLock.
   - `node scripts/dependency-lock/validate.mjs` on clean checkout -> DependencyLock `packages` is non-empty and exactly matches the root Bun lock graph's direct external workspace dependencies by `name`, resolved `version`, `dependency_type`, and `source`.
   - Negative package fixtures -> empty `packages`, deleting direct dependency `zod`, and changing the resolved `typescript` version all fail validation.
-  - `.gitmodules` parse plus `git submodule status` -> four path/url entries exist and DependencyLock commits match SHUD, rSHUD, AutoSHUD, and zero with `dirty: false`.
+  - Negative package-manager identity fixtures -> stale `package_manager.version` and wrong `package_manager.lockfile_path` both fail validation.
+  - `.gitmodules` parse plus `git submodule status` -> exactly SHUD, rSHUD, AutoSHUD, and zero path/url entries exist; DependencyLock submodules contain no missing/extra/duplicate entries; commits match current checkout; every recorded `dirty` flag is `false`; zero commit is `13e25c116c62411e6ee8a0ad67a6c53dc7c376c6`.
+  - Negative submodule fixtures -> missing submodule, wrong submodule commit, dirty flag `true`, and wrong zero commit all fail validation.
   - `git -C zero rev-parse HEAD` and `git -C zero diff --quiet` -> zero remains `13e25c1` and source-clean.
   - `git status --short -- packages SHUD rSHUD AutoSHUD zero` -> empty, proving package and submodule source boundaries were not edited.
   - Secret scan over `package.json`, `bun.lock`, and `dependency-lock.initial.json` -> no registry auth, tokens, or API keys.

--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -122,6 +122,72 @@ Review focus:
 - Runtime output cannot accidentally satisfy source-controlled evidence or enter git.
 - `decision` aggregation is conservative and cannot classify contract conflicts as pass.
 
+## Subagent Workflow Fixture - Issue #14
+
+Fixture level: expanded; repair intensity: medium. Project profile: SHUD-Harness.
+
+Expanded-trigger rationale:
+- Core triggers: package-manager lockfile source of truth, dependency/version evidence file, submodule commit compatibility, and release/dependency reproducibility.
+- Profile triggers: `lock`, `SHUD`, `rSHUD`, `AutoSHUD`, `Zero`, and evidence-chain correctness for readiness.
+
+Change surface:
+- Root `package.json` packageManager field.
+- Root `bun.lock`.
+- Initial `dependency-lock.initial.json` DependencyLock record.
+
+Must preserve:
+- `zero/` remains source-clean and pinned to `13e25c1`.
+- SHUD, rSHUD, AutoSHUD, and zero submodule worktrees are not edited and record `dirty: false`.
+- `packages/**`, submodule source files, and unrelated docs/instruction files remain outside this PR.
+- This issue does not upgrade dependencies; it records the current resolved lock graph and submodule commits.
+
+Must add/change:
+- Root `package.json` declares a fixed Bun `packageManager`.
+- Root Bun lockfile is committed and supports frozen install without drift.
+- Initial DependencyLock records package manager version, lockfile path and sha256, direct runtime/dev dependency versions, and four submodule commits.
+
+Risk packs considered:
+- Public API / CLI / script entry: not selected - no runtime entrypoint behavior changes.
+- Config / project setup: selected - package manager version, lockfile, and submodule baselines define install/setup reproducibility.
+- File IO / path safety / overwrite: selected - the committed lockfile and DependencyLock are source-controlled evidence files and must not imply runtime workspace writes.
+- Schema / columns / units / field names: selected - DependencyLock fields must follow Dependency_Versioning_Policy §6.
+- Auth / permissions / secrets: selected - generated lock artifacts must not contain registry auth headers, tokens, or API keys.
+- Concurrency / shared state / ordering: not selected - no runtime shared state or concurrent execution path changes.
+- Resource limits / large input / discovery: not selected - dependency discovery is bounded to the root lock graph and four known submodules.
+- Legacy compatibility / examples: selected - SHUD, rSHUD, AutoSHUD, and zero checkouts remain readable and unchanged.
+- Error handling / rollback / partial outputs: selected - lock drift or submodule dirty state must block acceptance rather than be silently recorded.
+- Release / packaging / dependency compatibility: selected - this is the initial package-manager and dependency baseline.
+- Documentation / migration notes: selected - PR evidence must state Bun version, lockfile sha, and submodule pinning.
+Domain packs:
+- Scientific governance / PI gate / evidence lineage: selected - DependencyLock is readiness evidence bound to the exact checkout.
+- Hydrology runtime / SHUD-rSHUD-AutoSHUD compatibility: selected - scientific submodule commits are recorded as the compatibility baseline.
+- Zero adapter / tool registry / agent role governance: selected - zero remains pinned and source-clean for ADR-0001 Trial work.
+
+Invariant Matrix:
+- Governing invariant: The initial DependencyLock must describe exactly the package-manager lockfile and submodule state inspected for this checkout, without changing source packages or submodules.
+- Source-of-truth identity/contract: `package.json#packageManager`, root `bun.lock` sha256, Dependency_Versioning_Policy §6, `.gitmodules`, `git submodule status`, and zero commit `13e25c1`.
+- Producers: Bun lockfile generation and DependencyLock record generation.
+- Validators/preflight: frozen install, lockfile sha check, DependencyLock JSON validation, `.gitmodules` parser check, submodule status check, zero diff/pin check.
+- Storage/cache/query: committed root `bun.lock` and `dependency-lock.initial.json`; no runtime workspace state.
+- Public routes/entrypoints: none - #14 has no backend/API surface.
+- Frontend/downstream consumers: future release/readiness evidence consumes the DependencyLock file, not a runtime API.
+- Failure paths/rollback/stale state: lockfile drift, wrong sha, dirty submodule, wrong zero commit, or out-of-bound changed file blocks merge.
+- Evidence/audit/readiness: PR evidence records frozen install, lockfile sha, submodule commits, zero diff, and clean package/submodule source status.
+- Regression rows:
+  - Clean checkout with `bun@1.2.19` -> `bun install --frozen-lockfile` succeeds and `bun.lock` sha256 remains equal to DependencyLock.
+  - `.gitmodules` parse plus `git submodule status` -> four path/url entries exist and DependencyLock commits match SHUD, rSHUD, AutoSHUD, and zero with `dirty: false`.
+  - `git -C zero rev-parse HEAD` and `git -C zero diff --quiet` -> zero remains `13e25c1` and source-clean.
+  - `git status --short -- packages SHUD rSHUD AutoSHUD zero` -> empty, proving package and submodule source boundaries were not edited.
+  - Secret scan over `package.json`, `bun.lock`, and `dependency-lock.initial.json` -> no registry auth, tokens, or API keys.
+
+Non-goals:
+- Workspace/package initialization (#16), dependency upgrades, package source edits, submodule updates, DuckDB client selection, or CI frozen-install wiring beyond existing check coverage.
+
+Review focus:
+- DependencyLock schema fields, lockfile sha, packageManager version, submodule commits, dirty flags, and zero pin all match the inspected checkout.
+- Frozen install produces no lockfile drift.
+- The PR contains only the #14 boundary files plus this workflow fixture update.
+
 ## Subagent Workflow Fixture — Issue #19
 
 Fixture level: expanded; repair intensity: high. Project profile: SHUD-Harness.

--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -145,6 +145,7 @@ Must add/change:
 - Root `package.json` declares a fixed Bun `packageManager`.
 - Root Bun lockfile is committed and supports frozen install without drift.
 - Initial DependencyLock records package manager version, lockfile path and sha256, direct runtime/dev dependency versions, and four submodule commits.
+- Deterministic package-list validation under `scripts/dependency-lock/` derives direct external dependencies from root `bun.lock` workspace dependency sections, requires a non-empty DependencyLock `packages` array, and compares `name`, resolved `version`, `dependency_type`, and `source` without registry/network access.
 
 Risk packs considered:
 - Public API / CLI / script entry: not selected - no runtime entrypoint behavior changes.
@@ -167,7 +168,7 @@ Invariant Matrix:
 - Governing invariant: The initial DependencyLock must describe exactly the package-manager lockfile and submodule state inspected for this checkout, without changing source packages or submodules.
 - Source-of-truth identity/contract: `package.json#packageManager`, root `bun.lock` sha256, Dependency_Versioning_Policy §6, `.gitmodules`, `git submodule status`, and zero commit `13e25c1`.
 - Producers: Bun lockfile generation and DependencyLock record generation.
-- Validators/preflight: frozen install, lockfile sha check, DependencyLock JSON validation, `.gitmodules` parser check, submodule status check, zero diff/pin check.
+- Validators/preflight: frozen install, lockfile sha check, DependencyLock JSON validation, package-list validation against the root Bun lock graph, `.gitmodules` parser check, submodule status check, zero diff/pin check.
 - Storage/cache/query: committed root `bun.lock` and `dependency-lock.initial.json`; no runtime workspace state.
 - Public routes/entrypoints: none - #14 has no backend/API surface.
 - Frontend/downstream consumers: future release/readiness evidence consumes the DependencyLock file, not a runtime API.
@@ -175,6 +176,8 @@ Invariant Matrix:
 - Evidence/audit/readiness: PR evidence records frozen install, lockfile sha, submodule commits, zero diff, and clean package/submodule source status.
 - Regression rows:
   - Clean checkout with `bun@1.2.19` -> `bun install --frozen-lockfile` succeeds and `bun.lock` sha256 remains equal to DependencyLock.
+  - `node scripts/dependency-lock/validate.mjs` on clean checkout -> DependencyLock `packages` is non-empty and exactly matches the root Bun lock graph's direct external workspace dependencies by `name`, resolved `version`, `dependency_type`, and `source`.
+  - Negative package fixtures -> empty `packages`, deleting direct dependency `zod`, and changing the resolved `typescript` version all fail validation.
   - `.gitmodules` parse plus `git submodule status` -> four path/url entries exist and DependencyLock commits match SHUD, rSHUD, AutoSHUD, and zero with `dirty: false`.
   - `git -C zero rev-parse HEAD` and `git -C zero diff --quiet` -> zero remains `13e25c1` and source-clean.
   - `git status --short -- packages SHUD rSHUD AutoSHUD zero` -> empty, proving package and submodule source boundaries were not edited.
@@ -184,7 +187,7 @@ Non-goals:
 - Workspace/package initialization (#16), dependency upgrades, package source edits, submodule updates, DuckDB client selection, or CI frozen-install wiring beyond existing check coverage.
 
 Review focus:
-- DependencyLock schema fields, lockfile sha, packageManager version, submodule commits, dirty flags, and zero pin all match the inspected checkout.
+- DependencyLock schema fields, lockfile sha, packageManager version, package list, submodule commits, dirty flags, and zero pin all match the inspected checkout.
 - Frozen install produces no lockfile drift.
 - The PR contains only the #14 boundary files plus this workflow fixture update.
 

--- a/openspec/changes/m1-foundation/specs/readiness-gates/spec.md
+++ b/openspec/changes/m1-foundation/specs/readiness-gates/spec.md
@@ -38,12 +38,17 @@ link check 脚本与 schema drift 检查 SHALL 入库 `scripts/` 并接入 CI；
 
 ### Requirement: 初始 DependencyLock 生成
 
-系统 SHALL 生成初始 DependencyLock 记录：四个 submodule（SHUD/rSHUD/AutoSHUD/zero）的 commit 与 dirty 状态、package manager/lockfile identity、关键运行时依赖版本。
+系统 SHALL 生成初始 DependencyLock 记录：四个 submodule（SHUD/rSHUD/AutoSHUD/zero）的 commit 与 dirty 状态、package manager/lockfile identity、关键运行时依赖版本。系统 SHALL 提供确定性校验脚本，从根 `bun.lock` workspace 直接依赖图推导非空外部依赖集合，并按 `name`、resolved `version`、`dependency_type`、`source` 精确验证 DependencyLock `packages`。
 
 #### Scenario: gitmodules 解析
 
 - **WHEN** 执行 `.gitmodules` path/url 解析检查与 `git submodule status`
 - **THEN** 四个 submodule 均返回 path/url，DependencyLock 中的 commit 与 `git submodule status` 一致，`dirty=false`，且 zero commit 为 `13e25c1`
+
+#### Scenario: DependencyLock package 列表校验
+
+- **WHEN** 执行 DependencyLock package-list 校验脚本
+- **THEN** `packages` 非空，且其 direct external dependency 条目与根 `bun.lock` workspace dependency sections 推导结果按 `name`、resolved `version`、`dependency_type`、`source` 完全一致；空列表、删除任一直连依赖、篡改 resolved version 的负例均失败
 
 #### Scenario: DependencyLock PR 边界
 

--- a/openspec/changes/m1-foundation/specs/readiness-gates/spec.md
+++ b/openspec/changes/m1-foundation/specs/readiness-gates/spec.md
@@ -29,21 +29,26 @@ link check 脚本与 schema drift 检查 SHALL 入库 `scripts/` 并接入 CI；
 
 ### Requirement: packageManager 与 lockfile 固定
 
-根 `package.json` SHALL 声明固定的 `packageManager`（Bun 版本），lockfile SHALL 入库；干净环境安装 MUST 可用冻结模式完成。
+根 `package.json` SHALL 声明固定的 `packageManager`（Bun 版本），lockfile SHALL 入库；干净环境安装 MUST 可用冻结模式完成，且不得修改 lockfile。
 
 #### Scenario: 冻结安装
 
 - **WHEN** 在干净 checkout 上执行 `bun install --frozen-lockfile`
-- **THEN** 安装成功且不修改 lockfile
+- **THEN** 安装成功且不修改 lockfile，lockfile sha256 与 DependencyLock 记录一致
 
 ### Requirement: 初始 DependencyLock 生成
 
-系统 SHALL 生成初始 DependencyLock 记录：四个 submodule（SHUD/rSHUD/AutoSHUD/zero）的 commit 与关键运行时依赖版本。
+系统 SHALL 生成初始 DependencyLock 记录：四个 submodule（SHUD/rSHUD/AutoSHUD/zero）的 commit 与 dirty 状态、package manager/lockfile identity、关键运行时依赖版本。
 
 #### Scenario: gitmodules 解析
 
-- **WHEN** 执行 `git config --file .gitmodules --get-regexp` 解析检查
-- **THEN** 四个 submodule 均返回 path/url，且 DependencyLock 中的 commit 与 `git submodule status` 一致
+- **WHEN** 执行 `.gitmodules` path/url 解析检查与 `git submodule status`
+- **THEN** 四个 submodule 均返回 path/url，DependencyLock 中的 commit 与 `git submodule status` 一致，`dirty=false`，且 zero commit 为 `13e25c1`
+
+#### Scenario: DependencyLock PR 边界
+
+- **WHEN** #14 PR 提交 DependencyLock
+- **THEN** 变更边界仅包含根 `package.json`、根 lockfile、DependencyLock 记录和 workflow fixture；不得修改 `packages/**`、SHUD/rSHUD/AutoSHUD/zero 源码或 submodule pointer
 
 ### Requirement: SHUD make 复验与 rSHUD 在位确认
 

--- a/openspec/changes/m1-foundation/specs/readiness-gates/spec.md
+++ b/openspec/changes/m1-foundation/specs/readiness-gates/spec.md
@@ -38,12 +38,17 @@ link check 脚本与 schema drift 检查 SHALL 入库 `scripts/` 并接入 CI；
 
 ### Requirement: 初始 DependencyLock 生成
 
-系统 SHALL 生成初始 DependencyLock 记录：四个 submodule（SHUD/rSHUD/AutoSHUD/zero）的 commit 与 dirty 状态、package manager/lockfile identity、关键运行时依赖版本。系统 SHALL 提供确定性校验脚本，从根 `bun.lock` workspace 直接依赖图推导非空外部依赖集合，并按 `name`、resolved `version`、`dependency_type`、`source` 精确验证 DependencyLock `packages`。
+系统 SHALL 生成初始 DependencyLock 记录：四个 submodule（SHUD/rSHUD/AutoSHUD/zero）的 commit 与 dirty 状态、package manager/lockfile identity、关键运行时依赖版本。系统 SHALL 提供确定性校验脚本，从根 `bun.lock` workspace 直接依赖图推导非空外部依赖集合，并按 `name`、resolved `version`、`dependency_type`、`source` 精确验证 DependencyLock `packages`；同时 SHALL 精确验证 package-manager identity 与 submodule evidence set。
 
 #### Scenario: gitmodules 解析
 
 - **WHEN** 执行 `.gitmodules` path/url 解析检查与 `git submodule status`
-- **THEN** 四个 submodule 均返回 path/url，DependencyLock 中的 commit 与 `git submodule status` 一致，`dirty=false`，且 zero commit 为 `13e25c1`
+- **THEN** `.gitmodules` 与 DependencyLock 均恰好包含 SHUD/rSHUD/AutoSHUD/zero，无缺失/额外/重复；四个 submodule 均返回 path/url，DependencyLock 中的 commit 与 `git submodule status` 一致，`dirty=false`，且 zero commit 为 `13e25c116c62411e6ee8a0ad67a6c53dc7c376c6`；缺失 submodule、wrong commit、`dirty=true`、wrong zero commit 的负例均失败
+
+#### Scenario: DependencyLock package-manager identity 校验
+
+- **WHEN** 执行 DependencyLock package-manager identity 校验脚本
+- **THEN** `package_manager.name/version` 与 `package.json#packageManager` 一致，`package_manager.lockfile_path/lockfile_sha256` 与被检查的根 lockfile 一致；stale `package_manager.version` 与 wrong `package_manager.lockfile_path` 的负例均失败
 
 #### Scenario: DependencyLock package 列表校验
 

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -17,6 +17,8 @@
   - Evidence floor (#14):
     - `bun install --frozen-lockfile` succeeds and leaves root lockfile unchanged; lockfile sha256 equals DependencyLock `package_manager.lockfile_sha256`.
     - `.gitmodules` path/url parser check returns exactly SHUD/rSHUD/AutoSHUD/zero; DependencyLock commits match `git submodule status`.
+    - `node scripts/dependency-lock/validate.mjs` derives a non-empty direct external dependency set from root `bun.lock` workspace dependency sections and verifies DependencyLock `packages` exactly by `name`, resolved `version`, `dependency_type`, and `source`.
+    - `sh scripts/dependency-lock/self_test.sh` proves empty `packages`, a missing direct dependency, and a mismatched resolved version each fail validation.
     - DependencyLock records zero commit `13e25c1`, every submodule has `dirty: false`, and `git -C zero diff --quiet` passes.
     - `git status --short -- packages SHUD rSHUD AutoSHUD zero` is empty; PR changes stay inside root `package.json`, root lockfile, DependencyLock record, and workflow fixture.
     - Secret/token scan over the three lock artifacts reports no registry auth headers, API keys, or bearer tokens.

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -16,9 +16,11 @@
 - [ ] 1.3 根 `package.json` 固定 packageManager + lockfile 入库 + 初始 DependencyLock（四 submodule commit + dirty 状态 + 运行时依赖版本）
   - Evidence floor (#14):
     - `bun install --frozen-lockfile` succeeds and leaves root lockfile unchanged; lockfile sha256 equals DependencyLock `package_manager.lockfile_sha256`.
-    - `.gitmodules` path/url parser check returns exactly SHUD/rSHUD/AutoSHUD/zero; DependencyLock commits match `git submodule status`.
-    - `node scripts/dependency-lock/validate.mjs` derives a non-empty direct external dependency set from root `bun.lock` workspace dependency sections and verifies DependencyLock `packages` exactly by `name`, resolved `version`, `dependency_type`, and `source`.
-    - `sh scripts/dependency-lock/self_test.sh` proves empty `packages`, a missing direct dependency, and a mismatched resolved version each fail validation.
+    - `.gitmodules` path/url parser check returns exactly SHUD/rSHUD/AutoSHUD/zero; DependencyLock submodules are the exact same set, commits match `git submodule status`, every recorded `dirty` flag is `false`, and zero is pinned to `13e25c116c62411e6ee8a0ad67a6c53dc7c376c6`.
+    - `node scripts/dependency-lock/validate.mjs` derives a non-empty direct external dependency set from root `bun.lock` workspace dependency sections and verifies DependencyLock `packages` exactly by `name`, resolved `version`, `dependency_type`, and `source`; it also validates `package_manager.name/version/lockfile_path/lockfile_sha256` against `package.json#packageManager` and the inspected root lockfile.
+    - `sh scripts/dependency-lock/self_test.sh` proves package negative fixtures fail validation: empty `packages`, a missing direct dependency, and a mismatched resolved version.
+    - `sh scripts/dependency-lock/self_test.sh` proves package-manager identity negative fixtures fail validation: stale `package_manager.version` and wrong `package_manager.lockfile_path`.
+    - `sh scripts/dependency-lock/self_test.sh` proves submodule negative fixtures fail validation: missing submodule, wrong submodule commit, dirty flag `true`, and wrong zero commit.
     - DependencyLock records zero commit `13e25c1`, every submodule has `dirty: false`, and `git -C zero diff --quiet` passes.
     - `git status --short -- packages SHUD rSHUD AutoSHUD zero` is empty; PR changes stay inside root `package.json`, root lockfile, DependencyLock record, and workflow fixture.
     - Secret/token scan over the three lock artifacts reports no registry auth headers, API keys, or bearer tokens.

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -13,7 +13,13 @@
     - Absent or preexisting `workspace/readiness/` -> helper creates/overwrites only `workspace/readiness/readiness_gate_v0_8_1.yaml`; `git status --short -- workspace` remains empty.
     - PR description or issue comment -> records per-gate input/result, command evidence, and downstream action: `block` freezes #16+ coding; `pass|pass_with_notes` unlocks downstream M1 coding.
 - [ ] 1.2 link check 脚本入库 `scripts/` + CI 工作流骨架（PR 触发：link check + 单测占位；schema drift 检查由 4.2 接入，PERF-API-001 冒烟由 6.5 接入）
-- [ ] 1.3 根 `package.json` 固定 packageManager + lockfile 入库 + 初始 DependencyLock（四 submodule commit + 运行时依赖版本）
+- [ ] 1.3 根 `package.json` 固定 packageManager + lockfile 入库 + 初始 DependencyLock（四 submodule commit + dirty 状态 + 运行时依赖版本）
+  - Evidence floor (#14):
+    - `bun install --frozen-lockfile` succeeds and leaves root lockfile unchanged; lockfile sha256 equals DependencyLock `package_manager.lockfile_sha256`.
+    - `.gitmodules` path/url parser check returns exactly SHUD/rSHUD/AutoSHUD/zero; DependencyLock commits match `git submodule status`.
+    - DependencyLock records zero commit `13e25c1`, every submodule has `dirty: false`, and `git -C zero diff --quiet` passes.
+    - `git status --short -- packages SHUD rSHUD AutoSHUD zero` is empty; PR changes stay inside root `package.json`, root lockfile, DependencyLock record, and workflow fixture.
+    - Secret/token scan over the three lock artifacts reports no registry auth headers, API keys, or bearer tokens.
 - [ ] 1.4 SHUD `make` 复验（一次本机编译 + 环境快照记入 readiness notes）+ rSHUD ≥2.5.0 在位确认
 
 ## 2. Monorepo 骨架（monorepo-skeleton）

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "shud-harness",
   "private": true,
   "type": "module",
+  "packageManager": "bun@1.2.19",
   "workspaces": [
     "packages/*",
     "zero/packages/*"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test:tool-registry-governance": "bun test ./packages/core/src/tools/role-tool-map.test.ts",
     "test:backend-ws": "bun test ./packages/backend/src/ws/index.test.ts",
     "test:schemas": "bun test ./packages/core/src/domain/schemas/core-schemas.test.ts",
+    "validate:dependency-lock": "node scripts/dependency-lock/validate.mjs",
+    "test:dependency-lock": "sh scripts/dependency-lock/self_test.sh",
     "check": "bun run typecheck && bun run test:policy-gate && bun run test:tool-registry-governance && bun run test:backend-ws && bun run test:schemas"
   },
   "devDependencies": {

--- a/scripts/dependency-lock/self_test.sh
+++ b/scripts/dependency-lock/self_test.sh
@@ -22,15 +22,37 @@ MISSING_LOCK="$TMP_ROOT/missing-direct-dependency.json"
 MISMATCH_LOCK="$TMP_ROOT/mismatched-version.json"
 STALE_PACKAGE_MANAGER_VERSION_LOCK="$TMP_ROOT/stale-package-manager-version.json"
 STALE_LOCKFILE_PATH_LOCK="$TMP_ROOT/stale-lockfile-path.json"
+MISSING_SUBMODULE_LOCK="$TMP_ROOT/missing-submodule.json"
+WRONG_SUBMODULE_COMMIT_LOCK="$TMP_ROOT/wrong-submodule-commit.json"
+DIRTY_SUBMODULE_LOCK="$TMP_ROOT/dirty-submodule.json"
+WRONG_ZERO_COMMIT_LOCK="$TMP_ROOT/wrong-zero-commit.json"
 
-node --input-type=module - "$BASE_LOCK" "$EMPTY_LOCK" "$MISSING_LOCK" "$MISMATCH_LOCK" "$STALE_PACKAGE_MANAGER_VERSION_LOCK" "$STALE_LOCKFILE_PATH_LOCK" <<'JS'
+node --input-type=module - "$BASE_LOCK" "$EMPTY_LOCK" "$MISSING_LOCK" "$MISMATCH_LOCK" "$STALE_PACKAGE_MANAGER_VERSION_LOCK" "$STALE_LOCKFILE_PATH_LOCK" "$MISSING_SUBMODULE_LOCK" "$WRONG_SUBMODULE_COMMIT_LOCK" "$DIRTY_SUBMODULE_LOCK" "$WRONG_ZERO_COMMIT_LOCK" <<'JS'
 import { readFileSync, writeFileSync } from "node:fs";
 
-const [basePath, emptyPath, missingPath, mismatchPath, stalePackageManagerVersionPath, staleLockfilePathPath] =
+const [
+  basePath,
+  emptyPath,
+  missingPath,
+  mismatchPath,
+  stalePackageManagerVersionPath,
+  staleLockfilePathPath,
+  missingSubmodulePath,
+  wrongSubmoduleCommitPath,
+  dirtySubmodulePath,
+  wrongZeroCommitPath,
+] =
   process.argv.slice(2);
 const base = JSON.parse(readFileSync(basePath, "utf8"));
 const writeFixture = (target, value) => {
   writeFileSync(target, `${JSON.stringify(value, null, 2)}\n`);
+};
+const getSubmodule = (lock, name, fixtureName) => {
+  const submodule = lock.submodules.find((item) => item.name === name);
+  if (!submodule) {
+    throw new Error(`base DependencyLock does not contain ${name} for ${fixtureName} fixture`);
+  }
+  return submodule;
 };
 
 const empty = structuredClone(base);
@@ -60,6 +82,28 @@ writeFixture(stalePackageManagerVersionPath, stalePackageManagerVersion);
 const staleLockfilePath = structuredClone(base);
 staleLockfilePath.package_manager.lockfile_path = "stale/bun.lock";
 writeFixture(staleLockfilePathPath, staleLockfilePath);
+
+const missingSubmodule = structuredClone(base);
+const beforeSubmoduleCount = missingSubmodule.submodules.length;
+missingSubmodule.submodules = missingSubmodule.submodules.filter((submodule) => submodule.name !== "SHUD");
+if (missingSubmodule.submodules.length !== beforeSubmoduleCount - 1) {
+  throw new Error("base DependencyLock does not contain SHUD for missing-submodule fixture");
+}
+writeFixture(missingSubmodulePath, missingSubmodule);
+
+const wrongSubmoduleCommit = structuredClone(base);
+getSubmodule(wrongSubmoduleCommit, "SHUD", "wrong-submodule-commit").commit =
+  "0000000000000000000000000000000000000000";
+writeFixture(wrongSubmoduleCommitPath, wrongSubmoduleCommit);
+
+const dirtySubmodule = structuredClone(base);
+getSubmodule(dirtySubmodule, "rSHUD", "dirty-submodule").dirty = true;
+writeFixture(dirtySubmodulePath, dirtySubmodule);
+
+const wrongZeroCommit = structuredClone(base);
+getSubmodule(wrongZeroCommit, "zero", "wrong-zero-commit").commit =
+  "0000000000000000000000000000000000000000";
+writeFixture(wrongZeroCommitPath, wrongZeroCommit);
 JS
 
 node "$VALIDATOR" > "$TMP_ROOT/positive.out" 2>&1 || {
@@ -89,5 +133,9 @@ expect_failure "missing-direct-dependency" "$MISSING_LOCK" "missing package: zod
 expect_failure "mismatched-version" "$MISMATCH_LOCK" "version mismatch for typescript"
 expect_failure "stale-package-manager-version" "$STALE_PACKAGE_MANAGER_VERSION_LOCK" "DependencyLock.package_manager.version mismatch"
 expect_failure "stale-lockfile-path" "$STALE_LOCKFILE_PATH_LOCK" "DependencyLock.package_manager.lockfile_path mismatch"
+expect_failure "missing-submodule" "$MISSING_SUBMODULE_LOCK" "missing submodule: SHUD"
+expect_failure "wrong-submodule-commit" "$WRONG_SUBMODULE_COMMIT_LOCK" "submodule commit mismatch for SHUD"
+expect_failure "dirty-submodule" "$DIRTY_SUBMODULE_LOCK" "DependencyLock.submodule rSHUD dirty must be false"
+expect_failure "wrong-zero-commit" "$WRONG_ZERO_COMMIT_LOCK" "zero submodule commit must be 13e25c116c62411e6ee8a0ad67a6c53dc7c376c6"
 
-printf 'dependency-lock self-test passed: positive validation plus package and identity negative fixtures\n'
+printf 'dependency-lock self-test passed: positive validation plus package, package-manager identity, and submodule negative fixtures\n'

--- a/scripts/dependency-lock/self_test.sh
+++ b/scripts/dependency-lock/self_test.sh
@@ -20,11 +20,14 @@ fail() {
 EMPTY_LOCK="$TMP_ROOT/empty-packages.json"
 MISSING_LOCK="$TMP_ROOT/missing-direct-dependency.json"
 MISMATCH_LOCK="$TMP_ROOT/mismatched-version.json"
+STALE_PACKAGE_MANAGER_VERSION_LOCK="$TMP_ROOT/stale-package-manager-version.json"
+STALE_LOCKFILE_PATH_LOCK="$TMP_ROOT/stale-lockfile-path.json"
 
-node --input-type=module - "$BASE_LOCK" "$EMPTY_LOCK" "$MISSING_LOCK" "$MISMATCH_LOCK" <<'JS'
+node --input-type=module - "$BASE_LOCK" "$EMPTY_LOCK" "$MISSING_LOCK" "$MISMATCH_LOCK" "$STALE_PACKAGE_MANAGER_VERSION_LOCK" "$STALE_LOCKFILE_PATH_LOCK" <<'JS'
 import { readFileSync, writeFileSync } from "node:fs";
 
-const [basePath, emptyPath, missingPath, mismatchPath] = process.argv.slice(2);
+const [basePath, emptyPath, missingPath, mismatchPath, stalePackageManagerVersionPath, staleLockfilePathPath] =
+  process.argv.slice(2);
 const base = JSON.parse(readFileSync(basePath, "utf8"));
 const writeFixture = (target, value) => {
   writeFileSync(target, `${JSON.stringify(value, null, 2)}\n`);
@@ -49,6 +52,14 @@ if (!typescript) {
 }
 typescript.version = "0.0.0-self-test";
 writeFixture(mismatchPath, mismatch);
+
+const stalePackageManagerVersion = structuredClone(base);
+stalePackageManagerVersion.package_manager.version = "0.0.0-self-test";
+writeFixture(stalePackageManagerVersionPath, stalePackageManagerVersion);
+
+const staleLockfilePath = structuredClone(base);
+staleLockfilePath.package_manager.lockfile_path = "stale/bun.lock";
+writeFixture(staleLockfilePathPath, staleLockfilePath);
 JS
 
 node "$VALIDATOR" > "$TMP_ROOT/positive.out" 2>&1 || {
@@ -76,5 +87,7 @@ expect_failure() {
 expect_failure "empty-packages" "$EMPTY_LOCK" "DependencyLock.packages must be a non-empty array"
 expect_failure "missing-direct-dependency" "$MISSING_LOCK" "missing package: zod"
 expect_failure "mismatched-version" "$MISMATCH_LOCK" "version mismatch for typescript"
+expect_failure "stale-package-manager-version" "$STALE_PACKAGE_MANAGER_VERSION_LOCK" "DependencyLock.package_manager.version mismatch"
+expect_failure "stale-lockfile-path" "$STALE_LOCKFILE_PATH_LOCK" "DependencyLock.package_manager.lockfile_path mismatch"
 
-printf 'dependency-lock self-test passed: positive validation plus empty/missing/version negative fixtures\n'
+printf 'dependency-lock self-test passed: positive validation plus package and identity negative fixtures\n'

--- a/scripts/dependency-lock/self_test.sh
+++ b/scripts/dependency-lock/self_test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+VALIDATOR="$SCRIPT_DIR/validate.mjs"
+BASE_LOCK="$REPO_ROOT/dependency-lock.initial.json"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/shud-dependency-lock-test.XXXXXX")
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+
+fail() {
+  printf 'dependency-lock self-test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+EMPTY_LOCK="$TMP_ROOT/empty-packages.json"
+MISSING_LOCK="$TMP_ROOT/missing-direct-dependency.json"
+MISMATCH_LOCK="$TMP_ROOT/mismatched-version.json"
+
+node --input-type=module - "$BASE_LOCK" "$EMPTY_LOCK" "$MISSING_LOCK" "$MISMATCH_LOCK" <<'JS'
+import { readFileSync, writeFileSync } from "node:fs";
+
+const [basePath, emptyPath, missingPath, mismatchPath] = process.argv.slice(2);
+const base = JSON.parse(readFileSync(basePath, "utf8"));
+const writeFixture = (target, value) => {
+  writeFileSync(target, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+const empty = structuredClone(base);
+empty.packages = [];
+writeFixture(emptyPath, empty);
+
+const missing = structuredClone(base);
+const beforeMissingCount = missing.packages.length;
+missing.packages = missing.packages.filter((pkg) => pkg.name !== "zod");
+if (missing.packages.length !== beforeMissingCount - 1) {
+  throw new Error("base DependencyLock does not contain zod for missing-dependency fixture");
+}
+writeFixture(missingPath, missing);
+
+const mismatch = structuredClone(base);
+const typescript = mismatch.packages.find((pkg) => pkg.name === "typescript");
+if (!typescript) {
+  throw new Error("base DependencyLock does not contain typescript for version-mismatch fixture");
+}
+typescript.version = "0.0.0-self-test";
+writeFixture(mismatchPath, mismatch);
+JS
+
+node "$VALIDATOR" > "$TMP_ROOT/positive.out" 2>&1 || {
+  cat "$TMP_ROOT/positive.out" >&2
+  fail "real DependencyLock did not pass positive validation"
+}
+
+expect_failure() {
+  label=$1
+  fixture=$2
+  expected_text=$3
+  output="$TMP_ROOT/$label.out"
+
+  if node "$VALIDATOR" --dependency-lock "$fixture" > "$output" 2>&1; then
+    cat "$output" >&2
+    fail "$label fixture unexpectedly passed"
+  fi
+
+  if ! grep -F "$expected_text" "$output" >/dev/null; then
+    cat "$output" >&2
+    fail "$label fixture did not report expected text: $expected_text"
+  fi
+}
+
+expect_failure "empty-packages" "$EMPTY_LOCK" "DependencyLock.packages must be a non-empty array"
+expect_failure "missing-direct-dependency" "$MISSING_LOCK" "missing package: zod"
+expect_failure "mismatched-version" "$MISMATCH_LOCK" "version mismatch for typescript"
+
+printf 'dependency-lock self-test passed: positive validation plus empty/missing/version negative fixtures\n'

--- a/scripts/dependency-lock/validate.mjs
+++ b/scripts/dependency-lock/validate.mjs
@@ -1,0 +1,425 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEPENDENCY_SECTIONS = [
+  ["dependencies", "runtime"],
+  ["devDependencies", "dev"],
+  ["peerDependencies", "peer"],
+  ["optionalDependencies", "optional"],
+];
+
+const TYPE_RANK = {
+  optional: 0,
+  peer: 1,
+  dev: 2,
+  runtime: 3,
+};
+
+const ALLOWED_TYPES = new Set(["runtime", "dev", "peer", "optional"]);
+const ALLOWED_SOURCES = new Set(["npm", "git", "local"]);
+
+function usage() {
+  return `Usage: node scripts/dependency-lock/validate.mjs [options]
+
+Validates dependency-lock.initial.json packages against the root Bun lock graph.
+
+Options:
+  --repo-root <path>          Repository root. Defaults to this script's repo root.
+  --lockfile <path>           Bun lockfile. Defaults to <repo-root>/bun.lock.
+  --dependency-lock <path>    DependencyLock JSON. Defaults to <repo-root>/dependency-lock.initial.json.
+  --help                      Show this help.
+
+Derivation:
+  The expected package list is derived from bun.lock's workspaces section.
+  For every workspace, dependencies/devDependencies/peerDependencies/optionalDependencies
+  are scanned, workspace:* and workspace-local package names are ignored, and each
+  remaining direct external package is resolved through bun.lock's packages table.
+  Repeated declarations use dependency_type precedence runtime > dev > peer > optional.
+  Registry packages are source=npm; git/file-like specs resolve to git/local.
+`;
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+    if (arg === "--repo-root" || arg === "--lockfile" || arg === "--dependency-lock") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error(`${arg} requires a value`);
+      }
+      options[arg.slice(2).replace(/-/g, "_")] = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function stripJsonTrailingCommas(text) {
+  let output = "";
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      output += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      output += char;
+      continue;
+    }
+
+    if (char === ",") {
+      let nextIndex = index + 1;
+      while (nextIndex < text.length && /\s/.test(text[nextIndex])) {
+        nextIndex += 1;
+      }
+      if (text[nextIndex] === "}" || text[nextIndex] === "]") {
+        continue;
+      }
+    }
+
+    output += char;
+  }
+
+  return output;
+}
+
+function readJson(filePath) {
+  const text = readFileSync(filePath, "utf8");
+  return JSON.parse(text);
+}
+
+function readBunLock(filePath) {
+  const text = readFileSync(filePath, "utf8");
+  return JSON.parse(stripJsonTrailingCommas(text));
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOwn(record, key) {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function parsePackageDescriptor(name, entry) {
+  if (!Array.isArray(entry) || typeof entry[0] !== "string") {
+    return { error: `lock package ${name} does not have a Bun descriptor tuple` };
+  }
+
+  const descriptor = entry[0];
+  const prefix = `${name}@`;
+  if (!descriptor.startsWith(prefix)) {
+    return { error: `lock package ${name} descriptor ${descriptor} does not start with ${prefix}` };
+  }
+
+  const version = descriptor.slice(prefix.length);
+  if (!version) {
+    return { error: `lock package ${name} descriptor does not contain a resolved version` };
+  }
+
+  return { descriptor, version };
+}
+
+function resolvePackage(packagesTable, name) {
+  const directEntry = hasOwn(packagesTable, name) ? [[name, packagesTable[name]]] : [];
+  const descriptorMatches = Object.entries(packagesTable).filter(([, entry]) => {
+    return Array.isArray(entry) && typeof entry[0] === "string" && entry[0].startsWith(`${name}@`);
+  });
+  const matches = directEntry.length > 0 ? directEntry : descriptorMatches;
+
+  if (matches.length === 0) {
+    return { error: `lock packages table has no resolved entry for ${name}` };
+  }
+  if (matches.length > 1) {
+    const keys = matches.map(([key]) => key).sort().join(", ");
+    return { error: `lock packages table has multiple resolved entries for ${name}: ${keys}` };
+  }
+
+  const parsed = parsePackageDescriptor(name, matches[0][1]);
+  if (parsed.error) {
+    return parsed;
+  }
+
+  return parsed;
+}
+
+function inferSource(spec, descriptor) {
+  const values = [String(spec), descriptor];
+  if (values.some((value) => /^(?:file|link|portal):/.test(value))) {
+    return "local";
+  }
+  if (values.some((value) => /^(?:git|github|gitlab|bitbucket)(?:\+|:)/.test(value) || value.includes("github.com"))) {
+    return "git";
+  }
+  return "npm";
+}
+
+function addExpectedPackage(expected, item) {
+  const existing = expected.get(item.name);
+  if (!existing) {
+    expected.set(item.name, {
+      name: item.name,
+      version: item.version,
+      dependency_type: item.dependency_type,
+      source: item.source,
+      locations: [item.location],
+    });
+    return null;
+  }
+
+  existing.locations.push(item.location);
+  if (existing.version !== item.version) {
+    return `${item.name} resolves to both ${existing.version} and ${item.version}`;
+  }
+  if (existing.source !== item.source) {
+    return `${item.name} resolves to both source=${existing.source} and source=${item.source}`;
+  }
+  if (TYPE_RANK[item.dependency_type] > TYPE_RANK[existing.dependency_type]) {
+    existing.dependency_type = item.dependency_type;
+  }
+  return null;
+}
+
+function collectExpectedPackages(lock) {
+  const errors = [];
+  if (!isRecord(lock.workspaces)) {
+    return { expected: new Map(), errors: ["bun.lock must contain a workspaces object"] };
+  }
+  if (!isRecord(lock.packages)) {
+    return { expected: new Map(), errors: ["bun.lock must contain a packages object"] };
+  }
+
+  const workspaceNames = new Set();
+  for (const [workspacePath, workspace] of Object.entries(lock.workspaces)) {
+    if (!isRecord(workspace)) {
+      errors.push(`workspace ${workspacePath || "<root>"} is not an object`);
+      continue;
+    }
+    if (typeof workspace.name === "string") {
+      workspaceNames.add(workspace.name);
+    }
+  }
+
+  const expected = new Map();
+  for (const [workspacePath, workspace] of Object.entries(lock.workspaces).sort(([left], [right]) => left.localeCompare(right))) {
+    if (!isRecord(workspace)) {
+      continue;
+    }
+
+    for (const [section, dependencyType] of DEPENDENCY_SECTIONS) {
+      const dependencies = workspace[section];
+      if (dependencies === undefined) {
+        continue;
+      }
+      if (!isRecord(dependencies)) {
+        errors.push(`workspace ${workspacePath || "<root>"} ${section} must be an object`);
+        continue;
+      }
+
+      for (const name of Object.keys(dependencies).sort()) {
+        const spec = dependencies[name];
+        if (workspaceNames.has(name) || String(spec).startsWith("workspace:")) {
+          continue;
+        }
+
+        const resolved = resolvePackage(lock.packages, name);
+        if (resolved.error) {
+          errors.push(`${workspacePath || "<root>"} ${section}.${name}: ${resolved.error}`);
+          continue;
+        }
+
+        const addError = addExpectedPackage(expected, {
+          name,
+          version: resolved.version,
+          dependency_type: dependencyType,
+          source: inferSource(spec, resolved.descriptor),
+          location: `${workspacePath || "<root>"} ${section}.${name}`,
+        });
+        if (addError) {
+          errors.push(addError);
+        }
+      }
+    }
+  }
+
+  if (expected.size === 0) {
+    errors.push("expected direct external dependency set is empty");
+  }
+
+  return { expected, errors };
+}
+
+function collectActualPackages(dependencyLock) {
+  const errors = [];
+  if (!Array.isArray(dependencyLock.packages) || dependencyLock.packages.length === 0) {
+    return {
+      actual: new Map(),
+      errors: ["DependencyLock.packages must be a non-empty array"],
+    };
+  }
+
+  const actual = new Map();
+  dependencyLock.packages.forEach((pkg, index) => {
+    const label = `DependencyLock.packages[${index}]`;
+    if (!isRecord(pkg)) {
+      errors.push(`${label} must be an object`);
+      return;
+    }
+    for (const field of ["name", "version", "dependency_type", "source"]) {
+      if (typeof pkg[field] !== "string" || pkg[field].length === 0) {
+        errors.push(`${label}.${field} must be a non-empty string`);
+      }
+    }
+    if (typeof pkg.dependency_type === "string" && !ALLOWED_TYPES.has(pkg.dependency_type)) {
+      errors.push(`${label}.dependency_type has invalid value ${pkg.dependency_type}`);
+    }
+    if (typeof pkg.source === "string" && !ALLOWED_SOURCES.has(pkg.source)) {
+      errors.push(`${label}.source has invalid value ${pkg.source}`);
+    }
+    if (typeof pkg.name === "string") {
+      if (actual.has(pkg.name)) {
+        errors.push(`duplicate DependencyLock package entry: ${pkg.name}`);
+      } else {
+        actual.set(pkg.name, {
+          name: pkg.name,
+          version: pkg.version,
+          dependency_type: pkg.dependency_type,
+          source: pkg.source,
+        });
+      }
+    }
+  });
+
+  return { actual, errors };
+}
+
+function comparePackages(expected, actual) {
+  const errors = [];
+  const expectedNames = [...expected.keys()].sort();
+  const actualNames = [...actual.keys()].sort();
+
+  for (const name of expectedNames) {
+    if (!actual.has(name)) {
+      const item = expected.get(name);
+      errors.push(
+        `missing package: ${name} (expected version=${item.version}, dependency_type=${item.dependency_type}, source=${item.source})`,
+      );
+    }
+  }
+
+  for (const name of actualNames) {
+    if (!expected.has(name)) {
+      const item = actual.get(name);
+      errors.push(
+        `extra package: ${name} (actual version=${item.version}, dependency_type=${item.dependency_type}, source=${item.source})`,
+      );
+    }
+  }
+
+  for (const name of expectedNames) {
+    if (!actual.has(name)) {
+      continue;
+    }
+    const expectedItem = expected.get(name);
+    const actualItem = actual.get(name);
+    for (const field of ["version", "dependency_type", "source"]) {
+      if (actualItem[field] !== expectedItem[field]) {
+        errors.push(`${field} mismatch for ${name}: expected ${expectedItem[field]}, got ${actualItem[field]}`);
+      }
+    }
+  }
+
+  return errors;
+}
+
+function sha256(filePath) {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+function validateLockfileIdentity(dependencyLock, lockfilePath) {
+  const errors = [];
+  const packageManager = dependencyLock.package_manager;
+  if (!isRecord(packageManager)) {
+    return ["DependencyLock.package_manager must be an object"];
+  }
+  if (packageManager.name !== "bun") {
+    errors.push(`DependencyLock.package_manager.name must be bun, got ${packageManager.name}`);
+  }
+  if (packageManager.lockfile_sha256 !== sha256(lockfilePath)) {
+    errors.push(
+      `DependencyLock.package_manager.lockfile_sha256 mismatch: expected ${sha256(lockfilePath)}, got ${packageManager.lockfile_sha256}`,
+    );
+  }
+  return errors;
+}
+
+function main() {
+  const scriptPath = fileURLToPath(import.meta.url);
+  const defaultRepoRoot = path.resolve(path.dirname(scriptPath), "..", "..");
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(usage());
+    return 0;
+  }
+
+  const repoRoot = path.resolve(options.repo_root ?? defaultRepoRoot);
+  const lockfilePath = path.resolve(options.lockfile ?? path.join(repoRoot, "bun.lock"));
+  const dependencyLockPath = path.resolve(options.dependency_lock ?? path.join(repoRoot, "dependency-lock.initial.json"));
+
+  const lock = readBunLock(lockfilePath);
+  const dependencyLock = readJson(dependencyLockPath);
+
+  const expectedResult = collectExpectedPackages(lock);
+  const actualResult = collectActualPackages(dependencyLock);
+  const identityErrors = validateLockfileIdentity(dependencyLock, lockfilePath);
+  const compareErrors = comparePackages(expectedResult.expected, actualResult.actual);
+  const errors = [...expectedResult.errors, ...actualResult.errors, ...identityErrors, ...compareErrors];
+
+  if (errors.length > 0) {
+    console.error("DependencyLock package validation failed:");
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    return 1;
+  }
+
+  console.log(
+    `DependencyLock package list valid: ${expectedResult.expected.size} direct external workspace dependencies match ${path.relative(
+      repoRoot,
+      dependencyLockPath,
+    )}.`,
+  );
+  console.log(
+    "Derivation: bun.lock workspaces direct dependency sections -> ignore workspace-local deps -> resolve versions from bun.lock packages table.",
+  );
+  return 0;
+}
+
+try {
+  process.exitCode = main();
+} catch (error) {
+  console.error(`DependencyLock package validation crashed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 2;
+}

--- a/scripts/dependency-lock/validate.mjs
+++ b/scripts/dependency-lock/validate.mjs
@@ -358,18 +358,69 @@ function sha256(filePath) {
   return createHash("sha256").update(readFileSync(filePath)).digest("hex");
 }
 
-function validateLockfileIdentity(dependencyLock, lockfilePath) {
+function toPosixRelativePath(fromPath, toPath) {
+  return path.relative(fromPath, toPath).split(path.sep).join("/");
+}
+
+function parsePackageManager(packageJson) {
+  if (!isRecord(packageJson)) {
+    return { errors: ["package.json root must be an object"] };
+  }
+
+  const packageManager = packageJson.packageManager;
+  if (typeof packageManager !== "string" || packageManager.length === 0) {
+    return { errors: ["package.json#packageManager must be a non-empty string"] };
+  }
+
+  const separatorIndex = packageManager.lastIndexOf("@");
+  if (separatorIndex <= 0 || separatorIndex === packageManager.length - 1) {
+    return { errors: [`package.json#packageManager must use <name>@<version>, got ${packageManager}`] };
+  }
+
+  return {
+    packageManager: {
+      name: packageManager.slice(0, separatorIndex),
+      version: packageManager.slice(separatorIndex + 1),
+    },
+    errors: [],
+  };
+}
+
+function validateLockfileIdentity(dependencyLock, packageJson, repoRoot, lockfilePath) {
   const errors = [];
+  const parsedPackageManager = parsePackageManager(packageJson);
+  errors.push(...parsedPackageManager.errors);
+
   const packageManager = dependencyLock.package_manager;
   if (!isRecord(packageManager)) {
-    return ["DependencyLock.package_manager must be an object"];
+    errors.push("DependencyLock.package_manager must be an object");
+    return errors;
   }
-  if (packageManager.name !== "bun") {
-    errors.push(`DependencyLock.package_manager.name must be bun, got ${packageManager.name}`);
+
+  if (parsedPackageManager.packageManager) {
+    if (packageManager.name !== parsedPackageManager.packageManager.name) {
+      errors.push(
+        `DependencyLock.package_manager.name mismatch: expected ${parsedPackageManager.packageManager.name} from package.json#packageManager, got ${packageManager.name}`,
+      );
+    }
+    if (packageManager.version !== parsedPackageManager.packageManager.version) {
+      errors.push(
+        `DependencyLock.package_manager.version mismatch: expected ${parsedPackageManager.packageManager.version} from package.json#packageManager, got ${packageManager.version}`,
+      );
+    }
   }
-  if (packageManager.lockfile_sha256 !== sha256(lockfilePath)) {
+
+  const expectedLockfilePath = toPosixRelativePath(repoRoot, lockfilePath);
+  if (packageManager.lockfile_path !== expectedLockfilePath) {
     errors.push(
-      `DependencyLock.package_manager.lockfile_sha256 mismatch: expected ${sha256(lockfilePath)}, got ${packageManager.lockfile_sha256}`,
+      `DependencyLock.package_manager.lockfile_path mismatch: expected ${expectedLockfilePath}, got ${packageManager.lockfile_path}`,
+    );
+  }
+
+  const expectedLockfileSha256 = sha256(lockfilePath);
+  if (packageManager.lockfile_sha256 !== expectedLockfileSha256) {
+    errors.push(
+      `DependencyLock.package_manager.lockfile_sha256 mismatch: expected ${expectedLockfileSha256}, got ${packageManager.lockfile_sha256}`,
     );
   }
   return errors;
@@ -387,13 +438,15 @@ function main() {
   const repoRoot = path.resolve(options.repo_root ?? defaultRepoRoot);
   const lockfilePath = path.resolve(options.lockfile ?? path.join(repoRoot, "bun.lock"));
   const dependencyLockPath = path.resolve(options.dependency_lock ?? path.join(repoRoot, "dependency-lock.initial.json"));
+  const packageJsonPath = path.join(repoRoot, "package.json");
 
   const lock = readBunLock(lockfilePath);
   const dependencyLock = readJson(dependencyLockPath);
+  const packageJson = readJson(packageJsonPath);
 
   const expectedResult = collectExpectedPackages(lock);
   const actualResult = collectActualPackages(dependencyLock);
-  const identityErrors = validateLockfileIdentity(dependencyLock, lockfilePath);
+  const identityErrors = validateLockfileIdentity(dependencyLock, packageJson, repoRoot, lockfilePath);
   const compareErrors = comparePackages(expectedResult.expected, actualResult.actual);
   const errors = [...expectedResult.errors, ...actualResult.errors, ...identityErrors, ...compareErrors];
 

--- a/scripts/dependency-lock/validate.mjs
+++ b/scripts/dependency-lock/validate.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -20,11 +21,15 @@ const TYPE_RANK = {
 
 const ALLOWED_TYPES = new Set(["runtime", "dev", "peer", "optional"]);
 const ALLOWED_SOURCES = new Set(["npm", "git", "local"]);
+const EXPECTED_SUBMODULES = ["SHUD", "rSHUD", "AutoSHUD", "zero"];
+const EXPECTED_SUBMODULE_SET = new Set(EXPECTED_SUBMODULES);
+const ZERO_COMMIT = "13e25c116c62411e6ee8a0ad67a6c53dc7c376c6";
 
 function usage() {
   return `Usage: node scripts/dependency-lock/validate.mjs [options]
 
-Validates dependency-lock.initial.json packages against the root Bun lock graph.
+Validates dependency-lock.initial.json against the root Bun lock graph,
+package-manager identity, and current submodule checkout evidence.
 
 Options:
   --repo-root <path>          Repository root. Defaults to this script's repo root.
@@ -39,6 +44,7 @@ Derivation:
   remaining direct external package is resolved through bun.lock's packages table.
   Repeated declarations use dependency_type precedence runtime > dev > peer > optional.
   Registry packages are source=npm; git/file-like specs resolve to git/local.
+  Submodule evidence is read from .gitmodules and git submodule status.
 `;
 }
 
@@ -426,6 +432,227 @@ function validateLockfileIdentity(dependencyLock, packageJson, repoRoot, lockfil
   return errors;
 }
 
+function parseGitmodules(text) {
+  const errors = [];
+  const entries = new Map();
+  let current = null;
+
+  for (const [lineIndex, rawLine] of text.split(/\r?\n/).entries()) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#") || line.startsWith(";")) {
+      continue;
+    }
+
+    const sectionMatch = line.match(/^\[submodule "(.+)"\]$/);
+    if (sectionMatch) {
+      const name = sectionMatch[1];
+      if (entries.has(name)) {
+        errors.push(`duplicate .gitmodules submodule section: ${name}`);
+      }
+      current = { name };
+      entries.set(name, current);
+      continue;
+    }
+
+    const assignmentMatch = line.match(/^([A-Za-z0-9_.-]+)\s*=\s*(.*)$/);
+    if (!assignmentMatch) {
+      errors.push(`.gitmodules line ${lineIndex + 1} is not a supported assignment or submodule section`);
+      continue;
+    }
+    if (!current) {
+      errors.push(`.gitmodules line ${lineIndex + 1} appears before any submodule section`);
+      continue;
+    }
+
+    const [, key, value] = assignmentMatch;
+    if (key === "path" || key === "url") {
+      if (hasOwn(current, key)) {
+        errors.push(`.gitmodules submodule ${current.name} has duplicate ${key}`);
+      }
+      current[key] = value;
+    }
+  }
+
+  for (const name of EXPECTED_SUBMODULES) {
+    const entry = entries.get(name);
+    if (!entry) {
+      errors.push(`missing .gitmodules submodule: ${name}`);
+      continue;
+    }
+    if (typeof entry.path !== "string" || entry.path.length === 0) {
+      errors.push(`.gitmodules submodule ${name} must have a non-empty path`);
+    }
+    if (typeof entry.url !== "string" || entry.url.length === 0) {
+      errors.push(`.gitmodules submodule ${name} must have a non-empty url`);
+    }
+  }
+
+  for (const name of [...entries.keys()].sort()) {
+    if (!EXPECTED_SUBMODULE_SET.has(name)) {
+      errors.push(`extra .gitmodules submodule: ${name}`);
+    }
+  }
+
+  return { entries, errors };
+}
+
+function gitOutput(args, repoRoot) {
+  return execFileSync("git", ["-C", repoRoot, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function parseGitSubmoduleStatus(output) {
+  const errors = [];
+  const statusByPath = new Map();
+
+  for (const rawLine of output.split(/\r?\n/)) {
+    if (rawLine.trim().length === 0) {
+      continue;
+    }
+
+    const statusChar = [" ", "+", "-", "U"].includes(rawLine[0]) ? rawLine[0] : " ";
+    const rest = statusChar === " " && rawLine[0] !== " " ? rawLine : rawLine.slice(1);
+    const match = rest.trimStart().match(/^([0-9a-f]{40})\s+([^\s]+)(?:\s|$)/);
+    if (!match) {
+      errors.push(`git submodule status line is not parseable: ${rawLine}`);
+      continue;
+    }
+
+    const [, commit, submodulePath] = match;
+    if (statusByPath.has(submodulePath)) {
+      errors.push(`duplicate git submodule status path: ${submodulePath}`);
+      continue;
+    }
+    statusByPath.set(submodulePath, { commit, statusChar });
+  }
+
+  return { statusByPath, errors };
+}
+
+function collectDependencyLockSubmodules(dependencyLock) {
+  const errors = [];
+  if (!Array.isArray(dependencyLock.submodules)) {
+    return { submodules: new Map(), errors: ["DependencyLock.submodules must be an array"] };
+  }
+
+  const submodules = new Map();
+  dependencyLock.submodules.forEach((submodule, index) => {
+    const label = `DependencyLock.submodules[${index}]`;
+    if (!isRecord(submodule)) {
+      errors.push(`${label} must be an object`);
+      return;
+    }
+
+    for (const field of ["name", "commit"]) {
+      if (typeof submodule[field] !== "string" || submodule[field].length === 0) {
+        errors.push(`${label}.${field} must be a non-empty string`);
+      }
+    }
+    if (typeof submodule.commit === "string" && !/^[0-9a-f]{40}$/.test(submodule.commit)) {
+      errors.push(`${label}.commit must be a 40-character lowercase git commit`);
+    }
+    if (submodule.dirty !== false) {
+      const name = typeof submodule.name === "string" ? submodule.name : `<index ${index}>`;
+      errors.push(`DependencyLock.submodule ${name} dirty must be false`);
+    }
+
+    if (typeof submodule.name === "string") {
+      if (submodules.has(submodule.name)) {
+        errors.push(`duplicate DependencyLock submodule entry: ${submodule.name}`);
+      } else {
+        submodules.set(submodule.name, {
+          name: submodule.name,
+          commit: submodule.commit,
+          dirty: submodule.dirty,
+        });
+      }
+    }
+  });
+
+  for (const name of EXPECTED_SUBMODULES) {
+    if (!submodules.has(name)) {
+      errors.push(`missing submodule: ${name}`);
+    }
+  }
+
+  for (const name of [...submodules.keys()].sort()) {
+    if (!EXPECTED_SUBMODULE_SET.has(name)) {
+      errors.push(`extra submodule: ${name}`);
+    }
+  }
+
+  return { submodules, errors };
+}
+
+function submoduleWorktreeIsDirty(repoRoot, submodulePath) {
+  const status = gitOutput(["status", "--porcelain=v1", "--untracked-files=all"], path.join(repoRoot, submodulePath));
+  return status.trim().length > 0;
+}
+
+function validateSubmodules(dependencyLock, repoRoot) {
+  const errors = [];
+  const dependencyLockResult = collectDependencyLockSubmodules(dependencyLock);
+  errors.push(...dependencyLockResult.errors);
+
+  const gitmodulesPath = path.join(repoRoot, ".gitmodules");
+  const gitmodulesResult = parseGitmodules(readFileSync(gitmodulesPath, "utf8"));
+  errors.push(...gitmodulesResult.errors);
+
+  let statusResult = { statusByPath: new Map(), errors: [] };
+  try {
+    statusResult = parseGitSubmoduleStatus(gitOutput(["submodule", "status"], repoRoot));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    errors.push(`git submodule status failed: ${message}`);
+  }
+  errors.push(...statusResult.errors);
+
+  for (const name of EXPECTED_SUBMODULES) {
+    const record = dependencyLockResult.submodules.get(name);
+    const gitmodule = gitmodulesResult.entries.get(name);
+    if (!record || !gitmodule || typeof gitmodule.path !== "string" || gitmodule.path.length === 0) {
+      continue;
+    }
+
+    const status = statusResult.statusByPath.get(gitmodule.path);
+    if (!status) {
+      errors.push(`git submodule status missing path for ${name}: ${gitmodule.path}`);
+      continue;
+    }
+    if (status.statusChar !== " ") {
+      errors.push(`git submodule status for ${name} must be clean at ${gitmodule.path}, got ${status.statusChar}`);
+    }
+    if (record.commit !== status.commit) {
+      errors.push(`submodule commit mismatch for ${name}: expected ${status.commit} from git submodule status, got ${record.commit}`);
+    }
+
+    try {
+      if (submoduleWorktreeIsDirty(repoRoot, gitmodule.path)) {
+        errors.push(`submodule worktree is dirty for ${name}: ${gitmodule.path}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(`git status failed for submodule ${name} at ${gitmodule.path}: ${message}`);
+    }
+  }
+
+  for (const submodulePath of [...statusResult.statusByPath.keys()].sort()) {
+    const matchingEntry = [...gitmodulesResult.entries.values()].find((entry) => entry.path === submodulePath);
+    if (!matchingEntry) {
+      errors.push(`git submodule status has path not declared in .gitmodules: ${submodulePath}`);
+    }
+  }
+
+  const zero = dependencyLockResult.submodules.get("zero");
+  if (zero && zero.commit !== ZERO_COMMIT) {
+    errors.push(`zero submodule commit must be ${ZERO_COMMIT}, got ${zero.commit}`);
+  }
+
+  return errors;
+}
+
 function main() {
   const scriptPath = fileURLToPath(import.meta.url);
   const defaultRepoRoot = path.resolve(path.dirname(scriptPath), "..", "..");
@@ -447,11 +674,12 @@ function main() {
   const expectedResult = collectExpectedPackages(lock);
   const actualResult = collectActualPackages(dependencyLock);
   const identityErrors = validateLockfileIdentity(dependencyLock, packageJson, repoRoot, lockfilePath);
+  const submoduleErrors = validateSubmodules(dependencyLock, repoRoot);
   const compareErrors = comparePackages(expectedResult.expected, actualResult.actual);
-  const errors = [...expectedResult.errors, ...actualResult.errors, ...identityErrors, ...compareErrors];
+  const errors = [...expectedResult.errors, ...actualResult.errors, ...identityErrors, ...submoduleErrors, ...compareErrors];
 
   if (errors.length > 0) {
-    console.error("DependencyLock package validation failed:");
+    console.error("DependencyLock validation failed:");
     for (const error of errors) {
       console.error(`- ${error}`);
     }
@@ -464,6 +692,7 @@ function main() {
       dependencyLockPath,
     )}.`,
   );
+  console.log(`DependencyLock submodules valid: ${EXPECTED_SUBMODULES.join(", ")} match .gitmodules and git submodule status.`);
   console.log(
     "Derivation: bun.lock workspaces direct dependency sections -> ignore workspace-local deps -> resolve versions from bun.lock packages table.",
   );

--- a/scripts/dependency-lock/validate.mjs
+++ b/scripts/dependency-lock/validate.mjs
@@ -24,6 +24,10 @@ const ALLOWED_SOURCES = new Set(["npm", "git", "local"]);
 const EXPECTED_SUBMODULES = ["SHUD", "rSHUD", "AutoSHUD", "zero"];
 const EXPECTED_SUBMODULE_SET = new Set(EXPECTED_SUBMODULES);
 const ZERO_COMMIT = "13e25c116c62411e6ee8a0ad67a6c53dc7c376c6";
+const READ_ONLY_GIT_ENV = {
+  GIT_OPTIONAL_LOCKS: "0",
+  GIT_NO_LAZY_FETCH: "1",
+};
 
 function usage() {
   return `Usage: node scripts/dependency-lock/validate.mjs [options]
@@ -499,6 +503,10 @@ function parseGitmodules(text) {
 function gitOutput(args, repoRoot) {
   return execFileSync("git", ["-C", repoRoot, ...args], {
     encoding: "utf8",
+    env: {
+      ...process.env,
+      ...READ_ONLY_GIT_ENV,
+    },
     stdio: ["ignore", "pipe", "pipe"],
   });
 }


### PR DESCRIPTION
Part of #11
Closes #14

## Summary
- Fix root packageManager to `bun@1.2.19` and commit the root Bun lockfile.
- Add the initial DependencyLock record for the root lockfile, direct runtime/dev dependencies, and SHUD/rSHUD/AutoSHUD/zero submodule commits.
- Add the #14 OpenSpec workflow fixture and deterministic DependencyLock validator/self-test for lockfile sha, package-manager identity, package list exactness, dirty=false submodule state, zero pin, and PR boundary.
- Harden validator Git reads with `GIT_OPTIONAL_LOCKS=0` and `GIT_NO_LAZY_FETCH=1`.

## Validation
- `openspec validate m1-foundation --strict --no-interactive`
- `npx --yes bun@1.2.19 run check`
- `npx --yes bun@1.2.19 install --frozen-lockfile --no-cache`
- `node scripts/dependency-lock/validate.mjs`
- `sh scripts/dependency-lock/self_test.sh`
- `npx --yes bun@1.2.19 run validate:dependency-lock`
- `npx --yes bun@1.2.19 run test:dependency-lock`
- `git diff --check`
- `git -C zero diff --quiet && git -C zero rev-parse HEAD`
- `git status --short -- packages SHUD rSHUD AutoSHUD zero`
- secret/token scan over `package.json`, `bun.lock`, `dependency-lock.initial.json`, and dependency-lock scripts
- submodule index mtime probe before/after validator: unchanged for SHUD, rSHUD, AutoSHUD, and zero

## Agent Review
- Reviewer agents used: correctness, integration, test/evidence, security/performance across expanded fixture rounds; final clean-context gap sweep is recorded separately before merge.
- Reviewed head SHA: `615375ce9b112c86ba2628b36a9b6dfda95fa72a`
- Review evidence: round-5 review clean for correctness/integration/security-performance; test/evidence finding was PR evidence placeholders, closed by this body update and the evidence comment.
- OpenSpec change: `m1-foundation`; fixture level: expanded; selected risk packs: config/project setup, file evidence, schema fields, auth/secrets scan, legacy compatibility, error/lock drift, release/dependency compatibility, documentation/migration notes, evidence lineage, hydrology submodule compatibility, zero pin governance.
- Key findings addressed: package list validation against `bun.lock`; package-manager identity validation; exact submodule set/status/dirty validation; zero pin validation; OpenSpec evidence alignment; Git optional-lock hardening.
- Non-blocking notes: CI frozen-install wiring is outside #14 scope; branch-exhaustive negative fixture expansion beyond the OpenSpec rows remains optional hardening.
