### PR TITLE
M1-5.2 tool registry governance lint

### DIFF
--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -414,3 +414,59 @@ Review focus:
 - The comparison directly references #24 constants and never duplicates the profile table.
 - Runtime tests exercise Zero's real `tools` input name, while PR evidence states it is the implementation of spec `allowed_tools`.
 - Denial occurs before the underlying spawn tool can create a subagent and gives an actionable `adjust_scope` remediation.
+
+## Subagent Workflow Fixture - Issue #25
+
+Fixture level: expanded
+Project profile: SHUD-Harness
+Change surface:
+- `packages/core/src/tools/policy-gate-registry.ts`
+- `packages/core/src/tools/policy-gate-registry.test.ts`
+
+Must preserve:
+- Existing policy-gated wrapper behavior: evaluator denials and input-preparation failures happen before inner tool execution and return structured payloads.
+- Existing spawn profile subset behavior and #24 role-map comparison semantics.
+- Existing raw-data sandbox registry behavior, including `bash` / `sandbox.exec` wrapping and raw-denial ownership.
+- `zero/` remains source-clean and pinned; no Zero source edits.
+
+Must add/change:
+- Register-time lint at the #17 tool registration/wrap seam.
+- Per-role visible tool count budget: `<= 20`; the 21st visible tool is rejected with role and excess count.
+- Tool description completeness check for the three Control_Kernel §5.3 sections: `何时该用`, `何时不该用`, `成功与失败样态`.
+- Zod parameter schema validation before inner tool execution; validation failure returns structured rejection payload with `remediation{next_action,hint,ref}`.
+
+Risk packs considered:
+- Public API / CLI / script entry: selected - tool registration and wrapped tool execution are shared entrypoints.
+- Config / project setup: not selected - no package manager, provider, or environment setup changes.
+- File IO / path safety / overwrite: not selected - no file mutation behavior beyond tests.
+- Schema / columns / units / field names: selected - tool parameter schema and rejection payload shape are contracts.
+- Auth / permissions / secrets: selected - role-visible tool budgets enforce the tool authority surface.
+- Concurrency / shared state / ordering: not selected - no shared runtime state or scheduling changes.
+- Resource limits / large input / discovery: selected - per-role tool count is an explicit resource/cognitive budget.
+- Legacy compatibility / examples: selected - existing policy-gate, spawn subset, and raw sandbox tests must remain green.
+- Error handling / rollback / partial outputs: selected - schema validation failure must be non-silent and pre-execution.
+- Release / packaging / dependency compatibility: selected - no new dependency; Bun/TypeScript checks must remain compatible.
+- Documentation / migration notes: selected - PR evidence must call out the lint boundary and non-goals.
+Domain packs:
+- Scientific governance / PI gate / evidence lineage: not selected - no scientific decision or evidence claim changes.
+- Hydrology runtime / SHUD-rSHUD-AutoSHUD compatibility: not selected - no solver/runtime behavior changes.
+- Zero adapter / tool registry / agent role governance: selected - this is the core shared boundary.
+
+Required evidence:
+- Focused Bun tests: 21st role-visible tool registration -> assembly failure with role and excess count.
+- Focused Bun tests: missing `何时不该用` description section -> assembly failure with missing section.
+- Focused Bun tests: Zod parameter schema failure -> inner tool not executed and structured rejection payload includes remediation three fields.
+- Compatibility: `bun run test:policy-gate` and `bun run check`.
+- `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`.
+
+Non-goals:
+- Changing `ROLE_TOOL_MAP` contents or #24 snapshot oracle.
+- `guard_class` assembly lint; remains #26.
+- Spawn depth/concurrency hard limits; remain #27.
+- Adding new runtime dependencies or editing Zero source.
+
+Review focus:
+- Lint is applied at registry assembly/wrap time, not as a late runtime note.
+- The description-section check is exact enough to fail missing required sections while preserving existing valid tools.
+- Zod validation failures are returned as structured policy-gate-style denials and do not execute inner tools.
+- Existing registry and sandbox behavior remains compatible.

--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -422,6 +422,7 @@ Project profile: SHUD-Harness
 Change surface:
 - `packages/core/src/tools/policy-gate-registry.ts`
 - `packages/core/src/tools/policy-gate-registry.test.ts`
+- `packages/core/src/tools/raw-data-sandbox.ts`
 
 Must preserve:
 - Existing policy-gated wrapper behavior: evaluator denials and input-preparation failures happen before inner tool execution and return structured payloads.

--- a/openspec/changes/m1-foundation/specs/tool-registry-governance/spec.md
+++ b/openspec/changes/m1-foundation/specs/tool-registry-governance/spec.md
@@ -81,6 +81,11 @@
 - **WHEN** 注册的工具描述缺少"何时不该用"节
 - **THEN** 注册期 lint 失败并指出缺失节
 
+#### Scenario: 参数 schema 校验失败回吐拒绝载荷
+
+- **WHEN** 注册工具的 Zod 参数 schema 校验调用输入失败
+- **THEN** 工具不会执行，返回结构化拒绝载荷，且载荷包含 `remediation.next_action`、`remediation.hint`、`remediation.ref`
+
 ### Requirement: 硬护栏 guard_class 标注
 
 M1 落地的每条硬护栏——路径写禁区（policy-gate-spike 条 2'，执行层沙箱护栏与其 advisory 层均须标注）、spawn 剖面子集校验（policy-gate-spike 条 3）、spawn depth 上限与并发上限（本 spec「spawn depth 与并发上限硬校验」requirement）——SHALL 标注 `guard_class ∈ {authority, capability}`（Control_Kernel §5.2 分类），为换代减重审查留数据基础；存在未标注护栏时装配或 lint MUST 失败。

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -59,6 +59,11 @@
 
 - [ ] 5.1 [GRILL-2] role→tool_id canonical 映射表常量（领域工具 id 遵 Zero_Reuse_Matrix §10 点分注册名）+ 快照测试 + 语义不变式单测（只读角色无写工具 / spawn 权唯一 / coordinator 无 bash / coder 独占 edit+patch）——依赖: 2.1
 - [ ] 5.2 注册期 lint（≤20/角色 + 描述三节完整性 + Zod 参数校验回吐）+ 负例测试（挂 3.1 横切点）——依赖: 3.1
+  - Evidence floor (#25):
+    - Registering a role-visible tool set with 21 tools fails during registry assembly and reports the role plus the excess count.
+    - Registering a tool whose description lacks `何时不该用` fails during registry assembly and reports the missing section.
+    - A Zod parameter schema validation failure prevents inner tool execution and returns a structured rejection payload containing `remediation{next_action,hint,ref}`.
+    - Existing policy-gated registry, spawn subset, and raw sandbox tests remain compatible; `git -C zero diff --quiet` still passes.
 - [ ] 5.3 硬护栏 guard_class 标注（authority|capability）+ 未标注装配失败负例——依赖: 3.1
 - [ ] 5.4 spawn depth/并发上限 kernel 硬校验（Control_Kernel §5：depth >1 拒绝且含 remediation 三字段；活跃子代理 =3 时新 spawn 非 allow——纯函数负例，真实排队调度随 M3 spawn 接线）+ guard_class 标注——依赖: 3.2
 

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -14,6 +14,7 @@ import type {
   ToolLogger,
   ToolResult
 } from "@zero-os/shared";
+import { z } from "zod";
 import {
   PolicyGateRemediationSchema,
   SPAWN_PROFILE_ALLOWLIST_MAX_ITEMS,
@@ -2080,6 +2081,101 @@ describe("policy-gated zero tool registry", () => {
     expect(spawnTool.lastInput).not.toHaveProperty("allowed_tools");
     expect(spawnTool.lastInput).not.toHaveProperty("ignoredBlob");
     expect(spawnTool.lastInput).not.toHaveProperty("ignoredFunction");
+  });
+
+  test("SHUD runtime assembly rejects the 21st role-visible tool", () => {
+    const tools = Array.from({ length: 19 }, (_, index) => new RecordingTool(`extra.${index}`));
+
+    expect(() =>
+      createShudRuntimeToolRegistry(
+        createMinimalShudRuntimeRegistryOptions({
+          role: "worker",
+          tools
+        })
+      )
+    ).toThrow(
+      /Policy-gated tool registration lint failed for role worker: visible tool count 21 exceeds 20; excess count 1/
+    );
+  });
+
+  test("SHUD runtime assembly rejects tool descriptions missing required sections", () => {
+    const badTool = new RecordingTool("bad.description");
+    badTool.description = [
+      "何时该用: Use this fixture for description lint tests.",
+      "成功与失败样态: Success returns a fixture result; failure throws during assembly."
+    ].join("\n");
+
+    expect(() =>
+      createShudRuntimeToolRegistry(
+        createMinimalShudRuntimeRegistryOptions({
+          tools: [badTool]
+        })
+      )
+    ).toThrow(/bad\.description: missing 何时不该用/);
+  });
+
+  test("Zod parameter schema rejection finalizes without executing the inner tool", async () => {
+    const zodTool = new ZodRecordingTool(
+      "zod.parameters",
+      z.object({
+        command: z.string()
+      })
+    );
+    const runningToolRegistry = new TestRunningToolRegistry();
+    const handle = runningToolRegistry.register({
+      toolUseId: "POLICY-ZOD-1",
+      toolName: "zod.parameters",
+      abortable: false
+    });
+    let evaluatorCalls = 0;
+    const wrapped = wrapToolWithPolicyGate(zodTool, {
+      evaluate: async () => {
+        evaluatorCalls += 1;
+        return { decision: "allow" };
+      }
+    });
+
+    const result = await wrapped.run(
+      {
+        ...createToolContext("worker"),
+        currentToolUseId: "POLICY-ZOD-1",
+        runningToolRegistry
+      },
+      {
+        command: 42
+      }
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("policy_gate_denied");
+    expect(result.output).toContain("tool-parameter-schema-validation");
+    const payload = JSON.parse(result.output) as {
+      error?: string;
+      ruleId?: string;
+      reason?: string;
+      remediation?: {
+        next_action?: string;
+        hint?: string;
+        ref?: string;
+      };
+    };
+    expect(payload.error).toBe("policy_gate_denied");
+    expect(payload.ruleId).toBe("tool-parameter-schema-validation");
+    expect(payload.reason).toContain("command");
+    expect(payload.remediation?.next_action).toBe("fix_and_retry");
+    expect(payload.remediation?.hint).toContain("Zod parameter schema");
+    expect(payload.remediation?.ref).toBe(
+      "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定"
+    );
+    expect(PolicyGateRemediationSchema.safeParse(payload.remediation).success).toBe(true);
+    expect(evaluatorCalls).toBe(0);
+    expect(zodTool.calls).toBe(0);
+    expect(handle.getState()).toBe("finished");
+    expect(handle.getTerminalMetadata()).toMatchObject({
+      cause: "completed",
+      success: false,
+      outputSummary: result.outputSummary
+    });
   });
 
   test("assembly fails when any registered zero tool bypasses the wrapper", () => {
@@ -4737,7 +4833,7 @@ class RecordingTool extends BaseTool {
 
   constructor(readonly name: string) {
     super();
-    this.description = `Test tool ${name}`;
+    this.description = createCompleteToolDescription(name);
   }
 
   protected async execute(_ctx: ToolContext, input: unknown): Promise<ToolResult> {
@@ -4761,6 +4857,39 @@ class RequiredCommandRecordingTool extends RecordingTool {
     },
     required: ["command"],
     additionalProperties: true
+  };
+}
+
+class ZodRecordingTool extends RecordingTool {
+  constructor(
+    name: string,
+    readonly parameterSchema: unknown
+  ) {
+    super(name);
+  }
+}
+
+function createCompleteToolDescription(name: string): string {
+  return [
+    `何时该用: Use ${name} when a test needs a policy-gated tool fixture.`,
+    `何时不该用: Do not use ${name} to exercise real filesystem, model, or SHUD solver behavior.`,
+    `成功与失败样态: Success records the input and returns a fixture result; failure is injected by the wrapper or test harness.`
+  ].join("\n");
+}
+
+function createMinimalShudRuntimeRegistryOptions(
+  overrides: Partial<{
+    tools: readonly BaseTool[];
+    role: "coordinator" | "repo_explorer" | "worker" | "coder" | "reviewer";
+  }> = {}
+) {
+  return {
+    protectedRawPaths: ["/tmp/shud-harness-test/data/raw"],
+    allowedWriteRoots: ["/tmp/shud-harness-test/workspace"],
+    tempRoot: "/tmp/shud-harness-test/tmp",
+    profileRoot: "/tmp/shud-harness-test/profiles",
+    fuseRules: [],
+    ...overrides
   };
 }
 

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -2547,6 +2547,47 @@ describe("policy-gated zero tool registry", () => {
     ).toThrow(/generic\.bad\.description: missing 何时不该用/);
   });
 
+  test("generic wrap seam lints final wrappers after stale prewrapped inner mutation", () => {
+    const innerTool = new RecordingTool("generic.stale.inner.description");
+    const prewrappedTool = wrapToolWithPolicyGate(innerTool, {
+      evaluate: async () => ({ decision: "allow" })
+    });
+
+    innerTool.description = [
+      "何时该用: Use this fixture after stale prewrapped mutation.",
+      "成功与失败样态: Success should never pass final wrapper lint."
+    ].join("\n");
+
+    expect(() =>
+      wrapAllRegisteredTools([prewrappedTool], {
+        evaluate: async () => ({ decision: "allow" })
+      })
+    ).toThrow(/generic\.stale\.inner\.description: missing 何时不该用/);
+  });
+
+  test("generic wrap seam lints final visible count after stale prewrapped inner name drift", () => {
+    const innerTools = Array.from(
+      { length: 21 },
+      (_, index) => new RecordingTool(`generic.stale.count.${Math.min(index, 19)}`)
+    );
+    const prewrappedTools = innerTools.map((tool) =>
+      wrapToolWithPolicyGate(tool, {
+        evaluate: async () => ({ decision: "allow" })
+      })
+    );
+
+    (innerTools[20] as unknown as { name: string }).name = "generic.stale.count.20";
+
+    expect(() =>
+      wrapAllRegisteredTools(prewrappedTools, {
+        role: "worker",
+        evaluate: async () => ({ decision: "allow" })
+      })
+    ).toThrow(
+      /Policy-gated tool registration lint failed for role worker: visible tool count 21 exceeds 20; excess count 1/
+    );
+  });
+
   test("direct spawn wrapper executes only sanitized spawn input", async () => {
     const spawnTool = new RecordingTool("spawn_agent");
     const tailSentinel = "ignored-tail-sentinel-that-must-not-appear";
@@ -2949,6 +2990,81 @@ describe("policy-gated zero tool registry", () => {
     expectToolParameterSchemaValidationDenial(result);
     expect(evaluatorCalls).toBe(1);
     expect(zodTool.calls).toBe(0);
+  });
+
+  test("Zod schema hardening rejects fake safeParse carriers without deep traversal", () => {
+    const fakeSchema = createDeepFakeZodLikeSchema(256);
+    const zodTool = new ZodRecordingTool("zod.fake.deep", fakeSchema);
+
+    expect(() =>
+      wrapToolWithPolicyGate(zodTool, {
+        evaluate: async () => ({ decision: "allow" })
+      })
+    ).toThrow(/Tool Zod parameter schema must be a real Zod v4 schema/);
+  });
+
+  test("Zod schema hardening rejects Proxy-backed schema carriers before trap traversal", () => {
+    let traps = 0;
+    const target = {
+      safeParse: () => ({
+        success: true,
+        data: {
+          command: "proxy"
+        }
+      })
+    };
+    const proxySchema = new Proxy(target, {
+      get(targetValue, key, receiver) {
+        traps += 1;
+        return Reflect.get(targetValue, key, receiver);
+      },
+      getOwnPropertyDescriptor(targetValue, key) {
+        traps += 1;
+        return Reflect.getOwnPropertyDescriptor(targetValue, key);
+      },
+      ownKeys(targetValue) {
+        traps += 1;
+        return Reflect.ownKeys(targetValue);
+      }
+    });
+    const zodTool = new ZodRecordingTool("zod.proxy", proxySchema);
+
+    expect(() =>
+      wrapToolWithPolicyGate(zodTool, {
+        evaluate: async () => ({ decision: "allow" })
+      })
+    ).toThrow(/Tool Zod parameter schema must be a real Zod v4 schema/);
+    expect(traps).toBe(0);
+  });
+
+  test("Zod schema hardening fails closed on over-depth real schema side graphs", () => {
+    const schema = z.object({
+      command: z.string()
+    });
+    (schema as unknown as { retainedSideGraph: unknown }).retainedSideGraph =
+      createNestedRecord(140);
+    const zodTool = new ZodRecordingTool("zod.deep.budget", schema);
+
+    expect(() =>
+      wrapToolWithPolicyGate(zodTool, {
+        evaluate: async () => ({ decision: "allow" })
+      })
+    ).toThrow(/Zod parameter schema exceeds hardening depth budget/);
+  });
+
+  test("Zod schema hardening fails closed on over-wide real schema side graphs", () => {
+    const schema = z.object({
+      command: z.string()
+    });
+    (schema as unknown as { retainedSideGraph: unknown }).retainedSideGraph =
+      createWideRecord(600);
+    const zodTool = new ZodRecordingTool("zod.wide.budget", schema);
+
+    expect(() =>
+      createPolicyGatedToolRegistry([zodTool], {
+        evaluate: async () => ({ decision: "allow" })
+      })
+    ).toThrow(/Zod parameter schema exceeds hardening property budget/);
   });
 
   test("Zod parameter schema rejection survives a throwing evaluator", async () => {
@@ -6172,6 +6288,42 @@ function monkeyPatchZodSafeParseToAccept(schema: unknown, data: unknown): void {
       data
     });
   }
+}
+
+function createDeepFakeZodLikeSchema(depth: number): unknown {
+  const root: Record<string, unknown> = {
+    safeParse: () => ({
+      success: true,
+      data: {
+        command: "fake"
+      }
+    })
+  };
+  let current = root;
+  for (let index = 0; index < depth; index += 1) {
+    const child: Record<string, unknown> = {};
+    current.child = child;
+    current = child;
+  }
+  return root;
+}
+
+function createNestedRecord(depth: number): Record<string, unknown> {
+  let current: Record<string, unknown> = {
+    leaf: true
+  };
+  for (let index = 0; index < depth; index += 1) {
+    current = {
+      child: current
+    };
+  }
+  return current;
+}
+
+function createWideRecord(width: number): Record<string, unknown> {
+  return Object.fromEntries(
+    Array.from({ length: width }, (_, index) => [`field${index}`, index])
+  );
 }
 
 function attemptZodCommandShapeMutationToAcceptNumber(schema: unknown): void {

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -2136,6 +2136,41 @@ describe("policy-gated zero tool registry", () => {
     expect(definitions.map((candidate) => candidate.name)).not.toContain("generic.snapshot.leaked");
   });
 
+  test("factory-returned registry owns wrapper kind and capability snapshots", () => {
+    const tool = new RecordingTool("generic.wrapper.snapshot");
+    const originalKind: BaseTool["kind"] = "tool";
+    const originalCapabilities = Object.freeze(["vision"]);
+    tool.kind = originalKind;
+    tool.requiredModelCapabilities = originalCapabilities;
+    const registry = createPolicyGatedToolRegistry([tool], {
+      evaluate: async () => ({ decision: "allow" })
+    });
+
+    const registered = registry.get("generic.wrapper.snapshot");
+    expect(registered).toBeDefined();
+    if (!registered) {
+      throw new Error("generic.wrapper.snapshot should be registered");
+    }
+
+    attemptRegisteredWrapperFieldMutation(registered, {
+      kind: "mcp",
+      requiredModelCapabilities: ["mutated-capability"]
+    });
+
+    const listed = registry.list().find((candidate) => candidate.name === "generic.wrapper.snapshot");
+    const definition = registry
+      .getDefinitions()
+      .find((candidate) => candidate.name === "generic.wrapper.snapshot");
+    expect(listed).toBe(registered);
+    expect(definition?.kind).toBe(originalKind);
+    expect(registered.kind).toBe(originalKind);
+    expect(listed?.kind).toBe(originalKind);
+    expect(registered.requiredModelCapabilities).toEqual(originalCapabilities);
+    expect(registered.requiredModelCapabilities).not.toBe(originalCapabilities);
+    expect(listed?.requiredModelCapabilities).toEqual(originalCapabilities);
+    expect(Object.isFrozen(registered.requiredModelCapabilities)).toBe(true);
+  });
+
   test("generic registry lint rejects the 21st visible tool without a role", () => {
     const tools = Array.from({ length: 21 }, (_, index) => new RecordingTool(`generic.${index}`));
 
@@ -5367,6 +5402,49 @@ describe("policy-gated zero tool registry", () => {
     }
   });
 
+  test("SHUD runtime registry owns wrapper kind and capability snapshots", async () => {
+    const fixture = await createRawFixture();
+    try {
+      const edit = new RecordingTool("edit");
+      const originalKind: BaseTool["kind"] = "built-in";
+      const originalCapabilities = Object.freeze(["vision"]);
+      edit.kind = originalKind;
+      edit.requiredModelCapabilities = originalCapabilities;
+      const registry = createShudRuntimeToolRegistry({
+        tools: [edit],
+        protectedRawPaths: [fixture.rawRoot],
+        allowedWriteRoots: [fixture.root],
+        tempRoot: fixture.tempRoot,
+        profileRoot: fixture.profileRoot,
+        fuseRules: []
+      });
+
+      const registered = registry.get("edit");
+      expect(registered).toBeDefined();
+      if (!registered) {
+        throw new Error("edit should be registered in the SHUD runtime registry");
+      }
+
+      attemptRegisteredWrapperFieldMutation(registered, {
+        kind: "mcp",
+        requiredModelCapabilities: ["mutated-capability"]
+      });
+
+      const listed = registry.list().find((candidate) => candidate.name === "edit");
+      const definition = registry.getDefinitions().find((candidate) => candidate.name === "edit");
+      expect(listed).toBe(registered);
+      expect(definition?.kind).toBe(originalKind);
+      expect(registered.kind).toBe(originalKind);
+      expect(listed?.kind).toBe(originalKind);
+      expect(registered.requiredModelCapabilities).toEqual(originalCapabilities);
+      expect(registered.requiredModelCapabilities).not.toBe(originalCapabilities);
+      expect(listed?.requiredModelCapabilities).toEqual(originalCapabilities);
+      expect(Object.isFrozen(registered.requiredModelCapabilities)).toBe(true);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   test("SHUD runtime rewraps prewrapped tools with the current evaluator", async () => {
     const fixture = await createRawFixture();
     try {
@@ -5513,6 +5591,31 @@ class ZodRecordingTool extends RecordingTool {
     readonly parameterSchema: unknown
   ) {
     super(name);
+  }
+}
+
+function attemptRegisteredWrapperFieldMutation(
+  tool: BaseTool,
+  replacement: {
+    kind: BaseTool["kind"];
+    requiredModelCapabilities: readonly string[];
+  }
+): void {
+  const mutations: Array<() => void> = [
+    () => {
+      tool.kind = replacement.kind;
+    },
+    () => {
+      tool.requiredModelCapabilities = replacement.requiredModelCapabilities;
+    }
+  ];
+
+  for (const mutate of mutations) {
+    try {
+      mutate();
+    } catch (error) {
+      expect(error).toBeInstanceOf(TypeError);
+    }
   }
 }
 

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -20,6 +20,7 @@ import type {
   RunningToolTerminalMetadata,
   SecretFilter,
   ToolContext,
+  ToolDefinition,
   ToolLogger,
   ToolResult
 } from "@zero-os/shared";
@@ -2053,6 +2054,46 @@ describe("policy-gated zero tool registry", () => {
     expect(tools.map((tool) => tool.calls)).toEqual([1, 1, 1]);
   });
 
+  test("factory-returned registry owns model-visible definitions when inner toDefinition diverges", () => {
+    const tool = new DivergentDefinitionTool(
+      "generic.definition",
+      "generic.leaked.definition",
+      "Leaked definition description without required governance sections."
+    );
+    const registry = createPolicyGatedToolRegistry([tool], {
+      evaluate: async () => ({ decision: "allow" })
+    });
+
+    let definition = registry
+      .getDefinitions()
+      .find((candidate) => candidate.name === "generic.definition");
+    expect(definition).toBeDefined();
+    expect(definition?.name).toBe("generic.definition");
+    expect(definition?.description).toBe(tool.description);
+    expect(definition?.description).toContain("何时该用:");
+    expect(definition?.parameters).toBe(tool.parameters);
+    expect(definition?.parameters).not.toEqual({ leaked: true });
+
+    const replacement = new DivergentDefinitionTool(
+      "generic.definition",
+      "generic.replacement.leaked",
+      "Replacement leaked definition description without required sections."
+    );
+    registry.register(
+      wrapToolWithPolicyGate(replacement, {
+        evaluate: async () => ({ decision: "allow" })
+      })
+    );
+
+    definition = registry
+      .getDefinitions()
+      .find((candidate) => candidate.name === "generic.definition");
+    expect(definition?.name).toBe("generic.definition");
+    expect(definition?.description).toBe(replacement.description);
+    expect(definition?.description).toContain("何时不该用:");
+    expect(definition?.parameters).toBe(replacement.parameters);
+  });
+
   test("generic registry lint rejects the 21st visible tool without a role", () => {
     const tools = Array.from({ length: 21 }, (_, index) => new RecordingTool(`generic.${index}`));
 
@@ -2114,27 +2155,62 @@ describe("policy-gated zero tool registry", () => {
       role: "worker",
       evaluate: async () => ({ decision: "allow" })
     });
-    const replacementTool = wrapToolWithPolicyGate(new RecordingTool("generic.19"), {
+    const replacementInnerTool = new RecordingTool("generic.19");
+    const replacementTool = wrapToolWithPolicyGate(replacementInnerTool, {
       evaluate: async () => ({ decision: "allow" })
     });
 
     expect(() => registry.register(replacementTool)).not.toThrow();
     expect(registry.list()).toHaveLength(20);
-    expect(registry.get("generic.19")).toBe(replacementTool);
+    const registeredReplacement = registry.get("generic.19");
+    expect(registeredReplacement).not.toBe(replacementTool);
+    expect(isPolicyGatedTool(registeredReplacement!)).toBe(true);
+    if (!isPolicyGatedTool(registeredReplacement!)) {
+      throw new Error("replacement should be wrapped by registry authority");
+    }
+    expect(registeredReplacement.innerTool).toBe(replacementInnerTool);
     expect(() => assertPolicyGatedToolRegistry(registry, { role: "worker" })).not.toThrow();
   });
 
-  test("factory-returned registry rejects post-return unwrapped tool registration", () => {
+  test("factory-returned registry rewraps stale post-return replacements with current evaluator", async () => {
+    const registry = createPolicyGatedToolRegistry([new RecordingTool("edit")], {
+      evaluate: async () => ({
+        decision: "deny",
+        ruleId: "registry-owned-deny",
+        reason: "blocked by registry-owned evaluator",
+        remediation: {
+          next_action: "adjust_scope",
+          hint: "Use a tool allowed by the registry owner.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        }
+      })
+    });
+    const staleReplacementInnerTool = new RecordingTool("edit");
+    const staleAllowReplacement = wrapToolWithPolicyGate(staleReplacementInnerTool, {
+      evaluate: async () => ({ decision: "allow" })
+    });
+
+    expect(() => registry.register(staleAllowReplacement)).not.toThrow();
+    const registeredReplacement = registry.get("edit");
+    expect(registeredReplacement).not.toBe(staleAllowReplacement);
+    expect(isPolicyGatedTool(registeredReplacement!)).toBe(true);
+
+    const result = await registeredReplacement?.run(createToolContext("coder"), {});
+
+    expect(result?.success).toBe(false);
+    expect(result?.output).toContain("policy_gate_denied");
+    expect(result?.output).toContain("registry-owned-deny");
+    expect(staleReplacementInnerTool.calls).toBe(0);
+  });
+
+  test("factory-returned registry wraps post-return unwrapped tool registration", () => {
     const registry = createPolicyGatedToolRegistry([new RecordingTool("generic.good")], {
       evaluate: async () => ({ decision: "allow" })
     });
 
-    expect(() => registry.register(new RecordingTool("generic.unwrapped"))).toThrow(
-      /Policy-gated tool assembly failed; unwrapped tool ids: generic\.unwrapped/
-    );
-    expect(registry.get("generic.unwrapped")).toBeUndefined();
-    expect(registry.list().map((tool) => tool.name)).not.toContain("generic.unwrapped");
-    expect(registry.getDefinitions().map((definition) => definition.name)).not.toContain(
+    expect(() => registry.register(new RecordingTool("generic.unwrapped"))).not.toThrow();
+    expect(isPolicyGatedTool(registry.get("generic.unwrapped")!)).toBe(true);
+    expect(registry.getDefinitions().map((definition) => definition.name)).toContain(
       "generic.unwrapped"
     );
   });
@@ -2400,6 +2476,50 @@ describe("policy-gated zero tool registry", () => {
       success: false,
       outputSummary: result.outputSummary
     });
+  });
+
+  test("Zod parameter schema rejection survives a throwing evaluator", async () => {
+    const zodTool = new ZodRecordingTool(
+      "zod.invalid.throwing.evaluator",
+      z.object({
+        command: z.string()
+      })
+    );
+    let evaluatorCalls = 0;
+    const wrapped = wrapToolWithPolicyGate(zodTool, {
+      evaluate: async () => {
+        evaluatorCalls += 1;
+        throw new Error("throwing evaluator must not replace schema denial");
+      }
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), {
+      command: 42
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("policy_gate_denied");
+    expect(result.output).toContain("tool-parameter-schema-validation");
+    expect(result.output).not.toContain("throwing evaluator");
+    const payload = JSON.parse(result.output) as {
+      error?: string;
+      ruleId?: string;
+      remediation?: {
+        next_action?: string;
+        hint?: string;
+        ref?: string;
+      };
+    };
+    expect(payload.error).toBe("policy_gate_denied");
+    expect(payload.ruleId).toBe("tool-parameter-schema-validation");
+    expect(payload.remediation?.next_action).toBe("fix_and_retry");
+    expect(payload.remediation?.hint).toContain("Zod parameter schema");
+    expect(payload.remediation?.ref).toBe(
+      "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定"
+    );
+    expect(PolicyGateRemediationSchema.safeParse(payload.remediation).success).toBe(true);
+    expect(evaluatorCalls).toBe(1);
+    expect(zodTool.calls).toBe(0);
   });
 
   test("policy evaluator denial wins before invalid Zod schema details", async () => {
@@ -5168,6 +5288,48 @@ describe("policy-gated zero tool registry", () => {
       await fixture.cleanup();
     }
   });
+
+  test("SHUD runtime rewraps stale post-return replacements with the current evaluator", async () => {
+    const fixture = await createRawFixture();
+    try {
+      const registry = createShudRuntimeToolRegistry({
+        tools: [new RecordingTool("edit")],
+        protectedRawPaths: [fixture.rawRoot],
+        allowedWriteRoots: [fixture.root],
+        tempRoot: fixture.tempRoot,
+        profileRoot: fixture.profileRoot,
+        fuseRules: [],
+        evaluate: async () => ({
+          decision: "deny",
+          ruleId: "runtime-owned-deny",
+          reason: "blocked by current runtime evaluator",
+          remediation: {
+            next_action: "adjust_scope",
+            hint: "Use an allowed tool for this runtime role.",
+            ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
+          }
+        })
+      });
+      const staleReplacementInnerTool = new RecordingTool("edit");
+      const staleAllowReplacement = wrapToolWithPolicyGate(staleReplacementInnerTool, {
+        evaluate: async () => ({ decision: "allow" })
+      });
+
+      expect(() => registry.register(staleAllowReplacement)).not.toThrow();
+      const registeredReplacement = registry.get("edit");
+      expect(registeredReplacement).not.toBe(staleAllowReplacement);
+      expect(isPolicyGatedTool(registeredReplacement!)).toBe(true);
+
+      const result = await registeredReplacement?.run(fixture.context, {});
+
+      expect(result?.success).toBe(false);
+      expect(result?.output).toContain("policy_gate_denied");
+      expect(result?.output).toContain("runtime-owned-deny");
+      expect(staleReplacementInnerTool.calls).toBe(0);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
 });
 
 class RecordingTool extends BaseTool {
@@ -5191,6 +5353,25 @@ class RecordingTool extends BaseTool {
       success: true,
       output: `${this.name} executed`,
       outputSummary: `${this.name} executed`
+    };
+  }
+}
+
+class DivergentDefinitionTool extends RecordingTool {
+  constructor(
+    name: string,
+    private readonly definitionName: string,
+    private readonly definitionDescription: string
+  ) {
+    super(name);
+  }
+
+  override toDefinition(): ToolDefinition {
+    return {
+      ...super.toDefinition(),
+      name: this.definitionName,
+      description: this.definitionDescription,
+      parameters: { leaked: true }
     };
   }
 }

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -2171,6 +2171,110 @@ describe("policy-gated zero tool registry", () => {
     expect(Object.isFrozen(registered.requiredModelCapabilities)).toBe(true);
   });
 
+  test("factory-returned registry rejects exposed wrapper authority shadowing", async () => {
+    const tool = new RecordingTool("generic.wrapper.authority");
+    const originalDescription = tool.description;
+    const originalParameters = tool.parameters;
+    const replacementInnerTool = new RecordingTool("generic.wrapper.shadow.inner");
+    const shadowParameters = {
+      type: "object",
+      properties: {
+        leaked: {
+          type: "boolean"
+        }
+      },
+      additionalProperties: false
+    };
+    let evaluatorCalls = 0;
+    const registry = createPolicyGatedToolRegistry([tool], {
+      evaluate: async (call) => {
+        evaluatorCalls += 1;
+        if ((call.input as { blocked?: unknown }).blocked === true) {
+          return {
+            decision: "deny",
+            ruleId: "registry-owned-deny",
+            reason: "blocked by registry-owned evaluator",
+            remediation: {
+              next_action: "adjust_scope",
+              hint: "Use a registry-authorized input.",
+              ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+            }
+          };
+        }
+        return { decision: "allow" };
+      }
+    });
+
+    const registered = registry.get("generic.wrapper.authority");
+    expect(registered).toBeDefined();
+    if (!registered) {
+      throw new Error("generic.wrapper.authority should be registered");
+    }
+    const listed = registry
+      .list()
+      .find((candidate) => candidate.name === "generic.wrapper.authority");
+    expect(listed).toBe(registered);
+
+    attemptRegisteredWrapperAuthorityMutation(registered, {
+      name: "generic.wrapper.shadowed",
+      description: "Shadowed description without governance sections.",
+      parameters: shadowParameters,
+      innerTool: replacementInnerTool,
+      policyGateToolId: "spawn_agent",
+      options: {
+        evaluate: async () => ({ decision: "allow" }),
+        validateExecutionInput: () => ({
+          decision: "deny",
+          ruleId: "shadow-validator-deny",
+          reason: "shadow validator should not run",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "This mutated validator must not control execution.",
+            ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+          }
+        })
+      }
+    });
+
+    expectWrapperAuthorityPropertiesHardened(registered);
+    expect(registered.name).toBe("generic.wrapper.authority");
+    expect(registered.description).toBe(originalDescription);
+    expect(registered.parameters).toEqual(originalParameters);
+    expect(registered.parameters).not.toBe(originalParameters);
+    expect(isPolicyGatedTool(registered) && registered.innerTool).toBe(tool);
+    expect(isPolicyGatedTool(registered) && registered.policyGateToolId).toBe(
+      "generic.wrapper.authority"
+    );
+    expect((registered as unknown as { options?: unknown }).options).toBeUndefined();
+
+    const definition = registry
+      .getDefinitions()
+      .find((candidate) => candidate.name === "generic.wrapper.authority");
+    expect(definition?.name).toBe("generic.wrapper.authority");
+    expect(definition?.description).toBe(originalDescription);
+    expect(definition?.parameters).toEqual(originalParameters);
+    expect(definition?.parameters).not.toEqual(shadowParameters);
+    expect(registry.get("generic.wrapper.shadowed")).toBeUndefined();
+    expect(registry.getDefinitions().map((candidate) => candidate.name)).not.toContain(
+      "generic.wrapper.shadowed"
+    );
+
+    const denied = await registered.run(createToolContext("worker"), { blocked: true });
+    expect(denied.success).toBe(false);
+    expect(denied.output).toContain("registry-owned-deny");
+
+    const allowed = await registered.run(createToolContext("worker"), { blocked: false });
+    expect(allowed).toEqual({
+      success: true,
+      output: "generic.wrapper.authority executed",
+      outputSummary: "generic.wrapper.authority executed"
+    });
+    expect(evaluatorCalls).toBe(2);
+    expect(tool.calls).toBe(1);
+    expect(tool.lastInput).toEqual({ blocked: false });
+    expect(replacementInnerTool.calls).toBe(0);
+  });
+
   test("generic registry lint rejects the 21st visible tool without a role", () => {
     const tools = Array.from({ length: 21 }, (_, index) => new RecordingTool(`generic.${index}`));
 
@@ -2627,6 +2731,61 @@ describe("policy-gated zero tool registry", () => {
       "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定"
     );
     expect(PolicyGateRemediationSchema.safeParse(payload.remediation).success).toBe(true);
+    expect(evaluatorCalls).toBe(1);
+    expect(zodTool.calls).toBe(0);
+  });
+
+  test("wrapped Zod schema validation ignores retained safeParse monkey-patches", async () => {
+    const schema = z.object({
+      command: z.string()
+    });
+    const zodTool = new ZodRecordingTool("zod.safeparse.patch.wrap", schema);
+    let evaluatorCalls = 0;
+    const wrapped = wrapToolWithPolicyGate(zodTool, {
+      evaluate: async () => {
+        evaluatorCalls += 1;
+        return { decision: "allow" };
+      }
+    });
+
+    monkeyPatchZodSafeParseToAccept(schema, {
+      command: "patched-valid"
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), {
+      command: 42
+    });
+
+    expectToolParameterSchemaValidationDenial(result);
+    expect(evaluatorCalls).toBe(1);
+    expect(zodTool.calls).toBe(0);
+  });
+
+  test("factory-returned registry Zod validation ignores retained safeParse monkey-patches", async () => {
+    const schema = z.object({
+      command: z.string()
+    });
+    const zodTool = new ZodRecordingTool("zod.safeparse.patch.registry", schema);
+    let evaluatorCalls = 0;
+    const registry = createPolicyGatedToolRegistry([zodTool], {
+      evaluate: async () => {
+        evaluatorCalls += 1;
+        return { decision: "allow" };
+      }
+    });
+
+    monkeyPatchZodSafeParseToAccept(schema, {
+      command: "patched-valid"
+    });
+
+    const result = await registry.get("zod.safeparse.patch.registry")?.run(
+      createToolContext("worker"),
+      {
+        command: 42
+      }
+    );
+
+    expectToolParameterSchemaValidationDenial(result);
     expect(evaluatorCalls).toBe(1);
     expect(zodTool.calls).toBe(0);
   });
@@ -5445,6 +5604,77 @@ describe("policy-gated zero tool registry", () => {
     }
   });
 
+  test("SHUD runtime registry rejects model-visible wrapper shadowing", async () => {
+    const fixture = await createRawFixture();
+    try {
+      const edit = new RecordingTool("edit");
+      const originalDescription = edit.description;
+      const originalParameters = edit.parameters;
+      const replacementInnerTool = new RecordingTool("edit.shadow.inner");
+      const shadowParameters = {
+        type: "object",
+        properties: {
+          leaked: {
+            type: "boolean"
+          }
+        },
+        additionalProperties: false
+      };
+      const registry = createShudRuntimeToolRegistry({
+        tools: [edit],
+        protectedRawPaths: [fixture.rawRoot],
+        allowedWriteRoots: [fixture.root],
+        tempRoot: fixture.tempRoot,
+        profileRoot: fixture.profileRoot,
+        fuseRules: []
+      });
+
+      const registered = registry.get("edit");
+      expect(registered).toBeDefined();
+      if (!registered) {
+        throw new Error("edit should be registered in the SHUD runtime registry");
+      }
+
+      attemptRegisteredWrapperAuthorityMutation(registered, {
+        name: "edit.shadowed",
+        description: "Shadowed runtime description without governance sections.",
+        parameters: shadowParameters,
+        innerTool: replacementInnerTool,
+        policyGateToolId: "spawn_agent",
+        options: {
+          evaluate: async () => ({ decision: "allow" })
+        }
+      });
+
+      expectWrapperAuthorityPropertiesHardened(registered);
+      const listed = registry.list().find((candidate) => candidate.name === "edit");
+      const definition = registry.getDefinitions().find((candidate) => candidate.name === "edit");
+      expect(listed).toBe(registered);
+      expect(registered.name).toBe("edit");
+      expect(registered.description).toBe(originalDescription);
+      expect(registered.parameters).toEqual(originalParameters);
+      expect(definition?.name).toBe("edit");
+      expect(definition?.description).toBe(originalDescription);
+      expect(definition?.parameters).toEqual(originalParameters);
+      expect(definition?.parameters).not.toEqual(shadowParameters);
+      expect(registry.get("edit.shadowed")).toBeUndefined();
+      expect(registry.getDefinitions().map((candidate) => candidate.name)).not.toContain(
+        "edit.shadowed"
+      );
+
+      const result = await registered.run(fixture.context, {});
+      expect(result).toEqual({
+        success: true,
+        output: "edit executed",
+        outputSummary: "edit executed"
+      });
+      expect(edit.calls).toBe(1);
+      expect(replacementInnerTool.calls).toBe(0);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   test("SHUD runtime rewraps prewrapped tools with the current evaluator", async () => {
     const fixture = await createRawFixture();
     try {
@@ -5619,6 +5849,105 @@ function attemptRegisteredWrapperFieldMutation(
   }
 }
 
+function attemptRegisteredWrapperAuthorityMutation(
+  tool: BaseTool,
+  replacement: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+    innerTool: BaseTool;
+    policyGateToolId: string;
+    options: Record<string, unknown>;
+  }
+): void {
+  const mutableTool = tool as BaseTool & {
+    innerTool?: BaseTool;
+    policyGateToolId?: string;
+    options?: unknown;
+  };
+  const exposedOptions = mutableTool.options;
+  if (exposedOptions !== null && typeof exposedOptions === "object") {
+    const mutableOptions = exposedOptions as Record<string, unknown>;
+    attemptMutation(() => {
+      mutableOptions.evaluate = replacement.options.evaluate;
+    });
+    attemptMutation(() => {
+      Object.defineProperty(mutableOptions, "evaluate", {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: replacement.options.evaluate
+      });
+    });
+  }
+
+  const replacements: Record<string, unknown> = {
+    name: replacement.name,
+    description: replacement.description,
+    parameters: replacement.parameters,
+    innerTool: replacement.innerTool,
+    policyGateToolId: replacement.policyGateToolId,
+    options: replacement.options
+  };
+
+  for (const [field, value] of Object.entries(replacements)) {
+    attemptMutation(() => {
+      (mutableTool as unknown as Record<string, unknown>)[field] = value;
+    });
+    attemptMutation(() => {
+      Object.defineProperty(mutableTool, field, {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value
+      });
+    });
+  }
+}
+
+function expectWrapperAuthorityPropertiesHardened(tool: BaseTool): void {
+  expect(Object.isExtensible(tool)).toBe(false);
+  for (const field of [
+    "name",
+    "description",
+    "parameters",
+    "innerTool",
+    "policyGateToolId"
+  ] as const) {
+    const descriptor = Object.getOwnPropertyDescriptor(tool, field);
+    expect(descriptor).toBeDefined();
+    if (!descriptor || !("get" in descriptor)) {
+      throw new Error(`${field} should be a hardened accessor property`);
+    }
+    expect(descriptor.configurable).toBe(false);
+    expect(descriptor.set).toBeUndefined();
+  }
+  for (const field of ["kind", "requiredModelCapabilities"] as const) {
+    const descriptor = Object.getOwnPropertyDescriptor(tool, field);
+    expect(descriptor).toBeDefined();
+    if (!descriptor || !("writable" in descriptor)) {
+      throw new Error(`${field} should be a hardened data property`);
+    }
+    expect(descriptor.configurable).toBe(false);
+    expect(descriptor.writable).toBe(false);
+  }
+  expect(Object.prototype.hasOwnProperty.call(tool, "options")).toBe(false);
+}
+
+function monkeyPatchZodSafeParseToAccept(schema: unknown, data: unknown): void {
+  const mutableSchema = schema as {
+    safeParse(input: unknown): unknown;
+  };
+  mutableSchema.safeParse = () => ({
+    success: true,
+    data
+  });
+  expect(mutableSchema.safeParse({ command: 42 })).toEqual({
+    success: true,
+    data
+  });
+}
+
 function createCompleteToolDescription(name: string): string {
   return [
     `何时该用: Use ${name} when a test needs a policy-gated tool fixture.`,
@@ -5776,6 +6105,31 @@ function expectOuterRawRuleMisconfiguration(result: ToolResult | undefined): voi
   expect(payload.profile_path).toBeUndefined();
   expect(payload.remediation?.next_action).toBe("fix_and_retry");
   expect(payload.remediation?.hint).toContain("RawDataSandboxedBashTool");
+  expect(PolicyGateRemediationSchema.safeParse(payload.remediation).success).toBe(true);
+}
+
+function expectToolParameterSchemaValidationDenial(result: ToolResult | undefined): void {
+  expect(result?.success).toBe(false);
+  expect(result?.output).toContain("policy_gate_denied");
+  expect(result?.output).toContain("tool-parameter-schema-validation");
+  const payload = JSON.parse(result?.output ?? "{}") as {
+    error?: string;
+    ruleId?: string;
+    reason?: string;
+    remediation?: {
+      next_action?: string;
+      hint?: string;
+      ref?: string;
+    };
+  };
+  expect(payload.error).toBe("policy_gate_denied");
+  expect(payload.ruleId).toBe("tool-parameter-schema-validation");
+  expect(payload.reason).toContain("command");
+  expect(payload.remediation?.next_action).toBe("fix_and_retry");
+  expect(payload.remediation?.hint).toContain("Zod parameter schema");
+  expect(payload.remediation?.ref).toBe(
+    "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定"
+  );
   expect(PolicyGateRemediationSchema.safeParse(payload.remediation).success).toBe(true);
 }
 

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -2071,7 +2071,8 @@ describe("policy-gated zero tool registry", () => {
     expect(definition?.name).toBe("generic.definition");
     expect(definition?.description).toBe(tool.description);
     expect(definition?.description).toContain("何时该用:");
-    expect(definition?.parameters).toBe(tool.parameters);
+    expect(definition?.parameters).toEqual(tool.parameters);
+    expect(definition?.parameters).not.toBe(tool.parameters);
     expect(definition?.parameters).not.toEqual({ leaked: true });
 
     const replacement = new DivergentDefinitionTool(
@@ -2091,7 +2092,48 @@ describe("policy-gated zero tool registry", () => {
     expect(definition?.name).toBe("generic.definition");
     expect(definition?.description).toBe(replacement.description);
     expect(definition?.description).toContain("何时不该用:");
-    expect(definition?.parameters).toBe(replacement.parameters);
+    expect(definition?.parameters).toEqual(replacement.parameters);
+    expect(definition?.parameters).not.toBe(replacement.parameters);
+  });
+
+  test("factory-returned registry snapshots metadata against retained inner tool mutation", () => {
+    const tool = new RecordingTool("generic.snapshot");
+    const originalName = tool.name;
+    const originalDescription = tool.description;
+    const originalParameters = tool.parameters;
+    const leakedParameters = {
+      type: "object",
+      properties: {
+        leaked: {
+          type: "string"
+        }
+      },
+      additionalProperties: false
+    };
+    const registry = createPolicyGatedToolRegistry([tool], {
+      evaluate: async () => ({ decision: "allow" })
+    });
+
+    (tool as unknown as { name: string }).name = "generic.snapshot.leaked";
+    tool.description = "何时该用: This mutated description intentionally drops governance sections.";
+    tool.parameters = leakedParameters;
+
+    const definitions = registry.getDefinitions();
+    const definition = definitions.find((candidate) => candidate.name === originalName);
+
+    expect(registry.get(originalName)).toBeDefined();
+    expect(registry.get("generic.snapshot.leaked")).toBeUndefined();
+    expect(definition).toBeDefined();
+    expect(definition?.name).toBe(originalName);
+    expect(definition?.description).toBe(originalDescription);
+    expect(definition?.description).toContain("何时该用:");
+    expect(definition?.description).toContain("何时不该用:");
+    expect(definition?.description).toContain("成功与失败样态:");
+    expect(definition?.description).not.toContain("mutated description");
+    expect(definition?.parameters).toEqual(originalParameters);
+    expect(definition?.parameters).not.toBe(originalParameters);
+    expect(definition?.parameters).not.toEqual(leakedParameters);
+    expect(definitions.map((candidate) => candidate.name)).not.toContain("generic.snapshot.leaked");
   });
 
   test("generic registry lint rejects the 21st visible tool without a role", () => {
@@ -2170,6 +2212,33 @@ describe("policy-gated zero tool registry", () => {
     }
     expect(registeredReplacement.innerTool).toBe(replacementInnerTool);
     expect(() => assertPolicyGatedToolRegistry(registry, { role: "worker" })).not.toThrow();
+
+    const originalReplacementDescription = replacementInnerTool.description;
+    const originalReplacementParameters = replacementInnerTool.parameters;
+    const leakedReplacementParameters = {
+      type: "object",
+      properties: {
+        replacementLeak: {
+          type: "boolean"
+        }
+      },
+      additionalProperties: false
+    };
+    (replacementInnerTool as unknown as { name: string }).name = "generic.19.leaked";
+    replacementInnerTool.description = "何时该用: Replacement mutation drops required sections.";
+    replacementInnerTool.parameters = leakedReplacementParameters;
+
+    const replacementDefinition = registry
+      .getDefinitions()
+      .find((candidate) => candidate.name === "generic.19");
+    expect(registry.get("generic.19")).toBe(registeredReplacement);
+    expect(registry.get("generic.19.leaked")).toBeUndefined();
+    expect(replacementDefinition?.name).toBe("generic.19");
+    expect(replacementDefinition?.description).toBe(originalReplacementDescription);
+    expect(replacementDefinition?.description).toContain("何时不该用:");
+    expect(replacementDefinition?.parameters).toEqual(originalReplacementParameters);
+    expect(replacementDefinition?.parameters).not.toBe(originalReplacementParameters);
+    expect(replacementDefinition?.parameters).not.toEqual(leakedReplacementParameters);
   });
 
   test("factory-returned registry rewraps stale post-return replacements with current evaluator", async () => {
@@ -2476,6 +2545,55 @@ describe("policy-gated zero tool registry", () => {
       success: false,
       outputSummary: result.outputSummary
     });
+  });
+
+  test("factory-returned registry snapshots Zod schema carrier against retained inner mutation", async () => {
+    const zodTool = new ZodRecordingTool(
+      "zod.schema.snapshot",
+      z.object({
+        command: z.string()
+      })
+    );
+    let evaluatorCalls = 0;
+    const registry = createPolicyGatedToolRegistry([zodTool], {
+      evaluate: async () => {
+        evaluatorCalls += 1;
+        return { decision: "allow" };
+      }
+    });
+
+    (zodTool as unknown as { parameterSchema: unknown }).parameterSchema = z.object({
+      command: z.unknown()
+    });
+
+    const result = await registry.get("zod.schema.snapshot")?.run(createToolContext("worker"), {
+      command: 42
+    });
+
+    expect(result?.success).toBe(false);
+    expect(result?.output).toContain("policy_gate_denied");
+    expect(result?.output).toContain("tool-parameter-schema-validation");
+    const payload = JSON.parse(result?.output ?? "{}") as {
+      error?: string;
+      ruleId?: string;
+      reason?: string;
+      remediation?: {
+        next_action?: string;
+        hint?: string;
+        ref?: string;
+      };
+    };
+    expect(payload.error).toBe("policy_gate_denied");
+    expect(payload.ruleId).toBe("tool-parameter-schema-validation");
+    expect(payload.reason).toContain("command");
+    expect(payload.remediation?.next_action).toBe("fix_and_retry");
+    expect(payload.remediation?.hint).toContain("Zod parameter schema");
+    expect(payload.remediation?.ref).toBe(
+      "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定"
+    );
+    expect(PolicyGateRemediationSchema.safeParse(payload.remediation).success).toBe(true);
+    expect(evaluatorCalls).toBe(1);
+    expect(zodTool.calls).toBe(0);
   });
 
   test("Zod parameter schema rejection survives a throwing evaluator", async () => {

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -3,7 +3,14 @@ import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { BaseTool, BashTool, SpawnAgentTool, ToolRegistry } from "@zero-os/core";
+import {
+  BaseTool,
+  BashTool,
+  ReadTool,
+  SpawnAgentTool,
+  ToolRegistry,
+  WaitAgentTool
+} from "@zero-os/core";
 import type {
   FuseRule,
   RunningToolHandle,
@@ -30,6 +37,7 @@ import {
   createShudRuntimeToolRegistry,
   createShudSandboxedBashTool,
   isPolicyGatedTool,
+  wrapAllRegisteredTools,
   wrapToolWithPolicyGate
 } from "./policy-gate-registry";
 import {
@@ -2043,6 +2051,32 @@ describe("policy-gated zero tool registry", () => {
     expect(tools.map((tool) => tool.calls)).toEqual([1, 1, 1]);
   });
 
+  test("generic registry lint rejects the 21st visible tool without a role", () => {
+    const tools = Array.from({ length: 21 }, (_, index) => new RecordingTool(`generic.${index}`));
+
+    expect(() =>
+      createPolicyGatedToolRegistry(tools, {
+        evaluate: async () => ({ decision: "allow" })
+      })
+    ).toThrow(
+      /Policy-gated tool registration lint failed for role unknown-role: visible tool count 21 exceeds 20; excess count 1/
+    );
+  });
+
+  test("generic wrap seam rejects descriptions missing required section headings", () => {
+    const badTool = new RecordingTool("generic.bad.description");
+    badTool.description = [
+      "何时该用: Use this fixture for generic wrap lint.",
+      "成功与失败样态: Success returns a fixture result."
+    ].join("\n");
+
+    expect(() =>
+      wrapAllRegisteredTools([badTool], {
+        evaluate: async () => ({ decision: "allow" })
+      })
+    ).toThrow(/generic\.bad\.description: missing 何时不该用/);
+  });
+
   test("direct spawn wrapper executes only sanitized spawn input", async () => {
     const spawnTool = new RecordingTool("spawn_agent");
     const tailSentinel = "ignored-tail-sentinel-that-must-not-appear";
@@ -2098,6 +2132,36 @@ describe("policy-gated zero tool registry", () => {
     );
   });
 
+  test("SHUD runtime assembly rejects the 21st visible tool when role is omitted", () => {
+    const tools = Array.from({ length: 19 }, (_, index) => new RecordingTool(`extra.${index}`));
+
+    expect(() =>
+      createShudRuntimeToolRegistry(
+        createMinimalShudRuntimeRegistryOptions({
+          tools
+        })
+      )
+    ).toThrow(
+      /Policy-gated tool registration lint failed for role unknown-role: visible tool count 21 exceeds 20; excess count 1/
+    );
+  });
+
+  test("SHUD runtime adapts real Zero native tool descriptions before strict lint", () => {
+    const registry = createShudRuntimeToolRegistry(
+      createMinimalShudRuntimeRegistryOptions({
+        tools: [new ReadTool(), new WaitAgentTool()]
+      })
+    );
+
+    assertPolicyGatedToolRegistry(registry);
+    for (const toolId of ["read", "wait_agent"] as const) {
+      const definition = registry.getDefinitions().find((candidate) => candidate.name === toolId);
+      expect(definition?.description).toContain("何时该用:");
+      expect(definition?.description).toContain("何时不该用:");
+      expect(definition?.description).toContain("成功与失败样态:");
+    }
+  });
+
   test("SHUD runtime assembly rejects tool descriptions missing required sections", () => {
     const badTool = new RecordingTool("bad.description");
     badTool.description = [
@@ -2112,6 +2176,53 @@ describe("policy-gated zero tool registry", () => {
         })
       )
     ).toThrow(/bad\.description: missing 何时不该用/);
+  });
+
+  test("description lint rejects section labels without bodies", () => {
+    const badTool = new RecordingTool("bad.empty.sections");
+    badTool.description = ["何时该用:", "何时不该用:", "成功与失败样态:"].join("\n");
+
+    expect(() =>
+      createShudRuntimeToolRegistry(
+        createMinimalShudRuntimeRegistryOptions({
+          tools: [badTool]
+        })
+      )
+    ).toThrow(/bad\.empty\.sections: empty 何时该用, 何时不该用, 成功与失败样态/);
+  });
+
+  test("description lint rejects mid-sentence section-label stuffing", () => {
+    const badTool = new RecordingTool("bad.stuffed.sections");
+    badTool.description =
+      "This sentence mentions 何时该用, 何时不该用, and 成功与失败样态 without section headings.";
+
+    expect(() =>
+      createShudRuntimeToolRegistry(
+        createMinimalShudRuntimeRegistryOptions({
+          tools: [badTool]
+        })
+      )
+    ).toThrow(/bad\.stuffed\.sections: missing 何时该用, 何时不该用, 成功与失败样态/);
+  });
+
+  test("description lint accepts multiline section bodies", () => {
+    const tool = new RecordingTool("good.multiline.description");
+    tool.description = [
+      "何时该用:",
+      "Use this fixture when the body is on the next line.",
+      "何时不该用：",
+      "Do not use it as a real tool.",
+      "成功与失败样态:",
+      "Success assembles the registry; failure belongs to the lint harness."
+    ].join("\n");
+
+    expect(() =>
+      createShudRuntimeToolRegistry(
+        createMinimalShudRuntimeRegistryOptions({
+          tools: [tool]
+        })
+      )
+    ).not.toThrow();
   });
 
   test("Zod parameter schema rejection finalizes without executing the inner tool", async () => {
@@ -2168,7 +2279,7 @@ describe("policy-gated zero tool registry", () => {
       "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定"
     );
     expect(PolicyGateRemediationSchema.safeParse(payload.remediation).success).toBe(true);
-    expect(evaluatorCalls).toBe(0);
+    expect(evaluatorCalls).toBe(1);
     expect(zodTool.calls).toBe(0);
     expect(handle.getState()).toBe("finished");
     expect(handle.getTerminalMetadata()).toMatchObject({
@@ -2176,6 +2287,81 @@ describe("policy-gated zero tool registry", () => {
       success: false,
       outputSummary: result.outputSummary
     });
+  });
+
+  test("policy evaluator denial wins before invalid Zod schema details", async () => {
+    const zodTool = new ZodRecordingTool(
+      "zod.denied.first",
+      z.object({
+        command: z.string()
+      })
+    );
+    let evaluatorCalls = 0;
+    const wrapped = wrapToolWithPolicyGate(zodTool, {
+      evaluate: async () => {
+        evaluatorCalls += 1;
+        return {
+          decision: "deny",
+          ruleId: "authorization-deny",
+          reason: "role is not authorized for this tool",
+          remediation: {
+            next_action: "adjust_scope",
+            hint: "Use a tool allowed for this role.",
+            ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+          }
+        };
+      }
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), {
+      command: 42
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("authorization-deny");
+    expect(result.output).not.toContain("tool-parameter-schema-validation");
+    expect(result.output).not.toContain("Expected string");
+    expect(evaluatorCalls).toBe(1);
+    expect(zodTool.calls).toBe(0);
+  });
+
+  test("valid Zod path runs evaluator once and executes with parsed input", async () => {
+    const zodTool = new ZodRecordingTool(
+      "zod.valid.parsed",
+      z.object({
+        count: z.coerce.number().default(1).transform((value) => value + 1),
+        label: z.string().default("default-label")
+      })
+    );
+    let evaluatorCalls = 0;
+    let validatorInput: unknown;
+    const wrapped = wrapToolWithPolicyGate(zodTool, {
+      evaluate: async () => {
+        evaluatorCalls += 1;
+        return { decision: "allow" };
+      },
+      validateExecutionInput: (input) => {
+        validatorInput = input;
+        return undefined;
+      }
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), {
+      count: "4"
+    });
+
+    expect(result).toEqual({
+      success: true,
+      output: "zod.valid.parsed executed",
+      outputSummary: "zod.valid.parsed executed"
+    });
+    expect(evaluatorCalls).toBe(1);
+    expect(zodTool.calls).toBe(1);
+    expect(zodTool.lastInput).toEqual({
+      count: 5,
+      label: "default-label"
+    });
+    expect(validatorInput).toBe(zodTool.lastInput);
   });
 
   test("assembly fails when any registered zero tool bypasses the wrapper", () => {

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -6,10 +6,12 @@ import { join } from "node:path";
 import {
   BaseTool,
   BashTool,
+  EditTool,
   ReadTool,
   SpawnAgentTool,
   ToolRegistry,
-  WaitAgentTool
+  WaitAgentTool,
+  WriteTool
 } from "@zero-os/core";
 import type {
   FuseRule,
@@ -2149,12 +2151,12 @@ describe("policy-gated zero tool registry", () => {
   test("SHUD runtime adapts real Zero native tool descriptions before strict lint", () => {
     const registry = createShudRuntimeToolRegistry(
       createMinimalShudRuntimeRegistryOptions({
-        tools: [new ReadTool(), new WaitAgentTool()]
+        tools: [new ReadTool(), new WriteTool(), new EditTool(), new WaitAgentTool()]
       })
     );
 
     assertPolicyGatedToolRegistry(registry);
-    for (const toolId of ["read", "wait_agent"] as const) {
+    for (const toolId of ["read", "write", "edit", "wait_agent"] as const) {
       const definition = registry.getDefinitions().find((candidate) => candidate.name === toolId);
       expect(definition?.description).toContain("何时该用:");
       expect(definition?.description).toContain("何时不该用:");
@@ -2223,6 +2225,43 @@ describe("policy-gated zero tool registry", () => {
         })
       )
     ).not.toThrow();
+  });
+
+  test("manual registry assertion rejects direct-wrapped tools above the visible count limit", () => {
+    const registry = new ToolRegistry();
+    const tools = Array.from(
+      { length: 21 },
+      (_, index) => new RecordingTool(`manual.${index}`)
+    );
+    for (const tool of tools) {
+      registry.register(
+        wrapToolWithPolicyGate(tool, {
+          evaluate: async () => ({ decision: "allow" })
+        })
+      );
+    }
+
+    expect(() => assertPolicyGatedToolRegistry(registry, { role: "worker" })).toThrow(
+      /Policy-gated tool registration lint failed for role worker: visible tool count 21 exceeds 20; excess count 1/
+    );
+  });
+
+  test("manual registry assertion rejects direct-wrapped tools with bad descriptions", () => {
+    const badTool = new RecordingTool("manual.bad.description");
+    badTool.description = [
+      "何时该用: Use this fixture for manual registry lint.",
+      "成功与失败样态: Success should never pass final registry validation."
+    ].join("\n");
+    const registry = new ToolRegistry();
+    registry.register(
+      wrapToolWithPolicyGate(badTool, {
+        evaluate: async () => ({ decision: "allow" })
+      })
+    );
+
+    expect(() => assertPolicyGatedToolRegistry(registry)).toThrow(
+      /manual\.bad\.description: missing 何时不该用/
+    );
   });
 
   test("Zod parameter schema rejection finalizes without executing the inner tool", async () => {
@@ -2334,10 +2373,12 @@ describe("policy-gated zero tool registry", () => {
       })
     );
     let evaluatorCalls = 0;
+    let evaluatorInput: unknown;
     let validatorInput: unknown;
     const wrapped = wrapToolWithPolicyGate(zodTool, {
-      evaluate: async () => {
+      evaluate: async (call) => {
         evaluatorCalls += 1;
+        evaluatorInput = call.input;
         return { decision: "allow" };
       },
       validateExecutionInput: (input) => {
@@ -2361,7 +2402,54 @@ describe("policy-gated zero tool registry", () => {
       count: 5,
       label: "default-label"
     });
+    expect(evaluatorInput).toEqual(zodTool.lastInput);
     expect(validatorInput).toBe(zodTool.lastInput);
+  });
+
+  test("valid Zod parsed-only values can be denied by the evaluator", async () => {
+    const zodTool = new ZodRecordingTool(
+      "zod.parsed.denied",
+      z.object({
+        count: z.coerce.number().default(1).transform((value) => value + 1),
+        label: z.string().default("default-label")
+      })
+    );
+    let evaluatorInput: unknown;
+    const wrapped = wrapToolWithPolicyGate(zodTool, {
+      evaluate: async (call) => {
+        evaluatorInput = call.input;
+        const input = call.input as { count?: unknown; label?: unknown };
+        if (input.count === 5 && input.label === "default-label") {
+          return {
+            decision: "deny",
+            ruleId: "parsed-zod-deny",
+            reason: "parsed count crossed the evaluator threshold",
+            remediation: {
+              next_action: "adjust_scope",
+              hint: "Lower the parsed count before retrying.",
+              ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+            }
+          };
+        }
+        return { decision: "allow" };
+      },
+      validateExecutionInput: () => {
+        throw new Error("validator must not run after evaluator denial");
+      }
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), {
+      count: "4"
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("parsed-zod-deny");
+    expect(result.output).toContain("parsed count crossed the evaluator threshold");
+    expect(evaluatorInput).toEqual({
+      count: 5,
+      label: "default-label"
+    });
+    expect(zodTool.calls).toBe(0);
   });
 
   test("assembly fails when any registered zero tool bypasses the wrapper", () => {

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -2411,6 +2411,116 @@ describe("policy-gated zero tool registry", () => {
     expect(staleReplacementInnerTool.calls).toBe(0);
   });
 
+  test("factory-returned registry keeps evaluator authority after visible options mutation", async () => {
+    const registry = createPolicyGatedToolRegistry([new RecordingTool("generic.authority")], {
+      evaluate: async () => ({
+        decision: "deny",
+        ruleId: "registry-owned-deny",
+        reason: "blocked by registry-owned evaluator",
+        remediation: {
+          next_action: "adjust_scope",
+          hint: "Use a registry-authorized input.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        }
+      })
+    });
+    const fakeOptions = {
+      evaluate: async () => ({ decision: "allow" as const })
+    };
+    const mutableRegistry = registry as unknown as {
+      options?: typeof fakeOptions;
+    };
+
+    if (mutableRegistry.options && typeof mutableRegistry.options === "object") {
+      attemptMutation(() => {
+        mutableRegistry.options!.evaluate = fakeOptions.evaluate;
+      });
+    }
+    attemptMutation(() => {
+      mutableRegistry.options = fakeOptions;
+    });
+    attemptMutation(() => {
+      Object.defineProperty(mutableRegistry, "options", {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: fakeOptions
+      });
+    });
+
+    const replacementTool = new RecordingTool("generic.authority");
+    expect(() => registry.register(replacementTool)).not.toThrow();
+    const registeredReplacement = registry.get("generic.authority");
+    expect(isPolicyGatedTool(registeredReplacement!)).toBe(true);
+    expect(isPolicyGatedTool(registeredReplacement!) && registeredReplacement.innerTool).toBe(
+      replacementTool
+    );
+    expect((registry as unknown as { options?: unknown }).options).toBeUndefined();
+
+    const result = await registeredReplacement?.run(createToolContext("worker"), {});
+
+    expect(result?.success).toBe(false);
+    expect(result?.output).toContain("policy_gate_denied");
+    expect(result?.output).toContain("registry-owned-deny");
+    expect(replacementTool.calls).toBe(0);
+  });
+
+  test("factory-returned registry public methods ignore inherited tools map mutation", async () => {
+    const originalTool = new RecordingTool("generic.tools.authority");
+    const registry = createPolicyGatedToolRegistry([originalTool], {
+      evaluate: async () => ({
+        decision: "deny",
+        ruleId: "registry-owned-deny",
+        reason: "blocked by registry-owned evaluator",
+        remediation: {
+          next_action: "adjust_scope",
+          hint: "Use a registry-authorized input.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        }
+      })
+    });
+    const registeredTool = registry.get("generic.tools.authority");
+    const attackerTool = new RecordingTool("generic.tools.authority");
+    const injectedTool = new RecordingTool("generic.tools.injected");
+    const mutableRegistry = registry as unknown as {
+      tools?: Map<string, BaseTool>;
+    };
+
+    if (mutableRegistry.tools instanceof Map) {
+      mutableRegistry.tools.set("generic.tools.authority", attackerTool);
+      mutableRegistry.tools.set("generic.tools.injected", injectedTool);
+      mutableRegistry.tools.delete("generic.tools.authority");
+      mutableRegistry.tools.clear();
+    }
+    attemptMutation(() => {
+      mutableRegistry.tools = new Map([
+        ["generic.tools.authority", attackerTool],
+        ["generic.tools.injected", injectedTool]
+      ]);
+    });
+
+    expect(registry.get("generic.tools.authority")).toBe(registeredTool);
+    expect(registry.get("generic.tools.injected")).toBeUndefined();
+    expect(registry.has("generic.tools.authority")).toBe(true);
+    expect(registry.has("generic.tools.injected")).toBe(false);
+    expect(registry.list()).toEqual([registeredTool]);
+    expect(registry.getDefinitions().map((definition) => definition.name)).toEqual([
+      "generic.tools.authority"
+    ]);
+    expect(isPolicyGatedTool(registeredTool!)).toBe(true);
+
+    const result = await registry
+      .get("generic.tools.authority")
+      ?.run(createToolContext("worker"), {});
+
+    expect(result?.success).toBe(false);
+    expect(result?.output).toContain("policy_gate_denied");
+    expect(result?.output).toContain("registry-owned-deny");
+    expect(originalTool.calls).toBe(0);
+    expect(attackerTool.calls).toBe(0);
+    expect(injectedTool.calls).toBe(0);
+  });
+
   test("factory-returned registry wraps post-return unwrapped tool registration", () => {
     const registry = createPolicyGatedToolRegistry([new RecordingTool("generic.good")], {
       evaluate: async () => ({ decision: "allow" })
@@ -5752,6 +5862,66 @@ describe("policy-gated zero tool registry", () => {
       expect(result?.output).toContain("policy_gate_denied");
       expect(result?.output).toContain("runtime-owned-deny");
       expect(staleReplacementInnerTool.calls).toBe(0);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("SHUD runtime registry public methods ignore inherited tools map mutation for edit", async () => {
+    const fixture = await createRawFixture();
+    try {
+      const edit = new RecordingTool("edit");
+      const registry = createShudRuntimeToolRegistry({
+        tools: [edit],
+        protectedRawPaths: [fixture.rawRoot],
+        allowedWriteRoots: [fixture.root],
+        tempRoot: fixture.tempRoot,
+        profileRoot: fixture.profileRoot,
+        fuseRules: []
+      });
+      const registeredEdit = registry.get("edit");
+      if (!registeredEdit) {
+        throw new Error("edit should be registered in the SHUD runtime registry");
+      }
+      const attackerEdit = new RecordingTool("edit");
+      const injectedTool = new RecordingTool("runtime.injected");
+      const mutableRegistry = registry as unknown as {
+        tools?: Map<string, BaseTool>;
+      };
+
+      if (mutableRegistry.tools instanceof Map) {
+        mutableRegistry.tools.set("edit", attackerEdit);
+        mutableRegistry.tools.set("runtime.injected", injectedTool);
+        mutableRegistry.tools.delete("edit");
+        mutableRegistry.tools.clear();
+      }
+      attemptMutation(() => {
+        mutableRegistry.tools = new Map([
+          ["edit", attackerEdit],
+          ["runtime.injected", injectedTool]
+        ]);
+      });
+
+      expect(registry.get("edit")).toBe(registeredEdit);
+      expect(registry.get("runtime.injected")).toBeUndefined();
+      expect(registry.has("edit")).toBe(true);
+      expect(registry.has("runtime.injected")).toBe(false);
+      expect(registry.list().find((tool) => tool.name === "edit")).toBe(registeredEdit);
+      expect(
+        registry.getDefinitions().filter((definition) => definition.name === "edit")
+      ).toHaveLength(1);
+      expect(isPolicyGatedTool(registeredEdit)).toBe(true);
+
+      const result = await registry.get("edit")?.run(fixture.context, {});
+
+      expect(result).toEqual({
+        success: true,
+        output: "edit executed",
+        outputSummary: "edit executed"
+      });
+      expect(edit.calls).toBe(1);
+      expect(attackerEdit.calls).toBe(0);
+      expect(injectedTool.calls).toBe(0);
     } finally {
       await fixture.cleanup();
     }

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -2065,6 +2065,80 @@ describe("policy-gated zero tool registry", () => {
     );
   });
 
+  test("factory-returned registry rejects post-return 21st wrapped tool registration", () => {
+    const tools = Array.from({ length: 20 }, (_, index) => new RecordingTool(`generic.${index}`));
+    const registry = createPolicyGatedToolRegistry(tools, {
+      role: "worker",
+      evaluate: async () => ({ decision: "allow" })
+    });
+    const extraTool = wrapToolWithPolicyGate(new RecordingTool("generic.20"), {
+      evaluate: async () => ({ decision: "allow" })
+    });
+
+    expect(() => registry.register(extraTool)).toThrow(
+      /Policy-gated tool registration lint failed for role worker: visible tool count 21 exceeds 20; excess count 1/
+    );
+    expect(registry.get("generic.20")).toBeUndefined();
+    expect(registry.list().map((tool) => tool.name)).not.toContain("generic.20");
+    expect(registry.getDefinitions().map((definition) => definition.name)).not.toContain(
+      "generic.20"
+    );
+  });
+
+  test("factory-returned registry rejects post-return wrapped tools with bad descriptions", () => {
+    const registry = createPolicyGatedToolRegistry([new RecordingTool("generic.good")], {
+      evaluate: async () => ({ decision: "allow" })
+    });
+    const badTool = new RecordingTool("generic.bad.description");
+    badTool.description = [
+      "何时该用: Use this fixture for mutation-boundary description lint.",
+      "成功与失败样态: Success should never pass registry mutation validation."
+    ].join("\n");
+    const wrappedBadTool = wrapToolWithPolicyGate(badTool, {
+      evaluate: async () => ({ decision: "allow" })
+    });
+
+    expect(() => registry.register(wrappedBadTool)).toThrow(
+      /generic\.bad\.description: missing 何时不该用/
+    );
+    expect(registry.get("generic.bad.description")).toBeUndefined();
+    expect(registry.list().map((tool) => tool.name)).not.toContain("generic.bad.description");
+    expect(registry.getDefinitions().map((definition) => definition.name)).not.toContain(
+      "generic.bad.description"
+    );
+  });
+
+  test("factory-returned registry replacements use Zero same-name semantics without double-counting", () => {
+    const tools = Array.from({ length: 20 }, (_, index) => new RecordingTool(`generic.${index}`));
+    const registry = createPolicyGatedToolRegistry(tools, {
+      role: "worker",
+      evaluate: async () => ({ decision: "allow" })
+    });
+    const replacementTool = wrapToolWithPolicyGate(new RecordingTool("generic.19"), {
+      evaluate: async () => ({ decision: "allow" })
+    });
+
+    expect(() => registry.register(replacementTool)).not.toThrow();
+    expect(registry.list()).toHaveLength(20);
+    expect(registry.get("generic.19")).toBe(replacementTool);
+    expect(() => assertPolicyGatedToolRegistry(registry, { role: "worker" })).not.toThrow();
+  });
+
+  test("factory-returned registry rejects post-return unwrapped tool registration", () => {
+    const registry = createPolicyGatedToolRegistry([new RecordingTool("generic.good")], {
+      evaluate: async () => ({ decision: "allow" })
+    });
+
+    expect(() => registry.register(new RecordingTool("generic.unwrapped"))).toThrow(
+      /Policy-gated tool assembly failed; unwrapped tool ids: generic\.unwrapped/
+    );
+    expect(registry.get("generic.unwrapped")).toBeUndefined();
+    expect(registry.list().map((tool) => tool.name)).not.toContain("generic.unwrapped");
+    expect(registry.getDefinitions().map((definition) => definition.name)).not.toContain(
+      "generic.unwrapped"
+    );
+  });
+
   test("generic wrap seam rejects descriptions missing required section headings", () => {
     const badTool = new RecordingTool("generic.bad.description");
     badTool.description = [

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -2900,6 +2900,57 @@ describe("policy-gated zero tool registry", () => {
     expect(zodTool.calls).toBe(0);
   });
 
+  test("wrapped Zod schema validation ignores retained def shape mutation", async () => {
+    const schema = z.object({
+      command: z.string()
+    });
+    const zodTool = new ZodRecordingTool("zod.def.patch.wrap", schema);
+    let evaluatorCalls = 0;
+    const wrapped = wrapToolWithPolicyGate(zodTool, {
+      evaluate: async () => {
+        evaluatorCalls += 1;
+        return { decision: "allow" };
+      }
+    });
+
+    attemptZodCommandShapeMutationToAcceptNumber(schema);
+
+    const result = await wrapped.run(createToolContext("worker"), {
+      command: 42
+    });
+
+    expectToolParameterSchemaValidationDenial(result);
+    expect(evaluatorCalls).toBe(1);
+    expect(zodTool.calls).toBe(0);
+  });
+
+  test("factory-returned registry Zod validation ignores retained def shape mutation", async () => {
+    const schema = z.object({
+      command: z.string()
+    });
+    const zodTool = new ZodRecordingTool("zod.def.patch.registry", schema);
+    let evaluatorCalls = 0;
+    const registry = createPolicyGatedToolRegistry([zodTool], {
+      evaluate: async () => {
+        evaluatorCalls += 1;
+        return { decision: "allow" };
+      }
+    });
+
+    attemptZodCommandShapeMutationToAcceptNumber(schema);
+
+    const result = await registry.get("zod.def.patch.registry")?.run(
+      createToolContext("worker"),
+      {
+        command: 42
+      }
+    );
+
+    expectToolParameterSchemaValidationDenial(result);
+    expect(evaluatorCalls).toBe(1);
+    expect(zodTool.calls).toBe(0);
+  });
+
   test("Zod parameter schema rejection survives a throwing evaluator", async () => {
     const zodTool = new ZodRecordingTool(
       "zod.invalid.throwing.evaluator",
@@ -6108,14 +6159,58 @@ function monkeyPatchZodSafeParseToAccept(schema: unknown, data: unknown): void {
   const mutableSchema = schema as {
     safeParse(input: unknown): unknown;
   };
-  mutableSchema.safeParse = () => ({
+  const replacement = () => ({
     success: true,
     data
   });
-  expect(mutableSchema.safeParse({ command: 42 })).toEqual({
-    success: true,
-    data
+  const patched = attemptMutation(() => {
+    mutableSchema.safeParse = replacement;
   });
+  if (patched) {
+    expect(mutableSchema.safeParse({ command: 42 })).toEqual({
+      success: true,
+      data
+    });
+  }
+}
+
+function attemptZodCommandShapeMutationToAcceptNumber(schema: unknown): void {
+  const mutableSchema = schema as {
+    def?: unknown;
+    _def?: unknown;
+  };
+  let attemptedMutations = 0;
+
+  for (const def of [mutableSchema.def, mutableSchema._def]) {
+    if (!isRecordLike(def)) {
+      continue;
+    }
+
+    const shape = def.shape;
+    if (!isRecordLike(shape)) {
+      continue;
+    }
+
+    attemptedMutations += 1;
+    attemptMutation(() => {
+      shape.command = z.unknown();
+    });
+    attemptedMutations += 1;
+    attemptMutation(() => {
+      Object.defineProperty(shape, "command", {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: z.unknown()
+      });
+    });
+  }
+
+  expect(attemptedMutations).toBeGreaterThan(0);
+}
+
+function isRecordLike(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
 }
 
 function createCompleteToolDescription(name: string): string {

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -499,11 +499,14 @@ class ShudSpawnAgentTool extends SpawnAgentTool {
 }
 
 class LintEnforcingPolicyGatedToolRegistry extends ToolRegistry {
-  private readonly options: LintEnforcingPolicyGatedToolRegistryOptions;
+  #options: LintEnforcingPolicyGatedToolRegistryOptions;
+  #tools = new Map<string, PolicyGatedTool>();
 
   constructor(options: LintEnforcingPolicyGatedToolRegistryOptions) {
     super();
-    this.options = { ...options };
+    this.#options = { ...options };
+    hardenInheritedZeroToolMap(this);
+    Object.preventExtensions(this);
   }
 
   override register(tool: BaseTool): void {
@@ -511,25 +514,51 @@ class LintEnforcingPolicyGatedToolRegistry extends ToolRegistry {
     const candidateTools = buildRegistrationCandidateTools(this.list(), ownedTool);
     assertAllToolsPolicyGated(candidateTools);
     assertPolicyGatedToolRegistrationLint(candidateTools, {
-      role: this.options.role,
+      role: this.#options.role,
       requireDescriptionSections: true
     });
-    super.register(ownedTool);
+    this.#tools.set(ownedTool.name, ownedTool);
+  }
+
+  override get(name: string): BaseTool | undefined {
+    return this.#tools.get(name);
+  }
+
+  override list(): BaseTool[] {
+    return Array.from(this.#tools.values());
+  }
+
+  override getDefinitions(): ToolDefinition[] {
+    return this.list().map((tool) => tool.toDefinition());
+  }
+
+  override has(name: string): boolean {
+    return this.#tools.has(name);
   }
 
   private wrapWithRegistryAuthority(tool: BaseTool): PolicyGatedTool {
     const unwrappedTool = unwrapPolicyGatedTool(tool);
-    const normalizedTool = this.options.normalizeTool?.(unwrappedTool) ?? unwrappedTool;
+    const normalizedTool = this.#options.normalizeTool?.(unwrappedTool) ?? unwrappedTool;
     const validateExecutionInput =
-      this.options.resolveValidateExecutionInput?.(normalizedTool) ??
-      this.options.validateExecutionInput;
+      this.#options.resolveValidateExecutionInput?.(normalizedTool) ??
+      this.#options.validateExecutionInput;
     return wrapToolWithPolicyGate(normalizedTool, {
-      evaluate: this.options.evaluate,
-      role: this.options.role,
+      evaluate: this.#options.evaluate,
+      role: this.#options.role,
       toolId: normalizedTool.name,
       validateExecutionInput
     });
   }
+}
+
+function hardenInheritedZeroToolMap(registry: ToolRegistry): void {
+  const inheritedTools = (registry as unknown as { tools?: unknown }).tools;
+  Object.defineProperty(registry, "tools", {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value: inheritedTools instanceof Map ? inheritedTools : new Map<string, BaseTool>()
+  });
 }
 
 function buildRegistrationCandidateTools(

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -55,6 +55,17 @@ export interface PolicyGateWrapperOptions {
   validateExecutionInput?: PolicyGateExecutionInputValidator;
 }
 
+export interface PolicyGatedToolRegistrationLintOptions {
+  role?: HarnessRole;
+  requireDescriptionSections?: boolean;
+}
+
+export interface ToolZodParameterSchemaCarrier {
+  readonly parameterSchema?: unknown;
+  readonly zodParameters?: unknown;
+  readonly zodSchema?: unknown;
+}
+
 export type ShudBashFuseSource =
   | { fuseRules: readonly FuseRule[]; fuseListPath?: never }
   | { fuseListPath: string; fuseRules?: never };
@@ -81,6 +92,22 @@ export type PolicyGatedTool = BaseTool & {
 };
 
 const policyGatedTools = new WeakSet<BaseTool>();
+const ROLE_VISIBLE_TOOL_COUNT_LIMIT = 20;
+const CONTROL_KERNEL_TOOL_GOVERNANCE_REF =
+  "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定";
+const TOOL_PARAMETER_SCHEMA_RULE_ID = "tool-parameter-schema-validation";
+const TOOL_PARAMETER_SCHEMA_MAX_ISSUES = 3;
+const TOOL_PARAMETER_SCHEMA_ISSUE_MAX_CHARS = 240;
+const SHUD_TOOL_DESCRIPTION_REQUIRED_SECTIONS = Object.freeze([
+  "何时该用",
+  "何时不该用",
+  "成功与失败样态"
+] as const);
+const SHUD_SPAWN_AGENT_DESCRIPTION = [
+  "何时该用: 仅当 coordinator 需要把已明确边界的工作委派给 canonical 子角色时使用。",
+  "何时不该用: 不用于绕过当前角色权限、创建嵌套委派链，或替代 PI 科学判断。",
+  "成功与失败样态: 成功时返回 agent_id 并由后续 wait_agent 收集结果；失败时返回策略门拒绝、未知角色、模型或工具剖面错误。"
+].join("\n");
 
 export function createPolicyGateEvaluator(context: PolicyGateContext): PolicyGateEvaluator {
   return (call) => evaluatePolicyGate(call, context);
@@ -136,6 +163,9 @@ export function wrapAllRegisteredTools(
   tools: readonly BaseTool[],
   options: Omit<PolicyGateWrapperOptions, "toolId">
 ): PolicyGatedTool[] {
+  assertPolicyGatedToolRegistrationLint(tools, {
+    role: options.role
+  });
   const wrappedTools = tools.map((tool) =>
     wrapToolWithPolicyGate(tool, {
       ...options,
@@ -150,8 +180,18 @@ export function createPolicyGatedToolRegistry(
   tools: readonly BaseTool[],
   options: Omit<PolicyGateWrapperOptions, "toolId">
 ): ToolRegistry {
+  assertPolicyGatedToolRegistrationLint(tools, {
+    role: options.role
+  });
   const registry = new ToolRegistry();
-  for (const tool of wrapAllRegisteredTools(tools, options)) {
+  const wrappedTools = tools.map((tool) =>
+    wrapToolWithPolicyGate(tool, {
+      ...options,
+      toolId: tool.name
+    })
+  );
+  assertAllToolsPolicyGated(wrappedTools);
+  for (const tool of wrappedTools) {
     registry.register(tool);
   }
   assertPolicyGatedToolRegistry(registry);
@@ -185,6 +225,10 @@ export function createShudRuntimeToolRegistry(
   const registry = new ToolRegistry();
   const evaluate = createShudPolicyGateEvaluator(options.evaluate);
   let includesSpawnAgent = false;
+  const registrations: Array<{
+    tool: BaseTool;
+    validateExecutionInput?: PolicyGateExecutionInputValidator;
+  }> = [];
 
   for (const tool of options.tools ?? []) {
     if (tool.name === "spawn_agent") {
@@ -196,29 +240,11 @@ export function createShudRuntimeToolRegistry(
       continue;
     }
 
-    registry.register(
-      wrapToolWithPolicyGate(tool, {
-        evaluate,
-        role: options.role,
-        toolId: tool.name
-      })
-    );
+    registrations.push({ tool });
   }
 
-  registry.register(
-    wrapToolWithPolicyGate(createShudSandboxedBashTool(options), {
-      evaluate,
-      role: options.role,
-      toolId: "bash"
-    })
-  );
-  registry.register(
-    wrapToolWithPolicyGate(createShudSandboxedBashTool(options, "sandbox.exec"), {
-      evaluate,
-      role: options.role,
-      toolId: "sandbox.exec"
-    })
-  );
+  registrations.push({ tool: createShudSandboxedBashTool(options) });
+  registrations.push({ tool: createShudSandboxedBashTool(options, "sandbox.exec") });
 
   if (includesSpawnAgent) {
     if (!options.modelRouter) {
@@ -226,18 +252,43 @@ export function createShudRuntimeToolRegistry(
         "SHUD runtime registry cannot reuse a prebuilt spawn_agent; provide modelRouter to rebuild it against the final registry."
       );
     }
+    registrations.push({
+      tool: new ShudSpawnAgentTool(options.modelRouter, registry, options.metrics),
+      validateExecutionInput: createSpawnAgentToolAvailabilityValidator(registry)
+    });
+  }
+
+  assertPolicyGatedToolRegistrationLint(
+    registrations.map((registration) => registration.tool),
+    {
+      role: options.role,
+      requireDescriptionSections: true
+    }
+  );
+
+  for (const registration of registrations) {
     registry.register(
-      wrapToolWithPolicyGate(new SpawnAgentTool(options.modelRouter, registry, options.metrics), {
+      wrapToolWithPolicyGate(registration.tool, {
         evaluate,
         role: options.role,
-        toolId: "spawn_agent",
-        validateExecutionInput: createSpawnAgentToolAvailabilityValidator(registry)
+        toolId: registration.tool.name,
+        validateExecutionInput: registration.validateExecutionInput
       })
     );
   }
 
   assertPolicyGatedToolRegistry(registry);
   return registry;
+}
+
+export function assertPolicyGatedToolRegistrationLint(
+  tools: readonly BaseTool[],
+  options: PolicyGatedToolRegistrationLintOptions = {}
+): void {
+  assertRoleVisibleToolCountLimit(tools, options.role);
+  if (options.requireDescriptionSections) {
+    assertToolDescriptionsIncludeRequiredSections(tools);
+  }
 }
 
 export function assertPolicyGatedToolRegistry(registry: ToolRegistry): void {
@@ -260,12 +311,54 @@ export function isPolicyGatedTool(tool: BaseTool): tool is PolicyGatedTool {
   return policyGatedTools.has(tool);
 }
 
+function assertRoleVisibleToolCountLimit(
+  tools: readonly BaseTool[],
+  role: HarnessRole | undefined
+): void {
+  if (!isHarnessRole(role)) {
+    return;
+  }
+
+  const visibleToolCount = new Set(tools.map((tool) => tool.name)).size;
+  if (visibleToolCount <= ROLE_VISIBLE_TOOL_COUNT_LIMIT) {
+    return;
+  }
+
+  const excessCount = visibleToolCount - ROLE_VISIBLE_TOOL_COUNT_LIMIT;
+  throw new Error(
+    `Policy-gated tool registration lint failed for role ${role}: visible tool count ${visibleToolCount} exceeds ${ROLE_VISIBLE_TOOL_COUNT_LIMIT}; excess count ${excessCount}.`
+  );
+}
+
+function assertToolDescriptionsIncludeRequiredSections(tools: readonly BaseTool[]): void {
+  const failures: string[] = [];
+  for (const tool of tools) {
+    const description = tool.description;
+    const missingSections = SHUD_TOOL_DESCRIPTION_REQUIRED_SECTIONS.filter(
+      (section) => !description.includes(section)
+    );
+    if (missingSections.length > 0) {
+      failures.push(`${tool.name}: missing ${missingSections.join(", ")}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Policy-gated tool registration lint failed; tool descriptions must include Control_Kernel §5.3 sections: ${failures.join("; ")}.`
+    );
+  }
+}
+
 function unwrapPolicyGatedTool(tool: BaseTool): BaseTool {
   let current = tool;
   while (isPolicyGatedTool(current)) {
     current = current.innerTool;
   }
   return current;
+}
+
+class ShudSpawnAgentTool extends SpawnAgentTool {
+  override description = SHUD_SPAWN_AGENT_DESCRIPTION;
 }
 
 class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
@@ -323,6 +416,20 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       return this.finalizePolicyGateResult(
         toolContext,
         buildPolicyGateDeniedResult(this.policyGateToolId, preparedInput),
+        durationMs
+      );
+    }
+
+    const parameterValidationDecision = validateToolZodParameters(
+      this.policyGateToolId,
+      this.innerTool,
+      preparedInput.executionInput
+    );
+    if (parameterValidationDecision) {
+      const durationMs = Date.now() - startTime;
+      return this.finalizePolicyGateResult(
+        toolContext,
+        buildPolicyGateDeniedResult(this.policyGateToolId, parameterValidationDecision),
         durationMs
       );
     }
@@ -539,6 +646,135 @@ function formatToolIdSample(toolId: string): string {
 
 function uniqueStrings(values: readonly string[]): string[] {
   return [...new Set(values)];
+}
+
+type ToolZodParameterSchema = {
+  safeParse(input: unknown): ToolZodSafeParseResult;
+};
+
+type ToolZodSafeParseResult =
+  | {
+      success: true;
+      data: unknown;
+    }
+  | {
+      success: false;
+      error: unknown;
+    };
+
+type ToolZodIssue = {
+  path?: readonly unknown[];
+  message?: unknown;
+};
+
+function validateToolZodParameters(
+  toolId: string,
+  tool: BaseTool,
+  input: unknown
+): Extract<PolicyGateDecision, { decision: "deny" }> | undefined {
+  const schema = resolveToolZodParameterSchema(tool);
+  if (!schema) {
+    return undefined;
+  }
+
+  let result: ToolZodSafeParseResult;
+  try {
+    result = schema.safeParse(input);
+  } catch {
+    return buildToolParameterSchemaValidationDeny(
+      toolId,
+      "Zod parameter schema could not validate the prepared input."
+    );
+  }
+
+  if (result.success) {
+    return undefined;
+  }
+
+  return buildToolParameterSchemaValidationDeny(
+    toolId,
+    summarizeToolZodValidationError(result.error)
+  );
+}
+
+function resolveToolZodParameterSchema(tool: BaseTool): ToolZodParameterSchema | undefined {
+  const carrier = tool as BaseTool & ToolZodParameterSchemaCarrier;
+  const parameters = tool.parameters as unknown;
+  const parameterRecord = isPlainRecord(parameters) ? parameters : undefined;
+  const candidates = [
+    carrier.parameterSchema,
+    carrier.zodParameters,
+    carrier.zodSchema,
+    parameterRecord?.zodSchema,
+    parameterRecord?.parameterSchema,
+    parameterRecord?.schema,
+    parameters
+  ];
+
+  return candidates.find(isToolZodParameterSchema);
+}
+
+function isToolZodParameterSchema(value: unknown): value is ToolZodParameterSchema {
+  return isPlainRecord(value) && typeof value.safeParse === "function";
+}
+
+function summarizeToolZodValidationError(error: unknown): string {
+  const issues = readToolZodIssues(error);
+  if (issues.length === 0) {
+    return "input did not match the Zod parameter schema";
+  }
+
+  const summary = issues
+    .slice(0, TOOL_PARAMETER_SCHEMA_MAX_ISSUES)
+    .map(formatToolZodIssue)
+    .join("; ");
+  const suffix =
+    issues.length > TOOL_PARAMETER_SCHEMA_MAX_ISSUES ? ` (${issues.length} total issues)` : "";
+  return truncateToolParameterSchemaIssueSummary(`${summary}${suffix}`);
+}
+
+function readToolZodIssues(error: unknown): readonly ToolZodIssue[] {
+  if (!isPlainRecord(error) || !Array.isArray(error.issues)) {
+    return [];
+  }
+  return error.issues.filter(isPlainRecord) as ToolZodIssue[];
+}
+
+function formatToolZodIssue(issue: ToolZodIssue): string {
+  const path = Array.isArray(issue.path) && issue.path.length > 0
+    ? issue.path.map(String).join(".")
+    : "<root>";
+  const message = typeof issue.message === "string" && issue.message.trim() !== ""
+    ? issue.message
+    : "invalid value";
+  return `${path}: ${message}`;
+}
+
+function truncateToolParameterSchemaIssueSummary(summary: string): string {
+  if (summary.length <= TOOL_PARAMETER_SCHEMA_ISSUE_MAX_CHARS) {
+    return summary;
+  }
+  return `${summary.slice(0, TOOL_PARAMETER_SCHEMA_ISSUE_MAX_CHARS - 3)}...`;
+}
+
+function buildToolParameterSchemaValidationDeny(
+  toolId: string,
+  issueSummary: string
+): Extract<PolicyGateDecision, { decision: "deny" }> {
+  return {
+    decision: "deny",
+    ruleId: TOOL_PARAMETER_SCHEMA_RULE_ID,
+    reason: `Tool input failed Zod parameter schema validation for ${toolId}: ${issueSummary}.`,
+    remediation: {
+      next_action: "fix_and_retry",
+      hint: `Adjust the tool input to match its Zod parameter schema before retrying; ${issueSummary}.`,
+      ref: CONTROL_KERNEL_TOOL_GOVERNANCE_REF
+    }
+  };
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function validatePolicyGateDecision(toolId: string, candidate: unknown): PolicyGateDecision {

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -596,6 +596,10 @@ class ShudRuntimeToolDescriptionAdapter extends BaseTool {
 
 class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
   readonly policyGateToolId: string;
+  private readonly nameSnapshot: string;
+  private readonly descriptionSnapshot: string;
+  private readonly parametersSnapshot: Record<string, unknown>;
+  private readonly zodParameterSchemaSnapshot: ToolZodParameterSchema | undefined;
 
   constructor(
     readonly innerTool: BaseTool,
@@ -603,25 +607,28 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
   ) {
     super();
     this.policyGateToolId = options.toolId ?? innerTool.name;
+    this.nameSnapshot = innerTool.name;
+    this.descriptionSnapshot = innerTool.description;
+    this.parametersSnapshot = snapshotToolParameters(innerTool.parameters);
+    this.zodParameterSchemaSnapshot = resolveToolZodParameterSchema(innerTool);
     this.kind = innerTool.kind;
-    this.requiredModelCapabilities = innerTool.requiredModelCapabilities;
+    this.requiredModelCapabilities = Object.freeze([...innerTool.requiredModelCapabilities]);
   }
 
   get name(): string {
-    return this.innerTool.name;
+    return this.nameSnapshot;
   }
 
   get description(): string {
-    return this.innerTool.description;
+    return this.descriptionSnapshot;
   }
 
   get parameters(): Record<string, unknown> {
-    return this.innerTool.parameters;
+    return this.parametersSnapshot;
   }
 
   toDefinition(): ToolDefinition {
     return {
-      ...this.innerTool.toDefinition(),
       name: this.name,
       description: this.description,
       parameters: this.parameters,
@@ -658,10 +665,10 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       );
     }
 
-    if (resolveToolZodParameterSchema(this.innerTool)) {
+    if (this.zodParameterSchemaSnapshot) {
       const parsedInput = parseToolZodParameters(
         this.policyGateToolId,
-        this.innerTool,
+        this.zodParameterSchemaSnapshot,
         preparedInput.executionInput
       );
       if (parsedInput.decision === "deny") {
@@ -865,7 +872,7 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
           workDir: toolContext.workDir
         },
         {
-          tool: this.innerTool,
+          tool: this,
           toolContext
         }
       );
@@ -992,16 +999,11 @@ type ToolZodIssue = {
 
 function parseToolZodParameters(
   toolId: string,
-  tool: BaseTool,
+  schema: ToolZodParameterSchema,
   input: unknown
 ):
   | { decision: "allow"; executionInput: unknown }
   | Extract<PolicyGateDecision, { decision: "deny" }> {
-  const schema = resolveToolZodParameterSchema(tool);
-  if (!schema) {
-    return { decision: "allow", executionInput: input };
-  }
-
   let result: ToolZodSafeParseResult;
   try {
     result = schema.safeParse(input);
@@ -1037,6 +1039,56 @@ function resolveToolZodParameterSchema(tool: BaseTool): ToolZodParameterSchema |
   ];
 
   return candidates.find(isToolZodParameterSchema);
+}
+
+function snapshotToolParameters(parameters: Record<string, unknown>): Record<string, unknown> {
+  return cloneToolParameterMetadata(parameters, new WeakMap<object, unknown>()) as Record<
+    string,
+    unknown
+  >;
+}
+
+function cloneToolParameterMetadata(
+  value: unknown,
+  snapshots: WeakMap<object, unknown>
+): unknown {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (isToolZodParameterSchema(value)) {
+    return value;
+  }
+
+  const objectValue = value as object;
+  const existingSnapshot = snapshots.get(objectValue);
+  if (existingSnapshot) {
+    return existingSnapshot;
+  }
+
+  if (Array.isArray(value)) {
+    const snapshot: unknown[] = [];
+    snapshots.set(objectValue, snapshot);
+    for (const item of value) {
+      snapshot.push(cloneToolParameterMetadata(item, snapshots));
+    }
+    return Object.freeze(snapshot);
+  }
+
+  const snapshot: Record<string, unknown> = {};
+  snapshots.set(objectValue, snapshot);
+  for (const key of Object.keys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor?.enumerable || !("value" in descriptor)) {
+      continue;
+    }
+    Object.defineProperty(snapshot, key, {
+      value: cloneToolParameterMetadata(descriptor.value, snapshots),
+      enumerable: true,
+      configurable: false,
+      writable: false
+    });
+  }
+  return Object.freeze(snapshot);
 }
 
 function isToolZodParameterSchema(value: unknown): value is ToolZodParameterSchema {

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -643,8 +643,8 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
     this.#validateExecutionInput = options.validateExecutionInput;
     this.#nameSnapshot = innerTool.name;
     this.#descriptionSnapshot = innerTool.description;
-    this.#parametersSnapshot = snapshotToolParameters(innerTool.parameters);
     this.#zodParameterValidatorSnapshot = createStableToolZodParameterValidator(innerTool);
+    this.#parametersSnapshot = snapshotToolParameters(innerTool.parameters);
     Object.defineProperties(this, {
       name: {
         configurable: false,
@@ -1110,7 +1110,12 @@ function createStableToolZodParameterValidator(
   tool: BaseTool
 ): ToolZodParameterValidator | undefined {
   const schema = resolveToolZodParameterSchema(tool);
-  return schema ? schema.safeParse.bind(schema) : undefined;
+  if (!schema) {
+    return undefined;
+  }
+
+  const hardenedSchema = hardenToolZodParameterSchema(schema);
+  return hardenedSchema.safeParse.bind(hardenedSchema);
 }
 
 function resolveToolZodParameterSchema(tool: BaseTool): ToolZodParameterSchema | undefined {
@@ -1145,7 +1150,7 @@ function cloneToolParameterMetadata(
     return value;
   }
   if (isToolZodParameterSchema(value)) {
-    return value;
+    return hardenToolZodParameterSchema(value);
   }
 
   const objectValue = value as object;
@@ -1182,6 +1187,138 @@ function cloneToolParameterMetadata(
 
 function isToolZodParameterSchema(value: unknown): value is ToolZodParameterSchema {
   return isPlainRecord(value) && typeof value.safeParse === "function";
+}
+
+function hardenToolZodParameterSchema<T extends ToolZodParameterSchema>(schema: T): T {
+  // Zod v4 keeps validation authority in mutable def/_def/shape slots; freeze the
+  // registration-time graph so retained schema references cannot rewrite it later.
+  materializeKnownZodLazyDataProperties(schema, new WeakSet<object>());
+  deepFreezeOwnDataPropertyGraph(schema, new WeakSet<object>());
+  return schema;
+}
+
+function materializeKnownZodLazyDataProperties(value: unknown, seen: WeakSet<object>): void {
+  if (!isObjectRecord(value) || seen.has(value)) {
+    return;
+  }
+
+  seen.add(value);
+  const zodDef = resolveZodV4SchemaDef(value);
+  if (zodDef) {
+    materializeZodV4ObjectShape(value, zodDef);
+  }
+
+  for (const key of Reflect.ownKeys(value)) {
+    if (key === "_zod") {
+      continue;
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor || !("value" in descriptor)) {
+      continue;
+    }
+    materializeKnownZodLazyDataProperties(descriptor.value, seen);
+  }
+}
+
+function materializeZodV4ObjectShape(schema: object, zodDef: object): void {
+  const typeDescriptor = Object.getOwnPropertyDescriptor(zodDef, "type");
+  if (!typeDescriptor || !("value" in typeDescriptor) || typeDescriptor.value !== "object") {
+    return;
+  }
+
+  const defShapeDescriptor = Object.getOwnPropertyDescriptor(zodDef, "shape");
+  if (
+    defShapeDescriptor &&
+    !("value" in defShapeDescriptor) &&
+    typeof defShapeDescriptor.get === "function"
+  ) {
+    void (zodDef as { shape: unknown }).shape;
+  }
+
+  const schemaShapeDescriptor = Object.getOwnPropertyDescriptor(schema, "shape");
+  if (
+    schemaShapeDescriptor &&
+    !("value" in schemaShapeDescriptor) &&
+    typeof schemaShapeDescriptor.get === "function"
+  ) {
+    void (schema as { shape: unknown }).shape;
+  }
+}
+
+function deepFreezeOwnDataPropertyGraph(value: unknown, seen: WeakSet<object>): void {
+  if (!isObjectRecord(value) || seen.has(value)) {
+    return;
+  }
+
+  seen.add(value);
+  hardenZodV4RuntimeAuthoritySlots(value);
+  for (const key of Reflect.ownKeys(value)) {
+    if (key === "_zod") {
+      continue;
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor || !("value" in descriptor)) {
+      continue;
+    }
+    deepFreezeOwnDataPropertyGraph(descriptor.value, seen);
+  }
+  Object.freeze(value);
+}
+
+function hardenZodV4RuntimeAuthoritySlots(value: object): void {
+  const runtimeDescriptor = Object.getOwnPropertyDescriptor(value, "_zod");
+  if (
+    !runtimeDescriptor ||
+    !("value" in runtimeDescriptor) ||
+    !isObjectRecord(runtimeDescriptor.value)
+  ) {
+    return;
+  }
+
+  for (const key of ["def", "parse", "run"] as const) {
+    const descriptor = Object.getOwnPropertyDescriptor(runtimeDescriptor.value, key);
+    if (!descriptor || !("value" in descriptor)) {
+      continue;
+    }
+    Object.defineProperty(runtimeDescriptor.value, key, {
+      value: descriptor.value,
+      enumerable: descriptor.enumerable,
+      configurable: false,
+      writable: false
+    });
+  }
+}
+
+function resolveZodV4SchemaDef(value: object): object | undefined {
+  const runtimeDescriptor = Object.getOwnPropertyDescriptor(value, "_zod");
+  if (
+    !runtimeDescriptor ||
+    !("value" in runtimeDescriptor) ||
+    !isObjectRecord(runtimeDescriptor.value)
+  ) {
+    return undefined;
+  }
+
+  const defDescriptor =
+    Object.getOwnPropertyDescriptor(value, "def") ?? Object.getOwnPropertyDescriptor(value, "_def");
+  if (!defDescriptor || !("value" in defDescriptor) || !isObjectRecord(defDescriptor.value)) {
+    return undefined;
+  }
+
+  const runtimeDefDescriptor = Object.getOwnPropertyDescriptor(runtimeDescriptor.value, "def");
+  if (
+    !runtimeDefDescriptor ||
+    !("value" in runtimeDefDescriptor) ||
+    runtimeDefDescriptor.value !== defDescriptor.value
+  ) {
+    return undefined;
+  }
+
+  return defDescriptor.value;
+}
+
+function isObjectRecord(value: unknown): value is object {
+  return value !== null && typeof value === "object";
 }
 
 function summarizeToolZodValidationError(error: unknown): string {

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -611,8 +611,18 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
     this.descriptionSnapshot = innerTool.description;
     this.parametersSnapshot = snapshotToolParameters(innerTool.parameters);
     this.zodParameterSchemaSnapshot = resolveToolZodParameterSchema(innerTool);
-    this.kind = innerTool.kind;
-    this.requiredModelCapabilities = Object.freeze([...innerTool.requiredModelCapabilities]);
+    Object.defineProperty(this, "kind", {
+      configurable: false,
+      enumerable: true,
+      writable: false,
+      value: innerTool.kind
+    });
+    Object.defineProperty(this, "requiredModelCapabilities", {
+      configurable: false,
+      enumerable: true,
+      writable: false,
+      value: Object.freeze([...innerTool.requiredModelCapabilities])
+    });
   }
 
   get name(): string {

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -218,7 +218,7 @@ export function createPolicyGatedToolRegistry(
     role: options.role,
     requireDescriptionSections: true
   });
-  const registry = new ToolRegistry();
+  const registry = new LintEnforcingPolicyGatedToolRegistry({ role: options.role });
   const wrappedTools = tools.map((tool) =>
     wrapToolWithPolicyGate(tool, {
       ...options,
@@ -257,7 +257,7 @@ export function createShudSandboxedBashTool(
 export function createShudRuntimeToolRegistry(
   options: ShudRuntimeToolRegistryOptions
 ): ToolRegistry {
-  const registry = new ToolRegistry();
+  const registry = new LintEnforcingPolicyGatedToolRegistry({ role: options.role });
   const evaluate = createShudPolicyGateEvaluator(options.evaluate);
   let includesSpawnAgent = false;
   const registrations: Array<{
@@ -495,6 +495,43 @@ function resolveShudZeroNativeToolDescription(tool: BaseTool): string | undefine
 
 class ShudSpawnAgentTool extends SpawnAgentTool {
   override description = SHUD_SPAWN_AGENT_DESCRIPTION;
+}
+
+class LintEnforcingPolicyGatedToolRegistry extends ToolRegistry {
+  constructor(private readonly assertionOptions: PolicyGatedToolRegistryAssertionOptions = {}) {
+    super();
+  }
+
+  override register(tool: BaseTool): void {
+    const candidateTools = buildRegistrationCandidateTools(this.list(), tool);
+    assertAllToolsPolicyGated(candidateTools);
+    assertPolicyGatedToolRegistrationLint(candidateTools, {
+      role: this.assertionOptions.role,
+      requireDescriptionSections: true
+    });
+    super.register(tool);
+  }
+}
+
+function buildRegistrationCandidateTools(
+  currentTools: readonly BaseTool[],
+  tool: BaseTool
+): BaseTool[] {
+  let replacedExistingTool = false;
+  const candidateTools = currentTools.map((currentTool) => {
+    if (currentTool.name !== tool.name) {
+      return currentTool;
+    }
+
+    replacedExistingTool = true;
+    return tool;
+  });
+
+  if (!replacedExistingTool) {
+    candidateTools.push(tool);
+  }
+
+  return candidateTools;
 }
 
 class ShudRuntimeToolDescriptionAdapter extends BaseTool {

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -73,6 +73,16 @@ export interface PolicyGatedToolRegistryAssertionOptions {
   role?: HarnessRole;
 }
 
+interface LintEnforcingPolicyGatedToolRegistryOptions
+  extends PolicyGatedToolRegistryAssertionOptions {
+  evaluate: PolicyGateEvaluator;
+  validateExecutionInput?: PolicyGateExecutionInputValidator;
+  resolveValidateExecutionInput?: (
+    tool: BaseTool
+  ) => PolicyGateExecutionInputValidator | undefined;
+  normalizeTool?: (tool: BaseTool) => BaseTool;
+}
+
 export interface ToolZodParameterSchemaCarrier {
   readonly parameterSchema?: unknown;
   readonly zodParameters?: unknown;
@@ -218,15 +228,8 @@ export function createPolicyGatedToolRegistry(
     role: options.role,
     requireDescriptionSections: true
   });
-  const registry = new LintEnforcingPolicyGatedToolRegistry({ role: options.role });
-  const wrappedTools = tools.map((tool) =>
-    wrapToolWithPolicyGate(tool, {
-      ...options,
-      toolId: tool.name
-    })
-  );
-  assertAllToolsPolicyGated(wrappedTools);
-  for (const tool of wrappedTools) {
+  const registry = new LintEnforcingPolicyGatedToolRegistry(options);
+  for (const tool of tools) {
     registry.register(tool);
   }
   assertPolicyGatedToolRegistry(registry, { role: options.role });
@@ -257,12 +260,18 @@ export function createShudSandboxedBashTool(
 export function createShudRuntimeToolRegistry(
   options: ShudRuntimeToolRegistryOptions
 ): ToolRegistry {
-  const registry = new LintEnforcingPolicyGatedToolRegistry({ role: options.role });
   const evaluate = createShudPolicyGateEvaluator(options.evaluate);
+  let registry: LintEnforcingPolicyGatedToolRegistry;
+  registry = new LintEnforcingPolicyGatedToolRegistry({
+    role: options.role,
+    evaluate,
+    normalizeTool: adaptShudRuntimeToolDescription,
+    resolveValidateExecutionInput: (tool) =>
+      tool.name === "spawn_agent" ? createSpawnAgentToolAvailabilityValidator(registry) : undefined
+  });
   let includesSpawnAgent = false;
   const registrations: Array<{
     tool: BaseTool;
-    validateExecutionInput?: PolicyGateExecutionInputValidator;
   }> = [];
 
   for (const candidateTool of options.tools ?? []) {
@@ -289,8 +298,7 @@ export function createShudRuntimeToolRegistry(
       );
     }
     registrations.push({
-      tool: new ShudSpawnAgentTool(options.modelRouter, registry, options.metrics),
-      validateExecutionInput: createSpawnAgentToolAvailabilityValidator(registry)
+      tool: new ShudSpawnAgentTool(options.modelRouter, registry, options.metrics)
     });
   }
 
@@ -303,14 +311,7 @@ export function createShudRuntimeToolRegistry(
   );
 
   for (const registration of registrations) {
-    registry.register(
-      wrapToolWithPolicyGate(registration.tool, {
-        evaluate,
-        role: options.role,
-        toolId: registration.tool.name,
-        validateExecutionInput: registration.validateExecutionInput
-      })
-    );
+    registry.register(registration.tool);
   }
 
   assertPolicyGatedToolRegistry(registry, { role: options.role });
@@ -498,18 +499,36 @@ class ShudSpawnAgentTool extends SpawnAgentTool {
 }
 
 class LintEnforcingPolicyGatedToolRegistry extends ToolRegistry {
-  constructor(private readonly assertionOptions: PolicyGatedToolRegistryAssertionOptions = {}) {
+  private readonly options: LintEnforcingPolicyGatedToolRegistryOptions;
+
+  constructor(options: LintEnforcingPolicyGatedToolRegistryOptions) {
     super();
+    this.options = { ...options };
   }
 
   override register(tool: BaseTool): void {
-    const candidateTools = buildRegistrationCandidateTools(this.list(), tool);
+    const ownedTool = this.wrapWithRegistryAuthority(tool);
+    const candidateTools = buildRegistrationCandidateTools(this.list(), ownedTool);
     assertAllToolsPolicyGated(candidateTools);
     assertPolicyGatedToolRegistrationLint(candidateTools, {
-      role: this.assertionOptions.role,
+      role: this.options.role,
       requireDescriptionSections: true
     });
-    super.register(tool);
+    super.register(ownedTool);
+  }
+
+  private wrapWithRegistryAuthority(tool: BaseTool): PolicyGatedTool {
+    const unwrappedTool = unwrapPolicyGatedTool(tool);
+    const normalizedTool = this.options.normalizeTool?.(unwrappedTool) ?? unwrappedTool;
+    const validateExecutionInput =
+      this.options.resolveValidateExecutionInput?.(normalizedTool) ??
+      this.options.validateExecutionInput;
+    return wrapToolWithPolicyGate(normalizedTool, {
+      evaluate: this.options.evaluate,
+      role: this.options.role,
+      toolId: normalizedTool.name,
+      validateExecutionInput
+    });
   }
 }
 
@@ -601,7 +620,13 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
   }
 
   toDefinition(): ToolDefinition {
-    return this.innerTool.toDefinition();
+    return {
+      ...this.innerTool.toDefinition(),
+      name: this.name,
+      description: this.description,
+      parameters: this.parameters,
+      kind: this.kind
+    };
   }
 
   async run(toolContext: ToolContext, input: unknown): Promise<ToolResult> {
@@ -645,11 +670,7 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
           role,
           preparedInput.evaluatorInput
         );
-        if (evaluation.status === "error") {
-          const durationMs = Date.now() - startTime;
-          return this.finalizePolicyGateResult(toolContext, evaluation.result, durationMs);
-        }
-        if (evaluation.decision.decision === "deny") {
+        if (evaluation.status === "decision" && evaluation.decision.decision === "deny") {
           const durationMs = Date.now() - startTime;
           return this.finalizePolicyGateResult(
             toolContext,

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -11,6 +11,7 @@ import {
 import { toErrorMessage } from "@zero-os/shared";
 import type { FuseRule, ToolContext, ToolDefinition, ToolResult } from "@zero-os/shared";
 import { types as nodeUtilTypes } from "node:util";
+import { ZodType } from "zod";
 import {
   evaluatePolicyGate,
   normalizeSpawnAgentInput,
@@ -173,6 +174,10 @@ const GENERIC_POLICY_GATE_INPUT_MAX_NODES = 10_000;
 const GENERIC_POLICY_GATE_INPUT_MAX_ARRAY_LENGTH = 1_024;
 const GENERIC_POLICY_GATE_INPUT_MAX_OBJECT_KEYS = 256;
 const GENERIC_POLICY_GATE_INPUT_MAX_STRING_CHARS = 131_072;
+const ZOD_PARAMETER_SCHEMA_MAX_DEPTH = 128;
+const ZOD_PARAMETER_SCHEMA_MAX_NODES = 20_000;
+const ZOD_PARAMETER_SCHEMA_MAX_OWN_KEYS = 512;
+const ZOD_PARAMETER_SCHEMA_MAX_PROPERTIES = 50_000;
 const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
 export function createShudPolicyGateEvaluator(
@@ -217,6 +222,10 @@ export function wrapAllRegisteredTools(
     })
   );
   assertAllToolsPolicyGated(wrappedTools);
+  assertPolicyGatedToolRegistrationLint(wrappedTools, {
+    role: options.role,
+    requireDescriptionSections: true
+  });
   return wrappedTools;
 }
 
@@ -1058,9 +1067,7 @@ function uniqueStrings(values: readonly string[]): string[] {
   return [...new Set(values)];
 }
 
-type ToolZodParameterSchema = {
-  safeParse(input: unknown): ToolZodSafeParseResult;
-};
+type ToolZodParameterSchema = ZodType;
 
 type ToolZodParameterValidator = (input: unknown) => ToolZodSafeParseResult;
 
@@ -1077,6 +1084,12 @@ type ToolZodSafeParseResult =
 type ToolZodIssue = {
   path?: readonly unknown[];
   message?: unknown;
+};
+
+type ZodParameterSchemaHardeningState = {
+  seen: WeakSet<object>;
+  nodes: number;
+  properties: number;
 };
 
 function parseToolZodParameters(
@@ -1132,7 +1145,19 @@ function resolveToolZodParameterSchema(tool: BaseTool): ToolZodParameterSchema |
     parameters
   ];
 
-  return candidates.find(isToolZodParameterSchema);
+  for (const candidate of candidates) {
+    if (candidate === undefined) {
+      continue;
+    }
+    if (isToolZodParameterSchema(candidate)) {
+      return candidate;
+    }
+    if (isRejectedToolZodParameterSchemaCandidate(candidate)) {
+      throw new Error("Tool Zod parameter schema must be a real Zod v4 schema.");
+    }
+  }
+
+  return undefined;
 }
 
 function snapshotToolParameters(parameters: Record<string, unknown>): Record<string, unknown> {
@@ -1186,37 +1211,62 @@ function cloneToolParameterMetadata(
 }
 
 function isToolZodParameterSchema(value: unknown): value is ToolZodParameterSchema {
-  return isPlainRecord(value) && typeof value.safeParse === "function";
+  return (
+    isObjectRecord(value) &&
+    !nodeUtilTypes.isProxy(value) &&
+    value instanceof ZodType &&
+    resolveZodV4SchemaDef(value) !== undefined
+  );
+}
+
+function isRejectedToolZodParameterSchemaCandidate(value: unknown): boolean {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  if (nodeUtilTypes.isProxy(value)) {
+    return true;
+  }
+  return "safeParse" in value || "_zod" in value;
 }
 
 function hardenToolZodParameterSchema<T extends ToolZodParameterSchema>(schema: T): T {
   // Zod v4 keeps validation authority in mutable def/_def/shape slots; freeze the
   // registration-time graph so retained schema references cannot rewrite it later.
-  materializeKnownZodLazyDataProperties(schema, new WeakSet<object>());
-  deepFreezeOwnDataPropertyGraph(schema, new WeakSet<object>());
+  materializeKnownZodLazyDataProperties(schema, createZodParameterSchemaHardeningState());
+  deepFreezeOwnDataPropertyGraph(schema, createZodParameterSchemaHardeningState());
   return schema;
 }
 
-function materializeKnownZodLazyDataProperties(value: unknown, seen: WeakSet<object>): void {
-  if (!isObjectRecord(value) || seen.has(value)) {
+function createZodParameterSchemaHardeningState(): ZodParameterSchemaHardeningState {
+  return {
+    seen: new WeakSet<object>(),
+    nodes: 0,
+    properties: 0
+  };
+}
+
+function materializeKnownZodLazyDataProperties(
+  value: unknown,
+  state: ZodParameterSchemaHardeningState,
+  depth = 0
+): void {
+  if (!reserveZodParameterSchemaHardeningNode(value, state, depth)) {
     return;
   }
 
-  seen.add(value);
-  const zodDef = resolveZodV4SchemaDef(value);
-  if (zodDef) {
-    materializeZodV4ObjectShape(value, zodDef);
+  const objectValue = value as object;
+  if (objectValue instanceof ZodType) {
+    const zodDef = resolveZodV4SchemaDef(objectValue);
+    if (zodDef) {
+      materializeZodV4ObjectShape(objectValue, zodDef);
+    }
   }
 
-  for (const key of Reflect.ownKeys(value)) {
+  for (const { key, value: childValue } of readZodParameterSchemaOwnDataProperties(objectValue, state)) {
     if (key === "_zod") {
       continue;
     }
-    const descriptor = Object.getOwnPropertyDescriptor(value, key);
-    if (!descriptor || !("value" in descriptor)) {
-      continue;
-    }
-    materializeKnownZodLazyDataProperties(descriptor.value, seen);
+    materializeKnownZodLazyDataProperties(childValue, state, depth + 1);
   }
 }
 
@@ -1245,24 +1295,76 @@ function materializeZodV4ObjectShape(schema: object, zodDef: object): void {
   }
 }
 
-function deepFreezeOwnDataPropertyGraph(value: unknown, seen: WeakSet<object>): void {
-  if (!isObjectRecord(value) || seen.has(value)) {
+function deepFreezeOwnDataPropertyGraph(
+  value: unknown,
+  state: ZodParameterSchemaHardeningState,
+  depth = 0
+): void {
+  if (!reserveZodParameterSchemaHardeningNode(value, state, depth)) {
     return;
   }
 
-  seen.add(value);
-  hardenZodV4RuntimeAuthoritySlots(value);
-  for (const key of Reflect.ownKeys(value)) {
+  const objectValue = value as object;
+  if (objectValue instanceof ZodType) {
+    hardenZodV4RuntimeAuthoritySlots(objectValue);
+  }
+  for (const { key, value: childValue } of readZodParameterSchemaOwnDataProperties(objectValue, state)) {
     if (key === "_zod") {
       continue;
     }
+    deepFreezeOwnDataPropertyGraph(childValue, state, depth + 1);
+  }
+  Object.freeze(objectValue);
+}
+
+function reserveZodParameterSchemaHardeningNode(
+  value: unknown,
+  state: ZodParameterSchemaHardeningState,
+  depth: number
+): boolean {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  if (depth > ZOD_PARAMETER_SCHEMA_MAX_DEPTH) {
+    throw new Error("Zod parameter schema exceeds hardening depth budget.");
+  }
+  if (nodeUtilTypes.isProxy(value)) {
+    throw new Error("Zod parameter schema must not contain Proxy-backed objects.");
+  }
+  if (state.seen.has(value)) {
+    return false;
+  }
+
+  state.seen.add(value);
+  state.nodes += 1;
+  if (state.nodes > ZOD_PARAMETER_SCHEMA_MAX_NODES) {
+    throw new Error("Zod parameter schema exceeds hardening node budget.");
+  }
+  return true;
+}
+
+function readZodParameterSchemaOwnDataProperties(
+  value: object,
+  state: ZodParameterSchemaHardeningState
+): Array<{ key: PropertyKey; value: unknown }> {
+  const keys = Reflect.ownKeys(value);
+  if (keys.length > ZOD_PARAMETER_SCHEMA_MAX_OWN_KEYS) {
+    throw new Error("Zod parameter schema exceeds hardening property budget.");
+  }
+  state.properties += keys.length;
+  if (state.properties > ZOD_PARAMETER_SCHEMA_MAX_PROPERTIES) {
+    throw new Error("Zod parameter schema exceeds hardening property budget.");
+  }
+
+  const properties: Array<{ key: PropertyKey; value: unknown }> = [];
+  for (const key of keys) {
     const descriptor = Object.getOwnPropertyDescriptor(value, key);
     if (!descriptor || !("value" in descriptor)) {
       continue;
     }
-    deepFreezeOwnDataPropertyGraph(descriptor.value, seen);
+    properties.push({ key, value: descriptor.value });
   }
-  Object.freeze(value);
+  return properties;
 }
 
 function hardenZodV4RuntimeAuthoritySlots(value: object): void {

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -1,4 +1,13 @@
-import { BaseTool, SpawnAgentTool, ToolRegistry, loadFuseList } from "@zero-os/core";
+import {
+  BaseTool,
+  EditTool,
+  ReadTool,
+  SpawnAgentTool,
+  ToolRegistry,
+  WaitAgentTool,
+  WriteTool,
+  loadFuseList
+} from "@zero-os/core";
 import { toErrorMessage } from "@zero-os/shared";
 import type { FuseRule, ToolContext, ToolDefinition, ToolResult } from "@zero-os/shared";
 import { types as nodeUtilTypes } from "node:util";
@@ -108,6 +117,26 @@ const SHUD_SPAWN_AGENT_DESCRIPTION = [
   "何时不该用: 不用于绕过当前角色权限、创建嵌套委派链，或替代 PI 科学判断。",
   "成功与失败样态: 成功时返回 agent_id 并由后续 wait_agent 收集结果；失败时返回策略门拒绝、未知角色、模型或工具剖面错误。"
 ].join("\n");
+const SHUD_READ_TOOL_DESCRIPTION = [
+  "何时该用: 在 SHUD runtime 中读取调度、审查或执行所需的文件内容，并保持只读边界。",
+  "何时不该用: 不用于写入、编辑、删除文件，也不用于读取超出当前任务权限的敏感数据。",
+  "成功与失败样态: 成功时返回文件内容和摘要；失败时返回文件缺失、权限或参数错误。"
+].join("\n");
+const SHUD_WRITE_TOOL_DESCRIPTION = [
+  "何时该用: 在 coder worktree 边界内创建或覆盖明确授权的源码、测试或配置文件。",
+  "何时不该用: 不用于修改 raw data、baseline、主分支状态或缺少任务授权的路径。",
+  "成功与失败样态: 成功时写入目标文件；失败时返回权限、路径、参数或策略门拒绝错误。"
+].join("\n");
+const SHUD_EDIT_TOOL_DESCRIPTION = [
+  "何时该用: 在 coder worktree 边界内对已存在文件做小范围、可审查的编辑。",
+  "何时不该用: 不用于批量重写无关文件、修改 raw data，或替代明确的 patch.apply 流程。",
+  "成功与失败样态: 成功时应用目标编辑；失败时返回匹配失败、权限、路径或策略门拒绝错误。"
+].join("\n");
+const SHUD_WAIT_AGENT_DESCRIPTION = [
+  "何时该用: 当 coordinator 需要等待已派发子代理完成或进入可观察状态时使用。",
+  "何时不该用: 不用于创建新子代理、绕过 spawn 剖面校验，或等待非本会话拥有的 agent id。",
+  "成功与失败样态: 成功时返回子代理状态快照；失败时返回 agent control 不可用、超时或未知 agent id。"
+].join("\n");
 
 export function createPolicyGateEvaluator(context: PolicyGateContext): PolicyGateEvaluator {
   return (call) => evaluatePolicyGate(call, context);
@@ -164,7 +193,8 @@ export function wrapAllRegisteredTools(
   options: Omit<PolicyGateWrapperOptions, "toolId">
 ): PolicyGatedTool[] {
   assertPolicyGatedToolRegistrationLint(tools, {
-    role: options.role
+    role: options.role,
+    requireDescriptionSections: true
   });
   const wrappedTools = tools.map((tool) =>
     wrapToolWithPolicyGate(tool, {
@@ -181,7 +211,8 @@ export function createPolicyGatedToolRegistry(
   options: Omit<PolicyGateWrapperOptions, "toolId">
 ): ToolRegistry {
   assertPolicyGatedToolRegistrationLint(tools, {
-    role: options.role
+    role: options.role,
+    requireDescriptionSections: true
   });
   const registry = new ToolRegistry();
   const wrappedTools = tools.map((tool) =>
@@ -230,7 +261,8 @@ export function createShudRuntimeToolRegistry(
     validateExecutionInput?: PolicyGateExecutionInputValidator;
   }> = [];
 
-  for (const tool of options.tools ?? []) {
+  for (const candidateTool of options.tools ?? []) {
+    const tool = unwrapPolicyGatedTool(candidateTool);
     if (tool.name === "spawn_agent") {
       includesSpawnAgent = true;
       continue;
@@ -240,7 +272,7 @@ export function createShudRuntimeToolRegistry(
       continue;
     }
 
-    registrations.push({ tool });
+    registrations.push({ tool: adaptShudRuntimeToolDescription(tool) });
   }
 
   registrations.push({ tool: createShudSandboxedBashTool(options) });
@@ -315,10 +347,6 @@ function assertRoleVisibleToolCountLimit(
   tools: readonly BaseTool[],
   role: HarnessRole | undefined
 ): void {
-  if (!isHarnessRole(role)) {
-    return;
-  }
-
   const visibleToolCount = new Set(tools.map((tool) => tool.name)).size;
   if (visibleToolCount <= ROLE_VISIBLE_TOOL_COUNT_LIMIT) {
     return;
@@ -326,19 +354,23 @@ function assertRoleVisibleToolCountLimit(
 
   const excessCount = visibleToolCount - ROLE_VISIBLE_TOOL_COUNT_LIMIT;
   throw new Error(
-    `Policy-gated tool registration lint failed for role ${role}: visible tool count ${visibleToolCount} exceeds ${ROLE_VISIBLE_TOOL_COUNT_LIMIT}; excess count ${excessCount}.`
+    `Policy-gated tool registration lint failed for role ${formatRegistrationLintRole(role)}: visible tool count ${visibleToolCount} exceeds ${ROLE_VISIBLE_TOOL_COUNT_LIMIT}; excess count ${excessCount}.`
   );
 }
 
 function assertToolDescriptionsIncludeRequiredSections(tools: readonly BaseTool[]): void {
   const failures: string[] = [];
   for (const tool of tools) {
-    const description = tool.description;
-    const missingSections = SHUD_TOOL_DESCRIPTION_REQUIRED_SECTIONS.filter(
-      (section) => !description.includes(section)
-    );
+    const { missingSections, emptySections } = inspectToolDescriptionSections(tool.description);
+    const details: string[] = [];
     if (missingSections.length > 0) {
-      failures.push(`${tool.name}: missing ${missingSections.join(", ")}`);
+      details.push(`missing ${missingSections.join(", ")}`);
+    }
+    if (emptySections.length > 0) {
+      details.push(`empty ${emptySections.join(", ")}`);
+    }
+    if (details.length > 0) {
+      failures.push(`${tool.name}: ${details.join("; ")}`);
     }
   }
 
@@ -349,6 +381,74 @@ function assertToolDescriptionsIncludeRequiredSections(tools: readonly BaseTool[
   }
 }
 
+function formatRegistrationLintRole(role: HarnessRole | undefined): HarnessRole | "unknown-role" {
+  return isHarnessRole(role) ? role : "unknown-role";
+}
+
+function inspectToolDescriptionSections(description: string): {
+  missingSections: string[];
+  emptySections: string[];
+} {
+  const sectionState = new Map<
+    (typeof SHUD_TOOL_DESCRIPTION_REQUIRED_SECTIONS)[number],
+    { present: boolean; hasBody: boolean }
+  >(
+    SHUD_TOOL_DESCRIPTION_REQUIRED_SECTIONS.map((section) => [
+      section,
+      { present: false, hasBody: false }
+    ])
+  );
+  let currentSection: (typeof SHUD_TOOL_DESCRIPTION_REQUIRED_SECTIONS)[number] | undefined;
+
+  for (const line of description.split(/\r?\n/)) {
+    const heading = parseToolDescriptionSectionHeading(line);
+    if (heading) {
+      currentSection = heading.section;
+      const state = sectionState.get(currentSection)!;
+      state.present = true;
+      if (heading.inlineBody.trim() !== "") {
+        state.hasBody = true;
+      }
+      continue;
+    }
+
+    if (currentSection && line.trim() !== "") {
+      sectionState.get(currentSection)!.hasBody = true;
+    }
+  }
+
+  const missingSections: string[] = [];
+  const emptySections: string[] = [];
+  for (const section of SHUD_TOOL_DESCRIPTION_REQUIRED_SECTIONS) {
+    const state = sectionState.get(section)!;
+    if (!state.present) {
+      missingSections.push(section);
+    } else if (!state.hasBody) {
+      emptySections.push(section);
+    }
+  }
+
+  return { missingSections, emptySections };
+}
+
+function parseToolDescriptionSectionHeading(
+  line: string
+):
+  | {
+      section: (typeof SHUD_TOOL_DESCRIPTION_REQUIRED_SECTIONS)[number];
+      inlineBody: string;
+    }
+  | undefined {
+  const match = /^\s*(何时该用|何时不该用|成功与失败样态)\s*[:：]\s*(.*)$/u.exec(line);
+  if (!match) {
+    return undefined;
+  }
+  return {
+    section: match[1] as (typeof SHUD_TOOL_DESCRIPTION_REQUIRED_SECTIONS)[number],
+    inlineBody: match[2]
+  };
+}
+
 function unwrapPolicyGatedTool(tool: BaseTool): BaseTool {
   let current = tool;
   while (isPolicyGatedTool(current)) {
@@ -357,8 +457,73 @@ function unwrapPolicyGatedTool(tool: BaseTool): BaseTool {
   return current;
 }
 
+function adaptShudRuntimeToolDescription(tool: BaseTool): BaseTool {
+  const description = resolveShudZeroNativeToolDescription(tool);
+  if (!description) {
+    return tool;
+  }
+  return new ShudRuntimeToolDescriptionAdapter(tool, description);
+}
+
+function resolveShudZeroNativeToolDescription(tool: BaseTool): string | undefined {
+  if (tool instanceof ReadTool) {
+    return SHUD_READ_TOOL_DESCRIPTION;
+  }
+  if (tool instanceof WriteTool) {
+    return SHUD_WRITE_TOOL_DESCRIPTION;
+  }
+  if (tool instanceof EditTool) {
+    return SHUD_EDIT_TOOL_DESCRIPTION;
+  }
+  if (tool instanceof WaitAgentTool) {
+    return SHUD_WAIT_AGENT_DESCRIPTION;
+  }
+  return undefined;
+}
+
 class ShudSpawnAgentTool extends SpawnAgentTool {
   override description = SHUD_SPAWN_AGENT_DESCRIPTION;
+}
+
+class ShudRuntimeToolDescriptionAdapter extends BaseTool {
+  constructor(
+    readonly innerTool: BaseTool,
+    private readonly shudDescription: string
+  ) {
+    super();
+    this.kind = innerTool.kind;
+    this.requiredModelCapabilities = innerTool.requiredModelCapabilities;
+  }
+
+  get name(): string {
+    return this.innerTool.name;
+  }
+
+  get description(): string {
+    return this.shudDescription;
+  }
+
+  get parameters(): Record<string, unknown> {
+    return this.innerTool.parameters;
+  }
+
+  toDefinition(): ToolDefinition {
+    return {
+      ...this.innerTool.toDefinition(),
+      name: this.name,
+      description: this.description,
+      parameters: this.parameters,
+      kind: this.kind
+    };
+  }
+
+  async run(toolContext: ToolContext, input: unknown): Promise<ToolResult> {
+    return this.innerTool.run(toolContext, input);
+  }
+
+  protected async execute(): Promise<ToolResult> {
+    throw new Error("ShudRuntimeToolDescriptionAdapter delegates through run().");
+  }
 }
 
 class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
@@ -420,30 +585,19 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       );
     }
 
-    const parameterValidationDecision = validateToolZodParameters(
-      this.policyGateToolId,
-      this.innerTool,
-      preparedInput.executionInput
-    );
-    if (parameterValidationDecision) {
-      const durationMs = Date.now() - startTime;
-      return this.finalizePolicyGateResult(
-        toolContext,
-        buildPolicyGateDeniedResult(this.policyGateToolId, parameterValidationDecision),
-        durationMs
+    const hasZodParameterSchema = resolveToolZodParameterSchema(this.innerTool) !== undefined;
+    if (!hasZodParameterSchema) {
+      const executionValidationDecision = this.options.validateExecutionInput?.(
+        preparedInput.executionInput
       );
-    }
-
-    const executionValidationDecision = this.options.validateExecutionInput?.(
-      preparedInput.executionInput
-    );
-    if (executionValidationDecision) {
-      const durationMs = Date.now() - startTime;
-      return this.finalizePolicyGateResult(
-        toolContext,
-        buildPolicyGateDeniedResult(this.policyGateToolId, executionValidationDecision),
-        durationMs
-      );
+      if (executionValidationDecision) {
+        const durationMs = Date.now() - startTime;
+        return this.finalizePolicyGateResult(
+          toolContext,
+          buildPolicyGateDeniedResult(this.policyGateToolId, executionValidationDecision),
+          durationMs
+        );
+      }
     }
 
     try {
@@ -490,7 +644,33 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       );
     }
 
-    return this.innerTool.run(toolContext, preparedInput.executionInput);
+    const parsedInput = hasZodParameterSchema
+      ? parseToolZodParameters(this.policyGateToolId, this.innerTool, preparedInput.executionInput)
+      : { decision: "allow" as const, executionInput: preparedInput.executionInput };
+    if (parsedInput.decision === "deny") {
+      const durationMs = Date.now() - startTime;
+      return this.finalizePolicyGateResult(
+        toolContext,
+        buildPolicyGateDeniedResult(this.policyGateToolId, parsedInput),
+        durationMs
+      );
+    }
+
+    if (hasZodParameterSchema) {
+      const executionValidationDecision = this.options.validateExecutionInput?.(
+        parsedInput.executionInput
+      );
+      if (executionValidationDecision) {
+        const durationMs = Date.now() - startTime;
+        return this.finalizePolicyGateResult(
+          toolContext,
+          buildPolicyGateDeniedResult(this.policyGateToolId, executionValidationDecision),
+          durationMs
+        );
+      }
+    }
+
+    return this.innerTool.run(toolContext, parsedInput.executionInput);
   }
 
   protected async execute(): Promise<ToolResult> {
@@ -667,14 +847,16 @@ type ToolZodIssue = {
   message?: unknown;
 };
 
-function validateToolZodParameters(
+function parseToolZodParameters(
   toolId: string,
   tool: BaseTool,
   input: unknown
-): Extract<PolicyGateDecision, { decision: "deny" }> | undefined {
+):
+  | { decision: "allow"; executionInput: unknown }
+  | Extract<PolicyGateDecision, { decision: "deny" }> {
   const schema = resolveToolZodParameterSchema(tool);
   if (!schema) {
-    return undefined;
+    return { decision: "allow", executionInput: input };
   }
 
   let result: ToolZodSafeParseResult;
@@ -688,7 +870,7 @@ function validateToolZodParameters(
   }
 
   if (result.success) {
-    return undefined;
+    return { decision: "allow", executionInput: result.data };
   }
 
   return buildToolParameterSchemaValidationDeny(

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -69,6 +69,10 @@ export interface PolicyGatedToolRegistrationLintOptions {
   requireDescriptionSections?: boolean;
 }
 
+export interface PolicyGatedToolRegistryAssertionOptions {
+  role?: HarnessRole;
+}
+
 export interface ToolZodParameterSchemaCarrier {
   readonly parameterSchema?: unknown;
   readonly zodParameters?: unknown;
@@ -225,7 +229,7 @@ export function createPolicyGatedToolRegistry(
   for (const tool of wrappedTools) {
     registry.register(tool);
   }
-  assertPolicyGatedToolRegistry(registry);
+  assertPolicyGatedToolRegistry(registry, { role: options.role });
   return registry;
 }
 
@@ -309,7 +313,7 @@ export function createShudRuntimeToolRegistry(
     );
   }
 
-  assertPolicyGatedToolRegistry(registry);
+  assertPolicyGatedToolRegistry(registry, { role: options.role });
   return registry;
 }
 
@@ -323,8 +327,16 @@ export function assertPolicyGatedToolRegistrationLint(
   }
 }
 
-export function assertPolicyGatedToolRegistry(registry: ToolRegistry): void {
-  assertAllToolsPolicyGated(registry.list());
+export function assertPolicyGatedToolRegistry(
+  registry: ToolRegistry,
+  options: PolicyGatedToolRegistryAssertionOptions = {}
+): void {
+  const tools = registry.list();
+  assertAllToolsPolicyGated(tools);
+  assertPolicyGatedToolRegistrationLint(tools, {
+    role: options.role,
+    requireDescriptionSections: true
+  });
 }
 
 export function assertAllToolsPolicyGated(tools: readonly BaseTool[]): void {
@@ -557,7 +569,6 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
 
   async run(toolContext: ToolContext, input: unknown): Promise<ToolResult> {
     const startTime = Date.now();
-    let decision: PolicyGateDecision;
     const role = this.options.role ?? resolveRole(toolContext);
     let preparedInput:
       | {
@@ -585,80 +596,74 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       );
     }
 
-    const hasZodParameterSchema = resolveToolZodParameterSchema(this.innerTool) !== undefined;
-    if (!hasZodParameterSchema) {
-      const executionValidationDecision = this.options.validateExecutionInput?.(
+    if (resolveToolZodParameterSchema(this.innerTool)) {
+      const parsedInput = parseToolZodParameters(
+        this.policyGateToolId,
+        this.innerTool,
         preparedInput.executionInput
       );
-      if (executionValidationDecision) {
-        const durationMs = Date.now() - startTime;
-        return this.finalizePolicyGateResult(
+      if (parsedInput.decision === "deny") {
+        const evaluation = await this.evaluatePolicyGateInput(
           toolContext,
-          buildPolicyGateDeniedResult(this.policyGateToolId, executionValidationDecision),
-          durationMs
-        );
-      }
-    }
-
-    try {
-      const candidate = await this.options.evaluate(
-        {
-          toolId: this.policyGateToolId,
           role,
-          input: preparedInput.evaluatorInput,
-          workDir: toolContext.workDir
-        },
-        {
-          tool: this.innerTool,
-          toolContext
+          preparedInput.evaluatorInput
+        );
+        if (evaluation.status === "error") {
+          const durationMs = Date.now() - startTime;
+          return this.finalizePolicyGateResult(toolContext, evaluation.result, durationMs);
         }
-      );
-      decision = validatePolicyGateDecision(this.policyGateToolId, candidate);
-    } catch (error) {
-      const durationMs = Date.now() - startTime;
-      const errorMessage = toErrorMessage(error);
-      return this.finalizePolicyGateResult(
-        toolContext,
-        {
-          success: false,
-          output: errorMessage,
-          outputSummary: `Error: ${errorMessage.slice(0, 100)}`
-        },
-        durationMs
-      );
-    }
+        if (evaluation.decision.decision === "deny") {
+          const durationMs = Date.now() - startTime;
+          return this.finalizePolicyGateResult(
+            toolContext,
+            buildPolicyGateDeniedToolResult(this.policyGateToolId, evaluation.decision),
+            durationMs
+          );
+        }
 
-    if (decision.decision === "deny") {
-      const durationMs = Date.now() - startTime;
-      if (decision.ruleId === RAW_DATA_WRITE_RULE_ID) {
+        const durationMs = Date.now() - startTime;
         return this.finalizePolicyGateResult(
           toolContext,
-          buildRawDataRuleMisconfiguredResult(this.policyGateToolId, decision),
+          buildPolicyGateDeniedResult(this.policyGateToolId, parsedInput),
           durationMs
         );
       }
-      return this.finalizePolicyGateResult(
-        toolContext,
-        buildPolicyGateDeniedResult(this.policyGateToolId, decision),
-        durationMs
-      );
-    }
 
-    const parsedInput = hasZodParameterSchema
-      ? parseToolZodParameters(this.policyGateToolId, this.innerTool, preparedInput.executionInput)
-      : { decision: "allow" as const, executionInput: preparedInput.executionInput };
-    if (parsedInput.decision === "deny") {
-      const durationMs = Date.now() - startTime;
-      return this.finalizePolicyGateResult(
-        toolContext,
-        buildPolicyGateDeniedResult(this.policyGateToolId, parsedInput),
-        durationMs
-      );
-    }
+      let parsedPreparedInput: {
+        executionInput: unknown;
+        evaluatorInput: unknown;
+      };
+      try {
+        parsedPreparedInput = prepareGenericPolicyGateInputSnapshots(parsedInput.executionInput);
+      } catch {
+        const durationMs = Date.now() - startTime;
+        return this.finalizePolicyGateResult(
+          toolContext,
+          buildPolicyGatePreparationFailedResult(this.policyGateToolId),
+          durationMs
+        );
+      }
 
-    if (hasZodParameterSchema) {
+      const evaluation = await this.evaluatePolicyGateInput(
+        toolContext,
+        role,
+        parsedPreparedInput.evaluatorInput
+      );
+      if (evaluation.status === "error") {
+        const durationMs = Date.now() - startTime;
+        return this.finalizePolicyGateResult(toolContext, evaluation.result, durationMs);
+      }
+      if (evaluation.decision.decision === "deny") {
+        const durationMs = Date.now() - startTime;
+        return this.finalizePolicyGateResult(
+          toolContext,
+          buildPolicyGateDeniedToolResult(this.policyGateToolId, evaluation.decision),
+          durationMs
+        );
+      }
+
       const executionValidationDecision = this.options.validateExecutionInput?.(
-        parsedInput.executionInput
+        parsedPreparedInput.executionInput
       );
       if (executionValidationDecision) {
         const durationMs = Date.now() - startTime;
@@ -668,9 +673,41 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
           durationMs
         );
       }
+
+      return this.innerTool.run(toolContext, parsedPreparedInput.executionInput);
     }
 
-    return this.innerTool.run(toolContext, parsedInput.executionInput);
+    const executionValidationDecision = this.options.validateExecutionInput?.(
+      preparedInput.executionInput
+    );
+    if (executionValidationDecision) {
+      const durationMs = Date.now() - startTime;
+      return this.finalizePolicyGateResult(
+        toolContext,
+        buildPolicyGateDeniedResult(this.policyGateToolId, executionValidationDecision),
+        durationMs
+      );
+    }
+
+    const evaluation = await this.evaluatePolicyGateInput(
+      toolContext,
+      role,
+      preparedInput.evaluatorInput
+    );
+    if (evaluation.status === "error") {
+      const durationMs = Date.now() - startTime;
+      return this.finalizePolicyGateResult(toolContext, evaluation.result, durationMs);
+    }
+    if (evaluation.decision.decision === "deny") {
+      const durationMs = Date.now() - startTime;
+      return this.finalizePolicyGateResult(
+        toolContext,
+        buildPolicyGateDeniedToolResult(this.policyGateToolId, evaluation.decision),
+        durationMs
+      );
+    }
+
+    return this.innerTool.run(toolContext, preparedInput.executionInput);
   }
 
   protected async execute(): Promise<ToolResult> {
@@ -752,6 +789,54 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       evaluatorInput
     };
   }
+
+  private async evaluatePolicyGateInput(
+    toolContext: ToolContext,
+    role: HarnessRole | "unknown",
+    evaluatorInput: unknown
+  ): Promise<
+    | { status: "decision"; decision: PolicyGateDecision }
+    | { status: "error"; result: ToolResult }
+  > {
+    try {
+      const candidate = await this.options.evaluate(
+        {
+          toolId: this.policyGateToolId,
+          role,
+          input: evaluatorInput,
+          workDir: toolContext.workDir
+        },
+        {
+          tool: this.innerTool,
+          toolContext
+        }
+      );
+      return {
+        status: "decision",
+        decision: validatePolicyGateDecision(this.policyGateToolId, candidate)
+      };
+    } catch (error) {
+      const errorMessage = toErrorMessage(error);
+      return {
+        status: "error",
+        result: {
+          success: false,
+          output: errorMessage,
+          outputSummary: `Error: ${errorMessage.slice(0, 100)}`
+        }
+      };
+    }
+  }
+}
+
+function buildPolicyGateDeniedToolResult(
+  toolId: string,
+  decision: Extract<PolicyGateDecision, { decision: "deny" }>
+): ToolResult {
+  if (decision.ruleId === RAW_DATA_WRITE_RULE_ID) {
+    return buildRawDataRuleMisconfiguredResult(toolId, decision);
+  }
+  return buildPolicyGateDeniedResult(toolId, decision);
 }
 
 function createSpawnAgentToolAvailabilityValidator(

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -595,46 +595,87 @@ class ShudRuntimeToolDescriptionAdapter extends BaseTool {
 }
 
 class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
-  readonly policyGateToolId: string;
-  private readonly nameSnapshot: string;
-  private readonly descriptionSnapshot: string;
-  private readonly parametersSnapshot: Record<string, unknown>;
-  private readonly zodParameterSchemaSnapshot: ToolZodParameterSchema | undefined;
+  #innerTool: BaseTool;
+  #policyGateToolId: string;
+  #evaluate: PolicyGateEvaluator;
+  #role: HarnessRole | undefined;
+  #validateExecutionInput: PolicyGateExecutionInputValidator | undefined;
+  #nameSnapshot: string;
+  #descriptionSnapshot: string;
+  #parametersSnapshot: Record<string, unknown>;
+  #zodParameterValidatorSnapshot: ToolZodParameterValidator | undefined;
 
-  constructor(
-    readonly innerTool: BaseTool,
-    private readonly options: PolicyGateWrapperOptions
-  ) {
+  constructor(innerTool: BaseTool, options: PolicyGateWrapperOptions) {
     super();
-    this.policyGateToolId = options.toolId ?? innerTool.name;
-    this.nameSnapshot = innerTool.name;
-    this.descriptionSnapshot = innerTool.description;
-    this.parametersSnapshot = snapshotToolParameters(innerTool.parameters);
-    this.zodParameterSchemaSnapshot = resolveToolZodParameterSchema(innerTool);
-    Object.defineProperty(this, "kind", {
-      configurable: false,
-      enumerable: true,
-      writable: false,
-      value: innerTool.kind
+    this.#innerTool = innerTool;
+    this.#policyGateToolId = options.toolId ?? innerTool.name;
+    this.#evaluate = options.evaluate;
+    this.#role = options.role;
+    this.#validateExecutionInput = options.validateExecutionInput;
+    this.#nameSnapshot = innerTool.name;
+    this.#descriptionSnapshot = innerTool.description;
+    this.#parametersSnapshot = snapshotToolParameters(innerTool.parameters);
+    this.#zodParameterValidatorSnapshot = createStableToolZodParameterValidator(innerTool);
+    Object.defineProperties(this, {
+      name: {
+        configurable: false,
+        enumerable: true,
+        get: () => this.#nameSnapshot
+      },
+      description: {
+        configurable: false,
+        enumerable: true,
+        get: () => this.#descriptionSnapshot
+      },
+      parameters: {
+        configurable: false,
+        enumerable: true,
+        get: () => this.#parametersSnapshot
+      },
+      innerTool: {
+        configurable: false,
+        enumerable: true,
+        get: () => this.#innerTool
+      },
+      policyGateToolId: {
+        configurable: false,
+        enumerable: true,
+        get: () => this.#policyGateToolId
+      },
+      kind: {
+        configurable: false,
+        enumerable: true,
+        writable: false,
+        value: innerTool.kind
+      },
+      requiredModelCapabilities: {
+        configurable: false,
+        enumerable: true,
+        writable: false,
+        value: Object.freeze([...innerTool.requiredModelCapabilities])
+      }
     });
-    Object.defineProperty(this, "requiredModelCapabilities", {
-      configurable: false,
-      enumerable: true,
-      writable: false,
-      value: Object.freeze([...innerTool.requiredModelCapabilities])
-    });
+    Object.preventExtensions(this);
+  }
+
+  get innerTool(): BaseTool {
+    return this.#innerTool;
+  }
+
+  get policyGateToolId(): string {
+    return this.#policyGateToolId;
   }
 
   get name(): string {
-    return this.nameSnapshot;
+    return this.#nameSnapshot;
   }
 
   get description(): string {
-    return this.descriptionSnapshot;
+    return this.#descriptionSnapshot;
   }
 
   get parameters(): Record<string, unknown> {
-    return this.parametersSnapshot;
+    return this.#parametersSnapshot;
   }
 
   toDefinition(): ToolDefinition {
@@ -648,7 +689,7 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
 
   async run(toolContext: ToolContext, input: unknown): Promise<ToolResult> {
     const startTime = Date.now();
-    const role = this.options.role ?? resolveRole(toolContext);
+    const role = this.#role ?? resolveRole(toolContext);
     let preparedInput:
       | {
           decision: "allow";
@@ -662,7 +703,7 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       const durationMs = Date.now() - startTime;
       return this.finalizePolicyGateResult(
         toolContext,
-        buildPolicyGatePreparationFailedResult(this.policyGateToolId),
+        buildPolicyGatePreparationFailedResult(this.#policyGateToolId),
         durationMs
       );
     }
@@ -670,15 +711,15 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       const durationMs = Date.now() - startTime;
       return this.finalizePolicyGateResult(
         toolContext,
-        buildPolicyGateDeniedResult(this.policyGateToolId, preparedInput),
+        buildPolicyGateDeniedResult(this.#policyGateToolId, preparedInput),
         durationMs
       );
     }
 
-    if (this.zodParameterSchemaSnapshot) {
+    if (this.#zodParameterValidatorSnapshot) {
       const parsedInput = parseToolZodParameters(
-        this.policyGateToolId,
-        this.zodParameterSchemaSnapshot,
+        this.#policyGateToolId,
+        this.#zodParameterValidatorSnapshot,
         preparedInput.executionInput
       );
       if (parsedInput.decision === "deny") {
@@ -691,7 +732,7 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
           const durationMs = Date.now() - startTime;
           return this.finalizePolicyGateResult(
             toolContext,
-            buildPolicyGateDeniedToolResult(this.policyGateToolId, evaluation.decision),
+            buildPolicyGateDeniedToolResult(this.#policyGateToolId, evaluation.decision),
             durationMs
           );
         }
@@ -699,7 +740,7 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
         const durationMs = Date.now() - startTime;
         return this.finalizePolicyGateResult(
           toolContext,
-          buildPolicyGateDeniedResult(this.policyGateToolId, parsedInput),
+          buildPolicyGateDeniedResult(this.#policyGateToolId, parsedInput),
           durationMs
         );
       }
@@ -714,7 +755,7 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
         const durationMs = Date.now() - startTime;
         return this.finalizePolicyGateResult(
           toolContext,
-          buildPolicyGatePreparationFailedResult(this.policyGateToolId),
+          buildPolicyGatePreparationFailedResult(this.#policyGateToolId),
           durationMs
         );
       }
@@ -732,34 +773,34 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
         const durationMs = Date.now() - startTime;
         return this.finalizePolicyGateResult(
           toolContext,
-          buildPolicyGateDeniedToolResult(this.policyGateToolId, evaluation.decision),
+          buildPolicyGateDeniedToolResult(this.#policyGateToolId, evaluation.decision),
           durationMs
         );
       }
 
-      const executionValidationDecision = this.options.validateExecutionInput?.(
+      const executionValidationDecision = this.#validateExecutionInput?.(
         parsedPreparedInput.executionInput
       );
       if (executionValidationDecision) {
         const durationMs = Date.now() - startTime;
         return this.finalizePolicyGateResult(
           toolContext,
-          buildPolicyGateDeniedResult(this.policyGateToolId, executionValidationDecision),
+          buildPolicyGateDeniedResult(this.#policyGateToolId, executionValidationDecision),
           durationMs
         );
       }
 
-      return this.innerTool.run(toolContext, parsedPreparedInput.executionInput);
+      return this.#innerTool.run(toolContext, parsedPreparedInput.executionInput);
     }
 
-    const executionValidationDecision = this.options.validateExecutionInput?.(
+    const executionValidationDecision = this.#validateExecutionInput?.(
       preparedInput.executionInput
     );
     if (executionValidationDecision) {
       const durationMs = Date.now() - startTime;
       return this.finalizePolicyGateResult(
         toolContext,
-        buildPolicyGateDeniedResult(this.policyGateToolId, executionValidationDecision),
+        buildPolicyGateDeniedResult(this.#policyGateToolId, executionValidationDecision),
         durationMs
       );
     }
@@ -777,12 +818,12 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       const durationMs = Date.now() - startTime;
       return this.finalizePolicyGateResult(
         toolContext,
-        buildPolicyGateDeniedToolResult(this.policyGateToolId, evaluation.decision),
+        buildPolicyGateDeniedToolResult(this.#policyGateToolId, evaluation.decision),
         durationMs
       );
     }
 
-    return this.innerTool.run(toolContext, preparedInput.executionInput);
+    return this.#innerTool.run(toolContext, preparedInput.executionInput);
   }
 
   protected async execute(): Promise<ToolResult> {
@@ -839,9 +880,9 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
         evaluatorInput: unknown;
       }
     | Extract<PolicyGateDecision, { decision: "deny" }> {
-    if (this.policyGateToolId === "spawn_agent") {
+    if (this.#policyGateToolId === "spawn_agent") {
       const normalizedInput = normalizeSpawnAgentInput({
-        toolId: this.policyGateToolId,
+        toolId: this.#policyGateToolId,
         role,
         input,
         workDir: toolContext.workDir
@@ -874,9 +915,9 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
     | { status: "error"; result: ToolResult }
   > {
     try {
-      const candidate = await this.options.evaluate(
+      const candidate = await this.#evaluate(
         {
-          toolId: this.policyGateToolId,
+          toolId: this.#policyGateToolId,
           role,
           input: evaluatorInput,
           workDir: toolContext.workDir
@@ -888,7 +929,7 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       );
       return {
         status: "decision",
-        decision: validatePolicyGateDecision(this.policyGateToolId, candidate)
+        decision: validatePolicyGateDecision(this.#policyGateToolId, candidate)
       };
     } catch (error) {
       const errorMessage = toErrorMessage(error);
@@ -992,6 +1033,8 @@ type ToolZodParameterSchema = {
   safeParse(input: unknown): ToolZodSafeParseResult;
 };
 
+type ToolZodParameterValidator = (input: unknown) => ToolZodSafeParseResult;
+
 type ToolZodSafeParseResult =
   | {
       success: true;
@@ -1009,14 +1052,14 @@ type ToolZodIssue = {
 
 function parseToolZodParameters(
   toolId: string,
-  schema: ToolZodParameterSchema,
+  safeParse: ToolZodParameterValidator,
   input: unknown
 ):
   | { decision: "allow"; executionInput: unknown }
   | Extract<PolicyGateDecision, { decision: "deny" }> {
   let result: ToolZodSafeParseResult;
   try {
-    result = schema.safeParse(input);
+    result = safeParse(input);
   } catch {
     return buildToolParameterSchemaValidationDeny(
       toolId,
@@ -1032,6 +1075,13 @@ function parseToolZodParameters(
     toolId,
     summarizeToolZodValidationError(result.error)
   );
+}
+
+function createStableToolZodParameterValidator(
+  tool: BaseTool
+): ToolZodParameterValidator | undefined {
+  const schema = resolveToolZodParameterSchema(tool);
+  return schema ? schema.safeParse.bind(schema) : undefined;
 }
 
 function resolveToolZodParameterSchema(tool: BaseTool): ToolZodParameterSchema | undefined {

--- a/packages/core/src/tools/raw-data-sandbox.ts
+++ b/packages/core/src/tools/raw-data-sandbox.ts
@@ -61,6 +61,11 @@ const COMMAND_ANALYSIS_MAX_CALLS = 512;
 const PROCESS_PREFLIGHT_ANALYSIS_MAX_LENGTH = 32_000;
 const STREAM_CAPTURE_MAX_CHARS = 64_000;
 const DEFAULT_ABORT_MESSAGE = "Command aborted by user from Session Detail.";
+const RAW_DATA_SANDBOXED_BASH_DESCRIPTION = [
+  "何时该用: 在 SHUD runtime 中执行需要 shell 的本机命令，并让 raw/evidence 写保护与 fuse 规则生效。",
+  "何时不该用: 不用于修改受保护 raw data 或 evidence 路径，不用于替代结构化领域工具和 PI 审批。",
+  "成功与失败样态: 成功时返回命令输出和摘要；失败时返回 fuse 拒绝、sandbox 拒绝、超时、路径解析或命令退出错误。"
+].join("\n");
 const ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const SANDBOX_ENV_ALLOWLIST = new Set([
   "PATH",
@@ -519,7 +524,7 @@ export class RawDataSandboxedBashTool extends BaseTool {
     const metadataTool = new BashTool(cloneFuseRules(fuseRules));
     this.fuseChecker = new FuseListChecker(cloneFuseRules(fuseRules));
     this.name = options.toolId ?? metadataTool.name;
-    this.description = metadataTool.description;
+    this.description = RAW_DATA_SANDBOXED_BASH_DESCRIPTION;
     this.parameters = rawDataSandboxedBashParameters(metadataTool.parameters);
     this.kind = metadataTool.kind;
     this.requiredModelCapabilities = metadataTool.requiredModelCapabilities;


### PR DESCRIPTION
## Summary

Implements #25 for the M1 tool-registry governance slice.

- Adds registration-time lint for policy-gated tool assemblies:
  - canonical role visible tool count must stay at 20 or below;
  - SHUD runtime tools must include the three Control_Kernel section markers in descriptions.
- Adds pre-execution Zod parameter validation in the policy-gate wrapper.
- Preserves SHUD runtime wrapping for `bash`, `sandbox.exec`, and rebuilt `spawn_agent`.
- Adds OpenSpec fixture evidence for #25.

## Verification

- `npx --yes bun@1.2.19 test ./packages/core/src/tools/policy-gate-registry.test.ts` (`120 pass`, `0 fail`)
- `npx --yes bun@1.2.19 run test:policy-gate` (`330 pass`, `0 fail`)
- `npx --yes bun@1.2.19 run check`
- `openspec validate m1-foundation --strict --no-interactive`
- `git -C zero diff --quiet`
- `git diff --check`
- GitHub checks: `check`, `docs-links`, `linux-base`, `macos-seatbelt`

## Agent Review

Phase 4/4.5/7 completed through five comprehensive review rounds plus targeted invariant audits.

- Round 5 findings:
  - `R5-CORR-01`: confirmed, fixed, verified fixed.
  - `R5-SECPERF-01`: confirmed, fixed, verified fixed.
  - `R5-INT-01`: refuted; #25 requires structured denial when a real Zod parameter schema fails, not universal Zod schemas for every JSON-schema-only tool.
- Gate-level round-5 strategy note recorded locally.
- Final Phase 7 review: `FINAL REVIEW CLEAN` at `8829081f7937a3e51294d442e4a14533262c552c`.

Closes #25.
