### PR TITLE
feat(tools): enforce guard class metadata

### DIFF
--- a/packages/backend/src/ws/index.test.ts
+++ b/packages/backend/src/ws/index.test.ts
@@ -225,32 +225,76 @@ describe("backend ws tool.failed skeleton", () => {
     ).toThrow("Raw-data denial tool.failed events require");
   });
 
-  test("generic tool.failed builder still accepts raw lifecycle failures", () => {
-    const remediation = rawDataWriteRemediation();
+  test("generic tool.failed builder rejects raw lifecycle rule without authority guard", () => {
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 10,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: RAW_DATA_WRITE_RULE_ID,
+        decision: "failed",
+        error: sampleRawLifecycleError()
+      })
+    ).toThrow("Raw-data authority tool.failed events require guardClass authority");
+  });
+
+  test("generic tool.failed builder rejects raw lifecycle rule downgraded to capability", () => {
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 10,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: RAW_DATA_WRITE_RULE_ID,
+        decision: "failed",
+        guardClass: "capability",
+        error: sampleRawLifecycleError()
+      })
+    ).toThrow("Raw-data authority tool.failed events require guardClass authority");
+  });
+
+  test("generic tool.failed builder rejects raw lifecycle error_id without authority guard", () => {
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 10,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: "workspace-quota",
+        decision: "failed",
+        error: sampleRawLifecycleError()
+      })
+    ).toThrow("Raw-data authority tool.failed events require guardClass authority");
+  });
+
+  test("generic tool.failed builder rejects raw lifecycle error_id downgraded to capability", () => {
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 10,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: "workspace-quota",
+        decision: "failed",
+        guardClass: "capability",
+        error: sampleRawLifecycleError()
+      })
+    ).toThrow("Raw-data authority tool.failed events require guardClass authority");
+  });
+
+  test("generic tool.failed builder accepts raw lifecycle failures with authority guard", () => {
     const event = buildToolFailedWsEvent({
       seq: 10,
       timestamp: "2026-07-04T00:00:00.000Z",
       toolId: "bash",
       rule: RAW_DATA_WRITE_RULE_ID,
       decision: "failed",
-      error: {
-        error_id: "raw-data-write:failed:lifecycle",
-        category: "sandbox_error",
-        severity: "error",
-        message: "Bash command failed.",
-        user_message: "Bash command failed.",
-        evidence_refs: [],
-        retryable: false,
-        recommended_next_actions: [remediation.hint],
-        remediation,
-        created_at: "2026-07-04T00:00:00.000Z"
-      }
+      guardClass: "authority",
+      error: sampleRawLifecycleError()
     });
 
     expect(event.payload).toMatchObject({
       tool_id: "bash",
       rule: RAW_DATA_WRITE_RULE_ID,
-      decision: "failed"
+      decision: "failed",
+      guard_class: "authority"
     });
   });
 
@@ -424,6 +468,22 @@ function cloneErrorRecordForTest(error: ErrorRecord): ErrorRecord {
     evidence_refs: [...error.evidence_refs],
     recommended_next_actions: [...error.recommended_next_actions],
     ...(error.remediation ? { remediation: { ...error.remediation } } : {})
+  };
+}
+
+function sampleRawLifecycleError(): ErrorRecord {
+  const remediation = rawDataWriteRemediation();
+  return {
+    error_id: `${RAW_DATA_WRITE_RULE_ID}:failed:lifecycle`,
+    category: "sandbox_error",
+    severity: "error",
+    message: "Bash command failed.",
+    user_message: "Bash command failed.",
+    evidence_refs: [],
+    retryable: false,
+    recommended_next_actions: [remediation.hint],
+    remediation,
+    created_at: "2026-07-04T00:00:00.000Z"
   };
 }
 

--- a/packages/backend/src/ws/index.test.ts
+++ b/packages/backend/src/ws/index.test.ts
@@ -108,6 +108,113 @@ describe("backend ws tool.failed skeleton", () => {
     expect(event.payload.error.user_message).toBe(originalInput.error.user_message);
   });
 
+  test("raw-data advisory builder rejects unstable envelope fields", async () => {
+    const trusted = await sampleTrustedRawDataAdvisoryToolFailedEvent();
+
+    expect(() =>
+      buildRawDataAdvisoryToolFailedWsEvent({
+        seq: Number.NaN,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolResult: trusted.toolResult
+      })
+    ).toThrow("raw-data advisory tool.failed seq must be a finite number");
+
+    expect(() =>
+      buildRawDataAdvisoryToolFailedWsEvent({
+        seq: 17,
+        eventId: {
+          toJSON: () => "evt-forged"
+        } as never,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolResult: trusted.toolResult
+      })
+    ).toThrow("raw-data advisory tool.failed eventId must be a string");
+
+    expect(() =>
+      buildRawDataAdvisoryToolFailedWsEvent({
+        seq: 18,
+        eventId: "evt-18",
+        timestamp: 0 as never,
+        toolResult: trusted.toolResult
+      })
+    ).toThrow("raw-data advisory tool.failed timestamp must be a string");
+
+    expect(() =>
+      buildRawDataAdvisoryToolFailedWsEvent({
+        seq: 19,
+        eventId: "evt-19",
+        timestamp: "x".repeat(140_000),
+        toolResult: trusted.toolResult
+      })
+    ).toThrow("tool.failed input exceeds string budget");
+  });
+
+  test("raw-data advisory builder rejects envelope accessors without executing them", async () => {
+    const trusted = await sampleTrustedRawDataAdvisoryToolFailedEvent();
+    const reads = {
+      toolResult: 0,
+      seq: 0,
+      eventId: 0
+    };
+
+    expect(() =>
+      buildRawDataAdvisoryToolFailedWsEvent({
+        seq: 20,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        get toolResult() {
+          reads.toolResult += 1;
+          return trusted.toolResult;
+        }
+      } as never)
+    ).toThrow("raw-data advisory tool.failed toolResult must be a data field");
+    expect(reads.toolResult).toBe(0);
+
+    expect(() =>
+      buildRawDataAdvisoryToolFailedWsEvent({
+        get seq() {
+          reads.seq += 1;
+          return 21;
+        },
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolResult: trusted.toolResult
+      } as never)
+    ).toThrow("raw-data advisory tool.failed seq must be a data field");
+    expect(reads.seq).toBe(0);
+
+    expect(() =>
+      buildRawDataAdvisoryToolFailedWsEvent({
+        seq: 22,
+        get eventId() {
+          reads.eventId += 1;
+          return "evt-22";
+        },
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolResult: trusted.toolResult
+      } as never)
+    ).toThrow("raw-data advisory tool.failed eventId must be a data field");
+    expect(reads.eventId).toBe(0);
+  });
+
+  test("raw-data advisory builder rejects proxy envelopes before reading traps", async () => {
+    const trusted = await sampleTrustedRawDataAdvisoryToolFailedEvent();
+    const proxy = new Proxy(
+      {
+        seq: 23,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolResult: trusted.toolResult
+      },
+      {
+        get() {
+          throw new Error("proxy trap secret");
+        }
+      }
+    );
+
+    expect(() => buildRawDataAdvisoryToolFailedWsEvent(proxy)).toThrow(
+      "raw-data advisory tool.failed input must be stable structured data"
+    );
+  });
+
   test("raw-data advisory builder rejects caller-authored structural payloads", async () => {
     const advisory = await sampleRawDataAdvisoryDenialPayload();
 

--- a/packages/backend/src/ws/index.test.ts
+++ b/packages/backend/src/ws/index.test.ts
@@ -372,6 +372,68 @@ describe("backend ws tool.failed skeleton", () => {
     ).toThrow("Reserved authority policy rule tool.failed events require guardClass authority");
   });
 
+  test("generic tool.failed builder rejects reserved non-raw error_id prefixes without authority guard", () => {
+    const cases = [
+      {
+        seq: 30,
+        ruleId: SPAWN_PROFILE_SUBSET_RULE_ID,
+        guardClass: undefined
+      },
+      {
+        seq: 31,
+        ruleId: SPAWN_PROFILE_SUBSET_RULE_ID,
+        guardClass: "capability" as const
+      },
+      {
+        seq: 32,
+        ruleId: TOOL_PARAMETER_SCHEMA_RULE_ID,
+        guardClass: undefined
+      },
+      {
+        seq: 33,
+        ruleId: TOOL_PARAMETER_SCHEMA_RULE_ID,
+        guardClass: "capability" as const
+      }
+    ];
+
+    for (const testCase of cases) {
+      expect(() =>
+        buildToolFailedWsEvent({
+          seq: testCase.seq,
+          timestamp: "2026-07-04T00:00:00.000Z",
+          toolId: "bash",
+          decision: "failed",
+          ...(testCase.guardClass ? { guardClass: testCase.guardClass } : {}),
+          error: sampleGenericToolFailedError(`${testCase.ruleId}:failed:error-id-only`)
+        })
+      ).toThrow("Reserved authority policy rule tool.failed events require guardClass authority");
+    }
+  });
+
+  test("generic tool.failed builder accepts reserved non-raw error_id prefixes with authority guard", () => {
+    for (const [index, ruleId] of [
+      SPAWN_PROFILE_SUBSET_RULE_ID,
+      TOOL_PARAMETER_SCHEMA_RULE_ID
+    ].entries()) {
+      const event = buildToolFailedWsEvent({
+        seq: 34 + index,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        decision: "failed",
+        guardClass: "authority",
+        error: sampleGenericToolFailedError(`${ruleId}:failed:error-id-only-authority`)
+      });
+
+      expect(event.payload).toMatchObject({
+        tool_id: "bash",
+        decision: "failed",
+        guard_class: "authority"
+      });
+      expect(event.payload.rule).toBeUndefined();
+      expect(event.payload.error.error_id).toBe(`${ruleId}:failed:error-id-only-authority`);
+    }
+  });
+
   test("generic tool.failed builder accepts reserved non-raw authority rules with authority guard", () => {
     for (const [index, rule] of [
       SPAWN_PROFILE_SUBSET_RULE_ID,
@@ -411,6 +473,23 @@ describe("backend ws tool.failed skeleton", () => {
       rule: "workspace-quota",
       decision: "failed"
     });
+    expect(event.payload.guard_class).toBeUndefined();
+  });
+
+  test("generic tool.failed builder accepts non-reserved error_id without guardClass", () => {
+    const event = buildToolFailedWsEvent({
+      seq: 37,
+      timestamp: "2026-07-04T00:00:00.000Z",
+      toolId: "bash",
+      decision: "failed",
+      error: sampleGenericToolFailedError("workspace-quota:failed:error-id-only")
+    });
+
+    expect(event.payload).toMatchObject({
+      tool_id: "bash",
+      decision: "failed"
+    });
+    expect(event.payload.rule).toBeUndefined();
     expect(event.payload.guard_class).toBeUndefined();
   });
 

--- a/packages/backend/src/ws/index.test.ts
+++ b/packages/backend/src/ws/index.test.ts
@@ -565,47 +565,41 @@ describe("backend ws tool.failed skeleton", () => {
     }
   });
 
-  test("generic tool.failed builder snapshots top-level identity getters", () => {
+  test("generic tool.failed builder rejects top-level identity accessors", () => {
     const reads = {
       rule: 0,
       decision: 0,
       guardClass: 0
     };
-    const event = buildToolFailedWsEvent({
-      seq: 90,
-      timestamp: "2026-07-04T00:00:00.000Z",
-      toolId: "bash",
-      get rule() {
-        reads.rule += 1;
-        return reads.rule === 1
-          ? "workspace-quota"
-          : `${RAW_DATA_WRITE_RULE_ID}:failed:caller-minted`;
-      },
-      get decision() {
-        reads.decision += 1;
-        return reads.decision === 1 ? "failed" : "denied_by_advisory";
-      },
-      get guardClass() {
-        reads.guardClass += 1;
-        return reads.guardClass === 1 ? "authority" : "capability";
-      },
-      error: sampleGenericToolFailedError("workspace-quota:failed:getter-top")
-    });
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 90,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        get rule() {
+          reads.rule += 1;
+          return "workspace-quota";
+        },
+        get decision() {
+          reads.decision += 1;
+          return "failed";
+        },
+        get guardClass() {
+          reads.guardClass += 1;
+          return "authority";
+        },
+        error: sampleGenericToolFailedError("workspace-quota:failed:getter-top")
+      })
+    ).toThrow("tool.failed rule must be a data field");
 
     expect(reads).toEqual({
-      rule: 1,
-      decision: 1,
-      guardClass: 1
-    });
-    expect(event.payload).toMatchObject({
-      tool_id: "bash",
-      rule: "workspace-quota",
-      decision: "failed",
-      guard_class: "authority"
+      rule: 0,
+      decision: 0,
+      guardClass: 0
     });
   });
 
-  test("generic tool.failed builder snapshots nested error_id getters", () => {
+  test("generic tool.failed builder rejects nested error_id accessors", () => {
     const benignErrorId = "workspace-quota:failed:getter-error";
     const reservedErrorId = `${RAW_DATA_WRITE_RULE_ID}:denied_by_sandbox:reserved-profile:TOOL-CALL-WS-GETTER`;
     let errorIdReads = 0;
@@ -624,18 +618,19 @@ describe("backend ws tool.failed skeleton", () => {
       created_at: "2026-07-04T00:00:00.000Z"
     } as ErrorRecord;
 
-    const event = buildToolFailedWsEvent({
-      seq: 91,
-      timestamp: "2026-07-04T00:00:00.000Z",
-      toolId: "bash",
-      rule: "workspace-quota",
-      decision: "failed",
-      guardClass: "authority",
-      error
-    });
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 91,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: "workspace-quota",
+        decision: "failed",
+        guardClass: "authority",
+        error
+      })
+    ).toThrow("tool.failed error.error_id must be a data field");
 
-    expect(errorIdReads).toBe(1);
-    expect(event.payload.error.error_id).toBe(benignErrorId);
+    expect(errorIdReads).toBe(0);
   });
 
   test("generic tool.failed builder snapshots mutable error payloads", () => {
@@ -679,6 +674,77 @@ describe("backend ws tool.failed skeleton", () => {
     expect(event.payload.error.evidence_refs).toEqual(["evidence:before"]);
     expect(event.payload.error.recommended_next_actions).toEqual(["retry after cleanup"]);
     expect(event.payload.error.remediation?.hint).toBe("Repair workspace state.");
+  });
+
+  test("generic tool.failed builder rejects toJSON identity forgery", () => {
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 92,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: {
+          toJSON: () => SPAWN_PROFILE_SUBSET_RULE_ID
+        } as never,
+        decision: "failed",
+        error: sampleGenericToolFailedError("workspace-quota:failed:rule-to-json")
+      })
+    ).toThrow("tool.failed rule must be a string");
+
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 93,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: "workspace-quota",
+        decision: {
+          toJSON: () => "denied_by_sandbox"
+        } as never,
+        error: sampleGenericToolFailedError("workspace-quota:failed:decision-to-json")
+      })
+    ).toThrow("tool.failed decision must be a string");
+
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 94,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: "workspace-quota",
+        decision: "failed",
+        error: {
+          ...sampleGenericToolFailedError("workspace-quota:failed:error-id-to-json"),
+          error_id: {
+            startsWith: () => false,
+            toJSON: () => `${RAW_DATA_WRITE_RULE_ID}:denied_by_sandbox:profile:call`
+          }
+        } as never
+      })
+    ).toThrow("tool.failed error.error_id must be a string");
+  });
+
+  test("generic tool.failed builder rejects reserved error IDs before cloning arrays", () => {
+    const error = sampleGenericToolFailedError(
+      `${RAW_DATA_WRITE_RULE_ID}:denied_by_sandbox:reserved-profile:TOOL-CALL-WS-2`
+    );
+    let evidenceRefsReads = 0;
+    Object.defineProperty(error, "evidence_refs", {
+      enumerable: true,
+      get() {
+        evidenceRefsReads += 1;
+        throw new Error("evidence_refs trap secret");
+      }
+    });
+
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 95,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: "workspace-quota",
+        decision: "failed",
+        error
+      })
+    ).toThrow("Reserved raw-data denial error_id values require");
+    expect(evidenceRefsReads).toBe(0);
   });
 
   test("generic tool.failed builder rejects reserved raw-denial error IDs", () => {

--- a/packages/backend/src/ws/index.test.ts
+++ b/packages/backend/src/ws/index.test.ts
@@ -458,6 +458,76 @@ describe("backend ws tool.failed skeleton", () => {
     }
   });
 
+  test("generic tool.failed builder rejects reserved rule prefix impersonation", () => {
+    for (const [index, rule] of [
+      RAW_DATA_WRITE_RULE_ID,
+      SPAWN_PROFILE_SUBSET_RULE_ID,
+      TOOL_PARAMETER_SCHEMA_RULE_ID
+    ].entries()) {
+      expect(() =>
+        buildToolFailedWsEvent({
+          seq: 60 + index,
+          timestamp: "2026-07-04T00:00:00.000Z",
+          toolId: "bash",
+          rule: `${rule}:failed:caller-minted`,
+          decision: "failed",
+          guardClass: "authority",
+          error: sampleGenericToolFailedError(`workspace-quota:failed:rule-prefix-${index}`)
+        })
+      ).toThrow("Reserved authority policy rule prefixes are reserved for error_id");
+    }
+  });
+
+  test("generic tool.failed builder accepts exact reserved rules with authority guard", () => {
+    for (const [index, rule] of [
+      RAW_DATA_WRITE_RULE_ID,
+      SPAWN_PROFILE_SUBSET_RULE_ID,
+      TOOL_PARAMETER_SCHEMA_RULE_ID
+    ].entries()) {
+      const event = buildToolFailedWsEvent({
+        seq: 70 + index,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule,
+        decision: "failed",
+        guardClass: "authority",
+        error: sampleGenericToolFailedError(`workspace-quota:failed:exact-rule-${index}`)
+      });
+
+      expect(event.payload).toMatchObject({
+        tool_id: "bash",
+        rule,
+        decision: "failed",
+        guard_class: "authority"
+      });
+    }
+  });
+
+  test("generic tool.failed builder accepts legal reserved error_id prefixes with authority guard", () => {
+    for (const [index, rule] of [
+      RAW_DATA_WRITE_RULE_ID,
+      SPAWN_PROFILE_SUBSET_RULE_ID,
+      TOOL_PARAMETER_SCHEMA_RULE_ID
+    ].entries()) {
+      const event = buildToolFailedWsEvent({
+        seq: 80 + index,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        decision: "failed",
+        guardClass: "authority",
+        error: sampleGenericToolFailedError(`${rule}:failed:error-id-authority`)
+      });
+
+      expect(event.payload).toMatchObject({
+        tool_id: "bash",
+        decision: "failed",
+        guard_class: "authority"
+      });
+      expect(event.payload.rule).toBeUndefined();
+      expect(event.payload.error.error_id).toBe(`${rule}:failed:error-id-authority`);
+    }
+  });
+
   test("generic tool.failed builder accepts non-reserved generic failures without guardClass", () => {
     const event = buildToolFailedWsEvent({
       seq: 27,

--- a/packages/backend/src/ws/index.test.ts
+++ b/packages/backend/src/ws/index.test.ts
@@ -8,6 +8,8 @@ import {
   rawDataWriteRemediation,
   RawDataSandboxedBashTool,
   RAW_DATA_WRITE_RULE_ID,
+  SPAWN_PROFILE_SUBSET_RULE_ID,
+  TOOL_PARAMETER_SCHEMA_RULE_ID,
   type ErrorRecord,
   type RawDataToolFailedEventInput,
   type RawDataDenialPayload
@@ -298,6 +300,141 @@ describe("backend ws tool.failed skeleton", () => {
     });
   });
 
+  test("generic tool.failed builder rejects invalid guardClass on non-raw rules", () => {
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 20,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: "workspace-quota",
+        decision: "failed",
+        guardClass: "temporary" as never,
+        error: sampleGenericToolFailedError("workspace-quota:failed:invalid-guard")
+      })
+    ).toThrow("tool.failed guardClass must be authority or capability");
+  });
+
+  test("generic tool.failed builder rejects spawn-profile-subset without guardClass", () => {
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 21,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: SPAWN_PROFILE_SUBSET_RULE_ID,
+        decision: "failed",
+        error: sampleGenericToolFailedError("spawn-profile-subset:failed:missing-guard")
+      })
+    ).toThrow("Reserved authority policy rule tool.failed events require guardClass authority");
+  });
+
+  test("generic tool.failed builder rejects spawn-profile-subset downgraded to capability", () => {
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 22,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: SPAWN_PROFILE_SUBSET_RULE_ID,
+        decision: "failed",
+        guardClass: "capability",
+        error: sampleGenericToolFailedError("spawn-profile-subset:failed:capability-guard")
+      })
+    ).toThrow("Reserved authority policy rule tool.failed events require guardClass authority");
+  });
+
+  test("generic tool.failed builder rejects tool-parameter-schema-validation without guardClass", () => {
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 23,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: TOOL_PARAMETER_SCHEMA_RULE_ID,
+        decision: "failed",
+        error: sampleGenericToolFailedError(
+          "tool-parameter-schema-validation:failed:missing-guard"
+        )
+      })
+    ).toThrow("Reserved authority policy rule tool.failed events require guardClass authority");
+  });
+
+  test("generic tool.failed builder rejects tool-parameter-schema-validation downgraded to capability", () => {
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 24,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: TOOL_PARAMETER_SCHEMA_RULE_ID,
+        decision: "failed",
+        guardClass: "capability",
+        error: sampleGenericToolFailedError(
+          "tool-parameter-schema-validation:failed:capability-guard"
+        )
+      })
+    ).toThrow("Reserved authority policy rule tool.failed events require guardClass authority");
+  });
+
+  test("generic tool.failed builder accepts reserved non-raw authority rules with authority guard", () => {
+    for (const [index, rule] of [
+      SPAWN_PROFILE_SUBSET_RULE_ID,
+      TOOL_PARAMETER_SCHEMA_RULE_ID
+    ].entries()) {
+      const event = buildToolFailedWsEvent({
+        seq: 25 + index,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule,
+        decision: "failed",
+        guardClass: "authority",
+        error: sampleGenericToolFailedError(`${rule}:failed:authority-guard`)
+      });
+
+      expect(event.payload).toMatchObject({
+        tool_id: "bash",
+        rule,
+        decision: "failed",
+        guard_class: "authority"
+      });
+    }
+  });
+
+  test("generic tool.failed builder accepts non-reserved generic failures without guardClass", () => {
+    const event = buildToolFailedWsEvent({
+      seq: 27,
+      timestamp: "2026-07-04T00:00:00.000Z",
+      toolId: "bash",
+      rule: "workspace-quota",
+      decision: "failed",
+      error: sampleGenericToolFailedError("workspace-quota:failed:no-guard")
+    });
+
+    expect(event.payload).toMatchObject({
+      tool_id: "bash",
+      rule: "workspace-quota",
+      decision: "failed"
+    });
+    expect(event.payload.guard_class).toBeUndefined();
+  });
+
+  test("generic tool.failed builder accepts non-reserved generic failures with legal guardClass", () => {
+    for (const guardClass of ["capability", "authority"] as const) {
+      const event = buildToolFailedWsEvent({
+        seq: guardClass === "capability" ? 28 : 29,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: "workspace-quota",
+        decision: "failed",
+        guardClass,
+        error: sampleGenericToolFailedError(`workspace-quota:failed:${guardClass}-guard`)
+      });
+
+      expect(event.payload).toMatchObject({
+        tool_id: "bash",
+        rule: "workspace-quota",
+        decision: "failed",
+        guard_class: guardClass
+      });
+    }
+  });
+
   test("generic tool.failed builder snapshots mutable error payloads", () => {
     const remediation = {
       next_action: "fix_and_retry" as const,
@@ -483,6 +620,20 @@ function sampleRawLifecycleError(): ErrorRecord {
     retryable: false,
     recommended_next_actions: [remediation.hint],
     remediation,
+    created_at: "2026-07-04T00:00:00.000Z"
+  };
+}
+
+function sampleGenericToolFailedError(errorId: string): ErrorRecord {
+  return {
+    error_id: errorId,
+    category: "workspace_error",
+    severity: "error",
+    message: "Workspace quota check failed.",
+    user_message: "Workspace quota check failed.",
+    evidence_refs: [],
+    retryable: true,
+    recommended_next_actions: ["retry after cleanup"],
     created_at: "2026-07-04T00:00:00.000Z"
   };
 }

--- a/packages/backend/src/ws/index.test.ts
+++ b/packages/backend/src/ws/index.test.ts
@@ -584,6 +584,79 @@ describe("backend ws tool.failed skeleton", () => {
     }
   });
 
+  test("generic tool.failed builder snapshots top-level identity getters", () => {
+    const reads = {
+      rule: 0,
+      decision: 0,
+      guardClass: 0
+    };
+    const event = buildToolFailedWsEvent({
+      seq: 90,
+      timestamp: "2026-07-04T00:00:00.000Z",
+      toolId: "bash",
+      get rule() {
+        reads.rule += 1;
+        return reads.rule === 1
+          ? RAW_DATA_WRITE_RULE_ID
+          : `${RAW_DATA_WRITE_RULE_ID}:failed:caller-minted`;
+      },
+      get decision() {
+        reads.decision += 1;
+        return reads.decision === 1 ? "failed" : "denied_by_advisory";
+      },
+      get guardClass() {
+        reads.guardClass += 1;
+        return reads.guardClass === 1 ? "authority" : "capability";
+      },
+      error: sampleRawLifecycleError()
+    });
+
+    expect(reads).toEqual({
+      rule: 1,
+      decision: 1,
+      guardClass: 1
+    });
+    expect(event.payload).toMatchObject({
+      tool_id: "bash",
+      rule: RAW_DATA_WRITE_RULE_ID,
+      decision: "failed",
+      guard_class: "authority"
+    });
+  });
+
+  test("generic tool.failed builder snapshots nested error_id getters", () => {
+    const benignErrorId = "workspace-quota:failed:getter-error";
+    const reservedErrorId = `${RAW_DATA_WRITE_RULE_ID}:denied_by_sandbox:reserved-profile:TOOL-CALL-WS-GETTER`;
+    let errorIdReads = 0;
+    const error = {
+      get error_id() {
+        errorIdReads += 1;
+        return errorIdReads === 1 ? benignErrorId : reservedErrorId;
+      },
+      category: "workspace_error",
+      severity: "error",
+      message: "Workspace quota check failed.",
+      user_message: "Workspace quota check failed.",
+      evidence_refs: [],
+      retryable: true,
+      recommended_next_actions: ["retry after cleanup"],
+      created_at: "2026-07-04T00:00:00.000Z"
+    } as ErrorRecord;
+
+    const event = buildToolFailedWsEvent({
+      seq: 91,
+      timestamp: "2026-07-04T00:00:00.000Z",
+      toolId: "bash",
+      rule: "workspace-quota",
+      decision: "failed",
+      guardClass: "authority",
+      error
+    });
+
+    expect(errorIdReads).toBe(1);
+    expect(event.payload.error.error_id).toBe(benignErrorId);
+  });
+
   test("generic tool.failed builder snapshots mutable error payloads", () => {
     const remediation = {
       next_action: "fix_and_retry" as const,

--- a/packages/backend/src/ws/index.test.ts
+++ b/packages/backend/src/ws/index.test.ts
@@ -281,23 +281,18 @@ describe("backend ws tool.failed skeleton", () => {
     ).toThrow("Raw-data authority tool.failed events require guardClass authority");
   });
 
-  test("generic tool.failed builder accepts raw lifecycle failures with authority guard", () => {
-    const event = buildToolFailedWsEvent({
-      seq: 10,
-      timestamp: "2026-07-04T00:00:00.000Z",
-      toolId: "bash",
-      rule: RAW_DATA_WRITE_RULE_ID,
-      decision: "failed",
-      guardClass: "authority",
-      error: sampleRawLifecycleError()
-    });
-
-    expect(event.payload).toMatchObject({
-      tool_id: "bash",
-      rule: RAW_DATA_WRITE_RULE_ID,
-      decision: "failed",
-      guard_class: "authority"
-    });
+  test("generic tool.failed builder rejects raw lifecycle failures with authority guard", () => {
+    expect(() =>
+      buildToolFailedWsEvent({
+        seq: 10,
+        timestamp: "2026-07-04T00:00:00.000Z",
+        toolId: "bash",
+        rule: RAW_DATA_WRITE_RULE_ID,
+        decision: "failed",
+        guardClass: "authority",
+        error: sampleRawLifecycleError()
+      })
+    ).toThrow("Raw-data authority tool.failed events require trusted producer evidence");
   });
 
   test("generic tool.failed builder rejects invalid guardClass on non-raw rules", () => {
@@ -410,51 +405,40 @@ describe("backend ws tool.failed skeleton", () => {
     }
   });
 
-  test("generic tool.failed builder accepts reserved non-raw error_id prefixes with authority guard", () => {
+  test("generic tool.failed builder rejects reserved non-raw error_id prefixes with authority guard", () => {
     for (const [index, ruleId] of [
       SPAWN_PROFILE_SUBSET_RULE_ID,
       TOOL_PARAMETER_SCHEMA_RULE_ID
     ].entries()) {
-      const event = buildToolFailedWsEvent({
-        seq: 34 + index,
-        timestamp: "2026-07-04T00:00:00.000Z",
-        toolId: "bash",
-        decision: "failed",
-        guardClass: "authority",
-        error: sampleGenericToolFailedError(`${ruleId}:failed:error-id-only-authority`)
-      });
-
-      expect(event.payload).toMatchObject({
-        tool_id: "bash",
-        decision: "failed",
-        guard_class: "authority"
-      });
-      expect(event.payload.rule).toBeUndefined();
-      expect(event.payload.error.error_id).toBe(`${ruleId}:failed:error-id-only-authority`);
+      expect(() =>
+        buildToolFailedWsEvent({
+          seq: 34 + index,
+          timestamp: "2026-07-04T00:00:00.000Z",
+          toolId: "bash",
+          decision: "failed",
+          guardClass: "authority",
+          error: sampleGenericToolFailedError(`${ruleId}:failed:error-id-only-authority`)
+        })
+      ).toThrow("Reserved authority policy tool.failed events require trusted producer evidence");
     }
   });
 
-  test("generic tool.failed builder accepts reserved non-raw authority rules with authority guard", () => {
+  test("generic tool.failed builder rejects reserved non-raw authority rules with authority guard", () => {
     for (const [index, rule] of [
       SPAWN_PROFILE_SUBSET_RULE_ID,
       TOOL_PARAMETER_SCHEMA_RULE_ID
     ].entries()) {
-      const event = buildToolFailedWsEvent({
-        seq: 25 + index,
-        timestamp: "2026-07-04T00:00:00.000Z",
-        toolId: "bash",
-        rule,
-        decision: "failed",
-        guardClass: "authority",
-        error: sampleGenericToolFailedError(`${rule}:failed:authority-guard`)
-      });
-
-      expect(event.payload).toMatchObject({
-        tool_id: "bash",
-        rule,
-        decision: "failed",
-        guard_class: "authority"
-      });
+      expect(() =>
+        buildToolFailedWsEvent({
+          seq: 25 + index,
+          timestamp: "2026-07-04T00:00:00.000Z",
+          toolId: "bash",
+          rule,
+          decision: "failed",
+          guardClass: "authority",
+          error: sampleGenericToolFailedError(`${rule}:failed:authority-guard`)
+        })
+      ).toThrow("Reserved authority policy tool.failed events require trusted producer evidence");
     }
   });
 
@@ -478,53 +462,50 @@ describe("backend ws tool.failed skeleton", () => {
     }
   });
 
-  test("generic tool.failed builder accepts exact reserved rules with authority guard", () => {
+  test("generic tool.failed builder rejects exact reserved rules with authority guard", () => {
     for (const [index, rule] of [
       RAW_DATA_WRITE_RULE_ID,
       SPAWN_PROFILE_SUBSET_RULE_ID,
       TOOL_PARAMETER_SCHEMA_RULE_ID
     ].entries()) {
-      const event = buildToolFailedWsEvent({
-        seq: 70 + index,
-        timestamp: "2026-07-04T00:00:00.000Z",
-        toolId: "bash",
-        rule,
-        decision: "failed",
-        guardClass: "authority",
-        error: sampleGenericToolFailedError(`workspace-quota:failed:exact-rule-${index}`)
-      });
-
-      expect(event.payload).toMatchObject({
-        tool_id: "bash",
-        rule,
-        decision: "failed",
-        guard_class: "authority"
-      });
+      const expected =
+        rule === RAW_DATA_WRITE_RULE_ID
+          ? "Raw-data authority tool.failed events require trusted producer evidence"
+          : "Reserved authority policy tool.failed events require trusted producer evidence";
+      expect(() =>
+        buildToolFailedWsEvent({
+          seq: 70 + index,
+          timestamp: "2026-07-04T00:00:00.000Z",
+          toolId: "bash",
+          rule,
+          decision: "failed",
+          guardClass: "authority",
+          error: sampleGenericToolFailedError(`workspace-quota:failed:exact-rule-${index}`)
+        })
+      ).toThrow(expected);
     }
   });
 
-  test("generic tool.failed builder accepts legal reserved error_id prefixes with authority guard", () => {
+  test("generic tool.failed builder rejects caller-minted reserved error_id prefixes with authority guard", () => {
     for (const [index, rule] of [
       RAW_DATA_WRITE_RULE_ID,
       SPAWN_PROFILE_SUBSET_RULE_ID,
       TOOL_PARAMETER_SCHEMA_RULE_ID
     ].entries()) {
-      const event = buildToolFailedWsEvent({
-        seq: 80 + index,
-        timestamp: "2026-07-04T00:00:00.000Z",
-        toolId: "bash",
-        decision: "failed",
-        guardClass: "authority",
-        error: sampleGenericToolFailedError(`${rule}:failed:error-id-authority`)
-      });
-
-      expect(event.payload).toMatchObject({
-        tool_id: "bash",
-        decision: "failed",
-        guard_class: "authority"
-      });
-      expect(event.payload.rule).toBeUndefined();
-      expect(event.payload.error.error_id).toBe(`${rule}:failed:error-id-authority`);
+      const expected =
+        rule === RAW_DATA_WRITE_RULE_ID
+          ? "Raw-data authority tool.failed events require trusted producer evidence"
+          : "Reserved authority policy tool.failed events require trusted producer evidence";
+      expect(() =>
+        buildToolFailedWsEvent({
+          seq: 80 + index,
+          timestamp: "2026-07-04T00:00:00.000Z",
+          toolId: "bash",
+          decision: "failed",
+          guardClass: "authority",
+          error: sampleGenericToolFailedError(`${rule}:failed:error-id-authority`)
+        })
+      ).toThrow(expected);
     }
   });
 
@@ -597,7 +578,7 @@ describe("backend ws tool.failed skeleton", () => {
       get rule() {
         reads.rule += 1;
         return reads.rule === 1
-          ? RAW_DATA_WRITE_RULE_ID
+          ? "workspace-quota"
           : `${RAW_DATA_WRITE_RULE_ID}:failed:caller-minted`;
       },
       get decision() {
@@ -608,7 +589,7 @@ describe("backend ws tool.failed skeleton", () => {
         reads.guardClass += 1;
         return reads.guardClass === 1 ? "authority" : "capability";
       },
-      error: sampleRawLifecycleError()
+      error: sampleGenericToolFailedError("workspace-quota:failed:getter-top")
     });
 
     expect(reads).toEqual({
@@ -618,7 +599,7 @@ describe("backend ws tool.failed skeleton", () => {
     });
     expect(event.payload).toMatchObject({
       tool_id: "bash",
-      rule: RAW_DATA_WRITE_RULE_ID,
+      rule: "workspace-quota",
       decision: "failed",
       guard_class: "authority"
     });

--- a/packages/backend/src/ws/index.ts
+++ b/packages/backend/src/ws/index.ts
@@ -81,11 +81,12 @@ export function buildToolFailedWsEvent(input: ToolFailedWsEventInput): ToolFaile
 export function buildRawDataAdvisoryToolFailedWsEvent(
   input: RawDataAdvisoryToolFailedWsEventInput
 ): ToolFailedWsEvent {
-  const trustedInput = readRawDataAdvisoryToolFailedWsEventInput(input);
+  const snapshot = snapshotRawDataAdvisoryToolFailedWsEventInput(input);
+  const trustedInput = readRawDataAdvisoryToolFailedWsEventInput(snapshot.toolResult);
   return buildToolFailedWsEventUnchecked({
-    seq: input.seq,
-    eventId: input.eventId,
-    timestamp: input.timestamp,
+    seq: snapshot.seq,
+    eventId: snapshot.eventId,
+    timestamp: snapshot.timestamp,
     ...trustedInput
   });
 }
@@ -172,6 +173,47 @@ function snapshotToolFailedWsEventInput(input: ToolFailedWsEventInput): ToolFail
   return snapshot;
 }
 
+function snapshotRawDataAdvisoryToolFailedWsEventInput(
+  input: RawDataAdvisoryToolFailedWsEventInput
+): RawDataAdvisoryToolFailedWsEventInput {
+  const state: ToolFailedWsSnapshotState = { stringChars: 0 };
+  const inputRecord = readToolFailedWsRecord(input, "raw-data advisory tool.failed input");
+  const toolResult = readOptionalToolFailedWsDataField(
+    inputRecord,
+    "toolResult",
+    "raw-data advisory tool.failed toolResult"
+  ) as RawDataAdvisoryToolFailedWsEventInput["toolResult"];
+  if (toolResult === undefined) {
+    throw new Error(
+      "Raw-data advisory tool.failed events require RawDataSandboxedBashTool trusted evidence."
+    );
+  }
+  const seq = readRequiredToolFailedWsNumberField(
+    inputRecord,
+    "seq",
+    "raw-data advisory tool.failed seq"
+  );
+  const eventId = readOptionalToolFailedWsStringField(
+    inputRecord,
+    "eventId",
+    "raw-data advisory tool.failed eventId",
+    state
+  );
+  const timestamp = readOptionalToolFailedWsStringField(
+    inputRecord,
+    "timestamp",
+    "raw-data advisory tool.failed timestamp",
+    state
+  );
+
+  return {
+    seq,
+    toolResult,
+    ...(eventId !== undefined ? { eventId } : {}),
+    ...(timestamp !== undefined ? { timestamp } : {})
+  };
+}
+
 function snapshotToolFailedWsEventIdentity(
   input: object,
   error: object,
@@ -244,9 +286,9 @@ function assertPublicToolFailedWsEventIdentity(identity: ToolFailedWsEventIdenti
 }
 
 function readRawDataAdvisoryToolFailedWsEventInput(
-  input: RawDataAdvisoryToolFailedWsEventInput
+  toolResult: RawDataAdvisoryToolFailedWsEventInput["toolResult"]
 ): RawDataToolFailedEventInput {
-  const trustedInput = rawDataDeniedToolResultToToolFailedEventInput(input.toolResult);
+  const trustedInput = rawDataDeniedToolResultToToolFailedEventInput(toolResult);
   if (!trustedInput) {
     throw new Error(
       "Raw-data advisory tool.failed events require RawDataSandboxedBashTool trusted evidence."

--- a/packages/backend/src/ws/index.ts
+++ b/packages/backend/src/ws/index.ts
@@ -131,15 +131,20 @@ function assertPublicToolFailedWsEventInput(input: ToolFailedWsEventInput): void
     throw new Error("Reserved authority policy rule prefixes are reserved for error_id.");
   }
   const guardClass = readToolFailedGuardClass(input.guardClass);
-  if (
-    isReservedAuthorityPolicyToolFailedEvent(input) &&
-    guardClass !== "authority"
-  ) {
+  if (isReservedAuthorityPolicyToolFailedEvent(input)) {
+    if (guardClass !== "authority") {
+      if (isRawDataAuthorityToolFailedEvent(input)) {
+        throw new Error("Raw-data authority tool.failed events require guardClass authority.");
+      }
+      throw new Error(
+        "Reserved authority policy rule tool.failed events require guardClass authority."
+      );
+    }
     if (isRawDataAuthorityToolFailedEvent(input)) {
-      throw new Error("Raw-data authority tool.failed events require guardClass authority.");
+      throw new Error("Raw-data authority tool.failed events require trusted producer evidence.");
     }
     throw new Error(
-      "Reserved authority policy rule tool.failed events require guardClass authority."
+      "Reserved authority policy tool.failed events require trusted producer evidence."
     );
   }
 }

--- a/packages/backend/src/ws/index.ts
+++ b/packages/backend/src/ws/index.ts
@@ -95,6 +95,9 @@ function assertPublicToolFailedWsEventInput(input: ToolFailedWsEventInput): void
       "Reserved raw-data denial error_id values require the trusted raw-data advisory event builder."
     );
   }
+  if (isRawDataAuthorityToolFailedEvent(input) && input.guardClass !== "authority") {
+    throw new Error("Raw-data authority tool.failed events require guardClass authority.");
+  }
 }
 
 function readRawDataAdvisoryToolFailedWsEventInput(
@@ -118,6 +121,19 @@ function readRawDataAdvisoryToolFailedWsEventInput(
 
 function isRawDataDenialDecision(decision: string | undefined): boolean {
   return decision === "denied_by_advisory" || decision === "denied_by_sandbox";
+}
+
+function isRawDataAuthorityToolFailedEvent(input: ToolFailedWsEventInput): boolean {
+  return (
+    input.rule === RAW_DATA_WRITE_RULE_ID || isRawDataAuthorityErrorId(input.error.error_id)
+  );
+}
+
+function isRawDataAuthorityErrorId(errorId: string | undefined): boolean {
+  return (
+    errorId === RAW_DATA_WRITE_RULE_ID ||
+    errorId?.startsWith(`${RAW_DATA_WRITE_RULE_ID}:`) === true
+  );
 }
 
 function cloneErrorRecord(error: ErrorRecord): ErrorRecord {

--- a/packages/backend/src/ws/index.ts
+++ b/packages/backend/src/ws/index.ts
@@ -1,5 +1,7 @@
 import {
   assertTrustedRawDataToolFailedEventInput,
+  ErrorRemediationSchema,
+  ErrorRecordSchema,
   isReservedAuthorityPolicyErrorId,
   isReservedAuthorityPolicyRuleId,
   isReservedAuthorityPolicyRuleIdPrefixImpersonation,
@@ -11,6 +13,7 @@ import {
   type PolicyGuardClass,
   type RawDataToolFailedEventInput
 } from "@shud-harness/core";
+import { types as nodeUtilTypes } from "node:util";
 
 export const BACKEND_WS_NAMESPACE = "backend/ws" as const;
 
@@ -28,6 +31,24 @@ export interface ToolFailedWsEventInput {
   eventId?: string;
   timestamp?: string;
 }
+
+type ToolFailedWsEventIdentity = {
+  errorId: string;
+  rule?: string;
+  decision?: string;
+  guardClass?: PolicyGuardClass;
+};
+
+type ToolFailedWsSnapshotState = {
+  stringChars: number;
+};
+
+type ToolFailedWsDataDescriptor = PropertyDescriptor & {
+  value: unknown;
+};
+
+const TOOL_FAILED_WS_MAX_ARRAY_LENGTH = 1_024;
+const TOOL_FAILED_WS_MAX_STRING_CHARS = 131_072;
 
 export type RawDataAdvisoryToolFailedWsEventInput = Pick<
   ToolFailedWsEventInput,
@@ -54,7 +75,6 @@ export interface ToolFailedWsEvent {
 
 export function buildToolFailedWsEvent(input: ToolFailedWsEventInput): ToolFailedWsEvent {
   const snapshot = snapshotToolFailedWsEventInput(input);
-  assertPublicToolFailedWsEventInput(snapshot);
   return buildToolFailedWsEventUnchecked(snapshot);
 }
 
@@ -91,56 +111,130 @@ function buildToolFailedWsEventUnchecked(input: ToolFailedWsEventInput): ToolFai
 }
 
 function snapshotToolFailedWsEventInput(input: ToolFailedWsEventInput): ToolFailedWsEventInput {
-  const seq = input.seq;
-  const toolId = input.toolId;
-  const error = cloneErrorRecord(input.error);
-  const rule = input.rule;
-  const decision = input.decision;
-  const guardClass = input.guardClass;
-  const profileId = input.profileId;
-  const invocationId = input.invocationId;
-  const eventId = input.eventId;
-  const timestamp = input.timestamp;
+  const state: ToolFailedWsSnapshotState = { stringChars: 0 };
+  const inputRecord = readToolFailedWsRecord(input, "tool.failed input");
+  const errorInput = readRequiredToolFailedWsRecordField(
+    inputRecord,
+    "error",
+    "tool.failed error"
+  );
+  const errorRecord = readToolFailedWsRecord(errorInput, "tool.failed error");
+  const identity = snapshotToolFailedWsEventIdentity(inputRecord, errorRecord, state);
+  assertPublicToolFailedWsEventIdentity(identity);
 
-  return {
+  const seq = readRequiredToolFailedWsNumberField(inputRecord, "seq", "tool.failed seq");
+  const toolId = readRequiredToolFailedWsStringField(
+    inputRecord,
+    "toolId",
+    "tool.failed toolId",
+    state
+  );
+  const error = cloneErrorRecord(errorRecord, state);
+  const profileId = readOptionalToolFailedWsStringField(
+    inputRecord,
+    "profileId",
+    "tool.failed profileId",
+    state
+  );
+  const invocationId = readOptionalToolFailedWsStringField(
+    inputRecord,
+    "invocationId",
+    "tool.failed invocationId",
+    state
+  );
+  const eventId = readOptionalToolFailedWsStringField(
+    inputRecord,
+    "eventId",
+    "tool.failed eventId",
+    state
+  );
+  const timestamp = readOptionalToolFailedWsStringField(
+    inputRecord,
+    "timestamp",
+    "tool.failed timestamp",
+    state
+  );
+
+  const snapshot = {
     seq,
     toolId,
     error,
-    ...(rule !== undefined ? { rule } : {}),
-    ...(decision !== undefined ? { decision } : {}),
-    ...(guardClass !== undefined ? { guardClass } : {}),
+    ...(identity.rule !== undefined ? { rule: identity.rule } : {}),
+    ...(identity.decision !== undefined ? { decision: identity.decision } : {}),
+    ...(identity.guardClass !== undefined ? { guardClass: identity.guardClass } : {}),
     ...(profileId !== undefined ? { profileId } : {}),
     ...(invocationId !== undefined ? { invocationId } : {}),
     ...(eventId !== undefined ? { eventId } : {}),
     ...(timestamp !== undefined ? { timestamp } : {})
   };
+
+  assertPublicToolFailedWsEventInput(snapshot);
+  return snapshot;
+}
+
+function snapshotToolFailedWsEventIdentity(
+  input: object,
+  error: object,
+  state: ToolFailedWsSnapshotState
+): ToolFailedWsEventIdentity {
+  const errorId = readRequiredToolFailedWsStringField(
+    error,
+    "error_id",
+    "tool.failed error.error_id",
+    state
+  );
+  const rule = readOptionalToolFailedWsStringField(input, "rule", "tool.failed rule", state);
+  const decision = readOptionalToolFailedWsStringField(
+    input,
+    "decision",
+    "tool.failed decision",
+    state
+  );
+  const guardClass = readToolFailedGuardClass(
+    readOptionalToolFailedWsDataField(input, "guardClass", "tool.failed guardClass")
+  );
+
+  return {
+    errorId,
+    ...(rule !== undefined ? { rule } : {}),
+    ...(decision !== undefined ? { decision } : {}),
+    ...(guardClass !== undefined ? { guardClass } : {})
+  };
 }
 
 function assertPublicToolFailedWsEventInput(input: ToolFailedWsEventInput): void {
-  if (isRawDataDenialDecision(input.decision)) {
+  assertPublicToolFailedWsEventIdentity({
+    errorId: input.error.error_id,
+    ...(input.rule !== undefined ? { rule: input.rule } : {}),
+    ...(input.decision !== undefined ? { decision: input.decision } : {}),
+    ...(input.guardClass !== undefined ? { guardClass: input.guardClass } : {})
+  });
+}
+
+function assertPublicToolFailedWsEventIdentity(identity: ToolFailedWsEventIdentity): void {
+  if (isRawDataDenialDecision(identity.decision)) {
     throw new Error(
       "Raw-data denial tool.failed events require the trusted raw-data advisory event builder."
     );
   }
-  if (isReservedRawDataDenialErrorId(input.error.error_id)) {
+  if (isReservedRawDataDenialErrorId(identity.errorId)) {
     throw new Error(
       "Reserved raw-data denial error_id values require the trusted raw-data advisory event builder."
     );
   }
-  if (isReservedAuthorityPolicyRuleIdPrefixImpersonation(input.rule)) {
+  if (isReservedAuthorityPolicyRuleIdPrefixImpersonation(identity.rule)) {
     throw new Error("Reserved authority policy rule prefixes are reserved for error_id.");
   }
-  const guardClass = readToolFailedGuardClass(input.guardClass);
-  if (isReservedAuthorityPolicyToolFailedEvent(input)) {
-    if (guardClass !== "authority") {
-      if (isRawDataAuthorityToolFailedEvent(input)) {
+  if (isReservedAuthorityPolicyToolFailedEvent(identity)) {
+    if (identity.guardClass !== "authority") {
+      if (isRawDataAuthorityToolFailedEvent(identity)) {
         throw new Error("Raw-data authority tool.failed events require guardClass authority.");
       }
       throw new Error(
         "Reserved authority policy rule tool.failed events require guardClass authority."
       );
     }
-    if (isRawDataAuthorityToolFailedEvent(input)) {
+    if (isRawDataAuthorityToolFailedEvent(identity)) {
       throw new Error("Raw-data authority tool.failed events require trusted producer evidence.");
     }
     throw new Error(
@@ -183,16 +277,16 @@ function readToolFailedGuardClass(guardClass: unknown): PolicyGuardClass | undef
   return parsed.data;
 }
 
-function isRawDataAuthorityToolFailedEvent(input: ToolFailedWsEventInput): boolean {
+function isRawDataAuthorityToolFailedEvent(input: ToolFailedWsEventIdentity): boolean {
   return (
-    input.rule === RAW_DATA_WRITE_RULE_ID || isRawDataAuthorityErrorId(input.error.error_id)
+    input.rule === RAW_DATA_WRITE_RULE_ID || isRawDataAuthorityErrorId(input.errorId)
   );
 }
 
-function isReservedAuthorityPolicyToolFailedEvent(input: ToolFailedWsEventInput): boolean {
+function isReservedAuthorityPolicyToolFailedEvent(input: ToolFailedWsEventIdentity): boolean {
   return (
     isReservedAuthorityPolicyRuleId(input.rule ?? "") ||
-    isReservedAuthorityPolicyErrorId(input.error.error_id)
+    isReservedAuthorityPolicyErrorId(input.errorId)
   );
 }
 
@@ -203,21 +297,310 @@ function isRawDataAuthorityErrorId(errorId: string | undefined): boolean {
   );
 }
 
-function cloneErrorRecord(error: ErrorRecord): ErrorRecord {
-  return {
-    error_id: error.error_id,
-    category: error.category,
-    severity: error.severity,
-    ...(error.task_id !== undefined ? { task_id: error.task_id } : {}),
-    ...(error.job_id !== undefined ? { job_id: error.job_id } : {}),
-    ...(error.run_id !== undefined ? { run_id: error.run_id } : {}),
-    ...(error.report_id !== undefined ? { report_id: error.report_id } : {}),
-    message: error.message,
-    user_message: error.user_message,
-    evidence_refs: [...error.evidence_refs],
-    retryable: error.retryable,
-    recommended_next_actions: [...error.recommended_next_actions],
-    ...(error.remediation !== undefined ? { remediation: { ...error.remediation } } : {}),
-    created_at: error.created_at
+function cloneErrorRecord(
+  error: ErrorRecord | object,
+  state: ToolFailedWsSnapshotState = { stringChars: 0 }
+): ErrorRecord {
+  const errorRecord = readToolFailedWsRecord(error, "tool.failed error");
+  const snapshot = {
+    error_id: readRequiredToolFailedWsStringField(
+      errorRecord,
+      "error_id",
+      "tool.failed error.error_id",
+      state
+    ),
+    category: readRequiredToolFailedWsStringField(
+      errorRecord,
+      "category",
+      "tool.failed error.category",
+      state
+    ),
+    severity: readRequiredToolFailedWsStringField(
+      errorRecord,
+      "severity",
+      "tool.failed error.severity",
+      state
+    ),
+    ...readOptionalErrorRecordStringField(
+      errorRecord,
+      "task_id",
+      "tool.failed error.task_id",
+      state
+    ),
+    ...readOptionalErrorRecordStringField(
+      errorRecord,
+      "job_id",
+      "tool.failed error.job_id",
+      state
+    ),
+    ...readOptionalErrorRecordStringField(
+      errorRecord,
+      "run_id",
+      "tool.failed error.run_id",
+      state
+    ),
+    ...readOptionalErrorRecordStringField(
+      errorRecord,
+      "report_id",
+      "tool.failed error.report_id",
+      state
+    ),
+    message: readRequiredToolFailedWsStringField(
+      errorRecord,
+      "message",
+      "tool.failed error.message",
+      state
+    ),
+    user_message: readRequiredToolFailedWsStringField(
+      errorRecord,
+      "user_message",
+      "tool.failed error.user_message",
+      state
+    ),
+    evidence_refs: readToolFailedWsStringArrayField(
+      errorRecord,
+      "evidence_refs",
+      "tool.failed error.evidence_refs",
+      state
+    ),
+    retryable: readRequiredToolFailedWsBooleanField(
+      errorRecord,
+      "retryable",
+      "tool.failed error.retryable"
+    ),
+    recommended_next_actions: readToolFailedWsStringArrayField(
+      errorRecord,
+      "recommended_next_actions",
+      "tool.failed error.recommended_next_actions",
+      state
+    ),
+    ...readOptionalErrorRecordRemediation(errorRecord, state),
+    created_at: readRequiredToolFailedWsStringField(
+      errorRecord,
+      "created_at",
+      "tool.failed error.created_at",
+      state
+    )
   };
+  const parsed = ErrorRecordSchema.safeParse(snapshot);
+  if (!parsed.success) {
+    throw new Error("tool.failed error must match ErrorRecord schema.");
+  }
+  return parsed.data;
+}
+
+function readOptionalErrorRecordStringField(
+  carrier: object,
+  key: "task_id" | "job_id" | "run_id" | "report_id",
+  label: string,
+  state: ToolFailedWsSnapshotState
+): Partial<Pick<ErrorRecord, "task_id" | "job_id" | "run_id" | "report_id">> {
+  const value = readOptionalToolFailedWsStringField(carrier, key, label, state);
+  return value !== undefined ? { [key]: value } : {};
+}
+
+function readOptionalErrorRecordRemediation(
+  carrier: object,
+  state: ToolFailedWsSnapshotState
+): Pick<ErrorRecord, "remediation"> | Record<string, never> {
+  const value = readOptionalToolFailedWsDataField(
+    carrier,
+    "remediation",
+    "tool.failed error.remediation"
+  );
+  if (value === undefined) {
+    return {};
+  }
+  const remediation = readToolFailedWsRecord(value, "tool.failed error.remediation");
+  const snapshot = {
+    next_action: readRequiredToolFailedWsStringField(
+      remediation,
+      "next_action",
+      "tool.failed error.remediation.next_action",
+      state
+    ),
+    hint: readRequiredToolFailedWsStringField(
+      remediation,
+      "hint",
+      "tool.failed error.remediation.hint",
+      state
+    ),
+    ...readOptionalRemediationRef(remediation, state)
+  };
+  const parsed = ErrorRemediationSchema.safeParse(snapshot);
+  if (!parsed.success) {
+    throw new Error("tool.failed error.remediation must match ErrorRecord remediation schema.");
+  }
+  return {
+    remediation: parsed.data
+  };
+}
+
+function readOptionalRemediationRef(
+  remediation: object,
+  state: ToolFailedWsSnapshotState
+): { ref: string } | Record<string, never> {
+  const ref = readOptionalToolFailedWsStringField(
+    remediation,
+    "ref",
+    "tool.failed error.remediation.ref",
+    state
+  );
+  return ref !== undefined ? { ref } : {};
+}
+
+function readToolFailedWsRecord(value: unknown, label: string): object {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be a plain object.`);
+  }
+  if (nodeUtilTypes.isProxy(value)) {
+    throw new Error(`${label} must be stable structured data.`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`${label} must be a plain object.`);
+  }
+  return value;
+}
+
+function readRequiredToolFailedWsRecordField(
+  carrier: object,
+  key: string,
+  label: string
+): object {
+  return readToolFailedWsRecord(readRequiredToolFailedWsDataField(carrier, key, label), label);
+}
+
+function readRequiredToolFailedWsStringField(
+  carrier: object,
+  key: string,
+  label: string,
+  state: ToolFailedWsSnapshotState
+): string {
+  const value = readRequiredToolFailedWsDataField(carrier, key, label);
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string.`);
+  }
+  addToolFailedWsStringBudget(value.length, state);
+  return value;
+}
+
+function readOptionalToolFailedWsStringField(
+  carrier: object,
+  key: string,
+  label: string,
+  state: ToolFailedWsSnapshotState
+): string | undefined {
+  const value = readOptionalToolFailedWsDataField(carrier, key, label);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string.`);
+  }
+  addToolFailedWsStringBudget(value.length, state);
+  return value;
+}
+
+function readRequiredToolFailedWsNumberField(
+  carrier: object,
+  key: string,
+  label: string
+): number {
+  const value = readRequiredToolFailedWsDataField(carrier, key, label);
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${label} must be a finite number.`);
+  }
+  return value;
+}
+
+function readRequiredToolFailedWsBooleanField(
+  carrier: object,
+  key: string,
+  label: string
+): boolean {
+  const value = readRequiredToolFailedWsDataField(carrier, key, label);
+  if (typeof value !== "boolean") {
+    throw new Error(`${label} must be a boolean.`);
+  }
+  return value;
+}
+
+function readToolFailedWsStringArrayField(
+  carrier: object,
+  key: string,
+  label: string,
+  state: ToolFailedWsSnapshotState
+): string[] {
+  const value = readRequiredToolFailedWsDataField(carrier, key, label);
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be a string array.`);
+  }
+  if (nodeUtilTypes.isProxy(value) || Object.getPrototypeOf(value) !== Array.prototype) {
+    throw new Error(`${label} must be an ordinary string array.`);
+  }
+  if (value.length > TOOL_FAILED_WS_MAX_ARRAY_LENGTH) {
+    throw new Error(`${label} exceeds array length budget.`);
+  }
+  const copy: string[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const descriptor = readToolFailedWsDataDescriptor(value, String(index), label);
+    if (!descriptor || typeof descriptor.value !== "string") {
+      throw new Error(`${label} must contain only strings.`);
+    }
+    addToolFailedWsStringBudget(descriptor.value.length, state);
+    copy.push(descriptor.value);
+  }
+  return copy;
+}
+
+function readRequiredToolFailedWsDataField(
+  carrier: object,
+  key: string,
+  label: string
+): unknown {
+  const value = readOptionalToolFailedWsDataField(carrier, key, label);
+  if (value === undefined) {
+    throw new Error(`${label} is required.`);
+  }
+  return value;
+}
+
+function readOptionalToolFailedWsDataField(
+  carrier: object,
+  key: string,
+  label: string
+): unknown {
+  const descriptor = readToolFailedWsDataDescriptor(carrier, key, label);
+  return descriptor?.value;
+}
+
+function readToolFailedWsDataDescriptor(
+  carrier: object,
+  key: string,
+  label: string
+): ToolFailedWsDataDescriptor | undefined {
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = Object.getOwnPropertyDescriptor(carrier, key);
+  } catch {
+    throw new Error(`${label} must be stable structured data.`);
+  }
+  if (!descriptor) {
+    return undefined;
+  }
+  if (!("value" in descriptor) || descriptor.get !== undefined || descriptor.set !== undefined) {
+    throw new Error(`${label} must be a data field.`);
+  }
+  return descriptor as ToolFailedWsDataDescriptor;
+}
+
+function addToolFailedWsStringBudget(
+  length: number,
+  state: ToolFailedWsSnapshotState
+): void {
+  state.stringChars += length;
+  if (state.stringChars > TOOL_FAILED_WS_MAX_STRING_CHARS) {
+    throw new Error("tool.failed input exceeds string budget.");
+  }
 }

--- a/packages/backend/src/ws/index.ts
+++ b/packages/backend/src/ws/index.ts
@@ -53,8 +53,9 @@ export interface ToolFailedWsEvent {
 }
 
 export function buildToolFailedWsEvent(input: ToolFailedWsEventInput): ToolFailedWsEvent {
-  assertPublicToolFailedWsEventInput(input);
-  return buildToolFailedWsEventUnchecked(input);
+  const snapshot = snapshotToolFailedWsEventInput(input);
+  assertPublicToolFailedWsEventInput(snapshot);
+  return buildToolFailedWsEventUnchecked(snapshot);
 }
 
 export function buildRawDataAdvisoryToolFailedWsEvent(
@@ -86,6 +87,32 @@ function buildToolFailedWsEventUnchecked(input: ToolFailedWsEventInput): ToolFai
       ...(input.profileId ? { profile_id: input.profileId } : {}),
       ...(input.invocationId ? { invocation_id: input.invocationId } : {})
     }
+  };
+}
+
+function snapshotToolFailedWsEventInput(input: ToolFailedWsEventInput): ToolFailedWsEventInput {
+  const seq = input.seq;
+  const toolId = input.toolId;
+  const error = cloneErrorRecord(input.error);
+  const rule = input.rule;
+  const decision = input.decision;
+  const guardClass = input.guardClass;
+  const profileId = input.profileId;
+  const invocationId = input.invocationId;
+  const eventId = input.eventId;
+  const timestamp = input.timestamp;
+
+  return {
+    seq,
+    toolId,
+    error,
+    ...(rule !== undefined ? { rule } : {}),
+    ...(decision !== undefined ? { decision } : {}),
+    ...(guardClass !== undefined ? { guardClass } : {}),
+    ...(profileId !== undefined ? { profileId } : {}),
+    ...(invocationId !== undefined ? { invocationId } : {}),
+    ...(eventId !== undefined ? { eventId } : {}),
+    ...(timestamp !== undefined ? { timestamp } : {})
   };
 }
 

--- a/packages/backend/src/ws/index.ts
+++ b/packages/backend/src/ws/index.ts
@@ -1,6 +1,6 @@
 import {
   assertTrustedRawDataToolFailedEventInput,
-  isReservedAuthorityPolicyRuleId,
+  isReservedAuthorityPolicyEvidenceId,
   isReservedRawDataDenialErrorId,
   PolicyGuardClassSchema,
   rawDataDeniedToolResultToToolFailedEventInput,
@@ -99,14 +99,13 @@ function assertPublicToolFailedWsEventInput(input: ToolFailedWsEventInput): void
     );
   }
   const guardClass = readToolFailedGuardClass(input.guardClass);
-  if (isRawDataAuthorityToolFailedEvent(input) && guardClass !== "authority") {
-    throw new Error("Raw-data authority tool.failed events require guardClass authority.");
-  }
   if (
-    input.rule &&
-    isReservedAuthorityPolicyRuleId(input.rule) &&
+    isReservedAuthorityPolicyToolFailedEvent(input) &&
     guardClass !== "authority"
   ) {
+    if (isRawDataAuthorityToolFailedEvent(input)) {
+      throw new Error("Raw-data authority tool.failed events require guardClass authority.");
+    }
     throw new Error(
       "Reserved authority policy rule tool.failed events require guardClass authority."
     );
@@ -150,6 +149,13 @@ function readToolFailedGuardClass(guardClass: unknown): PolicyGuardClass | undef
 function isRawDataAuthorityToolFailedEvent(input: ToolFailedWsEventInput): boolean {
   return (
     input.rule === RAW_DATA_WRITE_RULE_ID || isRawDataAuthorityErrorId(input.error.error_id)
+  );
+}
+
+function isReservedAuthorityPolicyToolFailedEvent(input: ToolFailedWsEventInput): boolean {
+  return (
+    isReservedAuthorityPolicyEvidenceId(input.rule) ||
+    isReservedAuthorityPolicyEvidenceId(input.error.error_id)
   );
 }
 

--- a/packages/backend/src/ws/index.ts
+++ b/packages/backend/src/ws/index.ts
@@ -1,6 +1,8 @@
 import {
   assertTrustedRawDataToolFailedEventInput,
-  isReservedAuthorityPolicyEvidenceId,
+  isReservedAuthorityPolicyErrorId,
+  isReservedAuthorityPolicyRuleId,
+  isReservedAuthorityPolicyRuleIdPrefixImpersonation,
   isReservedRawDataDenialErrorId,
   PolicyGuardClassSchema,
   rawDataDeniedToolResultToToolFailedEventInput,
@@ -98,6 +100,9 @@ function assertPublicToolFailedWsEventInput(input: ToolFailedWsEventInput): void
       "Reserved raw-data denial error_id values require the trusted raw-data advisory event builder."
     );
   }
+  if (isReservedAuthorityPolicyRuleIdPrefixImpersonation(input.rule)) {
+    throw new Error("Reserved authority policy rule prefixes are reserved for error_id.");
+  }
   const guardClass = readToolFailedGuardClass(input.guardClass);
   if (
     isReservedAuthorityPolicyToolFailedEvent(input) &&
@@ -154,8 +159,8 @@ function isRawDataAuthorityToolFailedEvent(input: ToolFailedWsEventInput): boole
 
 function isReservedAuthorityPolicyToolFailedEvent(input: ToolFailedWsEventInput): boolean {
   return (
-    isReservedAuthorityPolicyEvidenceId(input.rule) ||
-    isReservedAuthorityPolicyEvidenceId(input.error.error_id)
+    isReservedAuthorityPolicyRuleId(input.rule ?? "") ||
+    isReservedAuthorityPolicyErrorId(input.error.error_id)
   );
 }
 

--- a/packages/backend/src/ws/index.ts
+++ b/packages/backend/src/ws/index.ts
@@ -1,9 +1,12 @@
 import {
   assertTrustedRawDataToolFailedEventInput,
+  isReservedAuthorityPolicyRuleId,
   isReservedRawDataDenialErrorId,
+  PolicyGuardClassSchema,
   rawDataDeniedToolResultToToolFailedEventInput,
   RAW_DATA_WRITE_RULE_ID,
   type ErrorRecord,
+  type PolicyGuardClass,
   type RawDataToolFailedEventInput
 } from "@shud-harness/core";
 
@@ -17,7 +20,7 @@ export interface ToolFailedWsEventInput {
   error: ErrorRecord;
   rule?: string;
   decision?: string;
-  guardClass?: string;
+  guardClass?: PolicyGuardClass;
   profileId?: string;
   invocationId?: string;
   eventId?: string;
@@ -41,7 +44,7 @@ export interface ToolFailedWsEvent {
     error: ErrorRecord;
     rule?: string;
     decision?: string;
-    guard_class?: string;
+    guard_class?: PolicyGuardClass;
     profile_id?: string;
     invocation_id?: string;
   };
@@ -95,8 +98,18 @@ function assertPublicToolFailedWsEventInput(input: ToolFailedWsEventInput): void
       "Reserved raw-data denial error_id values require the trusted raw-data advisory event builder."
     );
   }
-  if (isRawDataAuthorityToolFailedEvent(input) && input.guardClass !== "authority") {
+  const guardClass = readToolFailedGuardClass(input.guardClass);
+  if (isRawDataAuthorityToolFailedEvent(input) && guardClass !== "authority") {
     throw new Error("Raw-data authority tool.failed events require guardClass authority.");
+  }
+  if (
+    input.rule &&
+    isReservedAuthorityPolicyRuleId(input.rule) &&
+    guardClass !== "authority"
+  ) {
+    throw new Error(
+      "Reserved authority policy rule tool.failed events require guardClass authority."
+    );
   }
 }
 
@@ -121,6 +134,17 @@ function readRawDataAdvisoryToolFailedWsEventInput(
 
 function isRawDataDenialDecision(decision: string | undefined): boolean {
   return decision === "denied_by_advisory" || decision === "denied_by_sandbox";
+}
+
+function readToolFailedGuardClass(guardClass: unknown): PolicyGuardClass | undefined {
+  if (guardClass === undefined) {
+    return undefined;
+  }
+  const parsed = PolicyGuardClassSchema.safeParse(guardClass);
+  if (!parsed.success) {
+    throw new Error("tool.failed guardClass must be authority or capability.");
+  }
+  return parsed.data;
 }
 
 function isRawDataAuthorityToolFailedEvent(input: ToolFailedWsEventInput): boolean {

--- a/packages/core/src/tools/policy-gate-core.test.ts
+++ b/packages/core/src/tools/policy-gate-core.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
   assertPolicyGateContextGuardClasses,
   evaluatePolicyGate,
-  isReservedAuthorityPolicyEvidenceId,
+  isReservedAuthorityPolicyErrorId,
+  isReservedAuthorityPolicyRuleIdPrefixImpersonation,
   isReservedAuthorityPolicyRuleId,
   normalizeSpawnAgentInput,
   PolicyGateRemediationSchema,
@@ -161,19 +162,37 @@ describe("policy gate pure evaluator", () => {
     );
   });
 
-  test("reserved authority evidence helper matches exact rule ids and error-id prefixes", () => {
+  test("reserved authority identity helpers are field-specific", () => {
     for (const ruleId of RESERVED_AUTHORITY_POLICY_RULE_IDS) {
-      expect(isReservedAuthorityPolicyEvidenceId(ruleId)).toBe(true);
-      expect(isReservedAuthorityPolicyEvidenceId(`${ruleId}:failed:tool-call-1`)).toBe(true);
+      expect(isReservedAuthorityPolicyRuleId(ruleId)).toBe(true);
+      expect(isReservedAuthorityPolicyErrorId(ruleId)).toBe(true);
+      expect(isReservedAuthorityPolicyErrorId(`${ruleId}:failed:tool-call-1`)).toBe(true);
+      expect(isReservedAuthorityPolicyRuleIdPrefixImpersonation(`${ruleId}:failed`)).toBe(
+        true
+      );
+      expect(isReservedAuthorityPolicyRuleId(`${ruleId}:failed`)).toBe(false);
     }
 
-    expect(isReservedAuthorityPolicyEvidenceId(undefined)).toBe(false);
-    expect(isReservedAuthorityPolicyEvidenceId("spawn-profile-subset-extra")).toBe(false);
-    expect(isReservedAuthorityPolicyEvidenceId("tool-parameter-schema-validation-extra")).toBe(
+    expect(isReservedAuthorityPolicyErrorId(undefined)).toBe(false);
+    expect(isReservedAuthorityPolicyRuleIdPrefixImpersonation(undefined)).toBe(false);
+    expect(isReservedAuthorityPolicyErrorId("spawn-profile-subset-extra")).toBe(false);
+    expect(isReservedAuthorityPolicyRuleIdPrefixImpersonation("spawn-profile-subset-extra")).toBe(
       false
     );
-    expect(isReservedAuthorityPolicyEvidenceId("raw-data-write-extra")).toBe(false);
-    expect(isReservedAuthorityPolicyEvidenceId("workspace-quota:raw-data-write")).toBe(false);
+    expect(isReservedAuthorityPolicyErrorId("tool-parameter-schema-validation-extra")).toBe(
+      false
+    );
+    expect(
+      isReservedAuthorityPolicyRuleIdPrefixImpersonation(
+        "tool-parameter-schema-validation-extra"
+      )
+    ).toBe(false);
+    expect(isReservedAuthorityPolicyErrorId("raw-data-writeish")).toBe(false);
+    expect(isReservedAuthorityPolicyRuleIdPrefixImpersonation("raw-data-writeish")).toBe(false);
+    expect(isReservedAuthorityPolicyErrorId("workspace-quota:raw-data-write")).toBe(false);
+    expect(isReservedAuthorityPolicyRuleIdPrefixImpersonation("workspace-quota:raw-data-write")).toBe(
+      false
+    );
   });
 
   test("guard_class lint rejects unclassified hard guard rules", () => {

--- a/packages/core/src/tools/policy-gate-core.test.ts
+++ b/packages/core/src/tools/policy-gate-core.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  assertPolicyGateContextGuardClasses,
   evaluatePolicyGate,
   normalizeSpawnAgentInput,
   PolicyGateRemediationSchema,
@@ -32,6 +33,7 @@ describe("policy gate pure evaluator", () => {
         {
           ruleId: "raw-data-write",
           description: "Reject writes to data/raw.",
+          guardClass: "authority",
           evaluate: () => ({
             decision: "deny" as const,
             reason: "data/raw is protected",
@@ -57,8 +59,42 @@ describe("policy gate pure evaluator", () => {
         next_action: "adjust_scope",
         hint: "Write generated files under workspace/tasks instead.",
         ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
-      }
+      },
+      guardClass: "authority"
     });
+  });
+
+  test("guard_class lint rejects unclassified hard guard rules", () => {
+    expect(() =>
+      assertPolicyGateContextGuardClasses({
+        rules: [
+          {
+            ruleId: "unclassified-hard-guard",
+            description: "Missing guard_class metadata.",
+            evaluate: () => ({ decision: "allow" })
+          } as never
+        ]
+      })
+    ).toThrow(
+      /Policy gate guard_class lint failed: unclassified-hard-guard: missing or invalid guardClass\/guard_class/
+    );
+  });
+
+  test("guard_class lint rejects invalid hard guard classifications", () => {
+    expect(() =>
+      evaluatePolicyGate(sampleToolCall(), {
+        rules: [
+          {
+            ruleId: "invalid-guard-class",
+            description: "Invalid guard_class metadata.",
+            guardClass: "temporary",
+            evaluate: () => ({ decision: "allow" })
+          } as never
+        ]
+      })
+    ).toThrow(
+      /Policy gate guard_class lint failed: invalid-guard-class: missing or invalid guardClass\/guard_class/
+    );
   });
 
   test("remediation payload requires legal next_action plus hint and ref", () => {
@@ -91,6 +127,7 @@ describe("policy gate pure evaluator", () => {
           {
             ruleId: "bad-rule",
             description: "Returns invalid remediation.",
+            guardClass: "authority",
             evaluate: () => ({
               decision: "deny",
               reason: "invalid",

--- a/packages/core/src/tools/policy-gate-core.test.ts
+++ b/packages/core/src/tools/policy-gate-core.test.ts
@@ -118,6 +118,23 @@ describe("policy gate pure evaluator", () => {
     });
   });
 
+  test("guard_class lint rejects spawn profile authority downgrades", () => {
+    expect(() =>
+      assertPolicyGateContextGuardClasses({
+        rules: [
+          {
+            ruleId: SPAWN_PROFILE_SUBSET_RULE_ID,
+            description: "Attempts to downgrade reserved spawn authority.",
+            guardClass: "capability",
+            evaluate: () => ({ decision: "allow" })
+          }
+        ]
+      })
+    ).toThrow(
+      /Policy gate guard_class lint failed: spawn-profile-subset: known authority rule cannot be classified as capability/
+    );
+  });
+
   test("guard_class lint rejects unclassified hard guard rules", () => {
     expect(() =>
       assertPolicyGateContextGuardClasses({

--- a/packages/core/src/tools/policy-gate-core.test.ts
+++ b/packages/core/src/tools/policy-gate-core.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   assertPolicyGateContextGuardClasses,
   evaluatePolicyGate,
+  isReservedAuthorityPolicyEvidenceId,
   isReservedAuthorityPolicyRuleId,
   normalizeSpawnAgentInput,
   PolicyGateRemediationSchema,
@@ -158,6 +159,21 @@ describe("policy gate pure evaluator", () => {
         `Policy gate guard_class lint failed: ${TOOL_PARAMETER_SCHEMA_RULE_ID}: known authority rule cannot be classified as capability`
       )
     );
+  });
+
+  test("reserved authority evidence helper matches exact rule ids and error-id prefixes", () => {
+    for (const ruleId of RESERVED_AUTHORITY_POLICY_RULE_IDS) {
+      expect(isReservedAuthorityPolicyEvidenceId(ruleId)).toBe(true);
+      expect(isReservedAuthorityPolicyEvidenceId(`${ruleId}:failed:tool-call-1`)).toBe(true);
+    }
+
+    expect(isReservedAuthorityPolicyEvidenceId(undefined)).toBe(false);
+    expect(isReservedAuthorityPolicyEvidenceId("spawn-profile-subset-extra")).toBe(false);
+    expect(isReservedAuthorityPolicyEvidenceId("tool-parameter-schema-validation-extra")).toBe(
+      false
+    );
+    expect(isReservedAuthorityPolicyEvidenceId("raw-data-write-extra")).toBe(false);
+    expect(isReservedAuthorityPolicyEvidenceId("workspace-quota:raw-data-write")).toBe(false);
   });
 
   test("guard_class lint rejects unclassified hard guard rules", () => {

--- a/packages/core/src/tools/policy-gate-core.test.ts
+++ b/packages/core/src/tools/policy-gate-core.test.ts
@@ -162,6 +162,29 @@ describe("policy gate pure evaluator", () => {
     );
   });
 
+  test("ruleId lint rejects reserved authority rule prefix impersonation for every guard class", () => {
+    for (const reservedRuleId of RESERVED_AUTHORITY_POLICY_RULE_IDS) {
+      for (const guardClass of ["authority", "capability"] as const) {
+        const impersonatedRuleId = `${reservedRuleId}:caller-minted`;
+
+        expect(() =>
+          assertPolicyGateContextGuardClasses({
+            rules: [
+              {
+                ruleId: impersonatedRuleId,
+                description: "Attempts to mint a reserved authority rule prefix.",
+                guardClass,
+                evaluate: () => ({ decision: "allow" })
+              }
+            ]
+          })
+        ).toThrow(
+          `Policy gate ruleId lint failed: ${impersonatedRuleId}: reserved authority policy rule prefixes are reserved for error_id`
+        );
+      }
+    }
+  });
+
   test("reserved authority identity helpers are field-specific", () => {
     for (const ruleId of RESERVED_AUTHORITY_POLICY_RULE_IDS) {
       expect(isReservedAuthorityPolicyRuleId(ruleId)).toBe(true);

--- a/packages/core/src/tools/policy-gate-core.test.ts
+++ b/packages/core/src/tools/policy-gate-core.test.ts
@@ -11,8 +11,10 @@ import {
   SPAWN_PROFILE_SUBSET_RULE,
   SPAWN_PROFILE_SUBSET_RULE_ID,
   SPAWN_PROFILE_TOOL_ID_MAX_CHARS,
-  type PolicyGateToolCall
+  type PolicyGateToolCall,
+  type PolicyRule
 } from "./policy-gate-core";
+import { RAW_DATA_WRITE_RULE_ID } from "./raw-data-sandbox";
 import { getRoleToolIds } from "./role-tool-map";
 
 describe("policy gate pure evaluator", () => {
@@ -60,6 +62,58 @@ describe("policy gate pure evaluator", () => {
         hint: "Write generated files under workspace/tasks instead.",
         ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
       },
+      guardClass: "authority"
+    });
+  });
+
+  test("returns trimmed ruleId from padded rule metadata", () => {
+    const decision = evaluatePolicyGate(sampleToolCall(), {
+      rules: [
+        {
+          ruleId: " padded ",
+          description: "Uses padded source metadata.",
+          guardClass: "authority",
+          evaluate: () => ({
+            decision: "deny",
+            reason: "padded rule metadata denied",
+            remediation: sampleRemediation()
+          })
+        }
+      ]
+    });
+
+    expect(decision).toEqual({
+      decision: "deny",
+      ruleId: "padded",
+      reason: "padded rule metadata denied",
+      remediation: sampleRemediation(),
+      guardClass: "authority"
+    });
+  });
+
+  test("uses validated guard metadata when a raw data rule mutates during evaluation", () => {
+    const rule: PolicyRule = {
+      ruleId: RAW_DATA_WRITE_RULE_ID,
+      description: "Mutates guardClass after context validation.",
+      guardClass: "authority",
+      evaluate: () => {
+        rule.guardClass = "capability";
+        return {
+          decision: "deny",
+          reason: "raw data write denied after mutation",
+          remediation: sampleRemediation()
+        };
+      }
+    };
+
+    const decision = evaluatePolicyGate(sampleToolCall(), { rules: [rule] });
+
+    expect(rule.guardClass).toBe("capability");
+    expect(decision).toEqual({
+      decision: "deny",
+      ruleId: RAW_DATA_WRITE_RULE_ID,
+      reason: "raw data write denied after mutation",
+      remediation: sampleRemediation(),
       guardClass: "authority"
     });
   });
@@ -149,6 +203,160 @@ describe("policy gate pure evaluator", () => {
     );
   });
 
+  test("snake_case deny result guard_class matching rule metadata is accepted", () => {
+    const decision = evaluatePolicyGate(sampleToolCall(), {
+      rules: [
+        {
+          ruleId: "result-snake-case-guard",
+          description: "Returns a spec-shaped result-level classification.",
+          guardClass: "authority",
+          evaluate: () => ({
+            decision: "deny",
+            reason: "snake_case result guard denied",
+            remediation: sampleRemediation(),
+            guard_class: "authority"
+          })
+        }
+      ]
+    });
+
+    expect(decision).toMatchObject({
+      decision: "deny",
+      ruleId: "result-snake-case-guard",
+      guardClass: "authority"
+    });
+  });
+
+  test("guard_class lint rejects invalid snake_case deny result classifications", () => {
+    expect(() =>
+      evaluatePolicyGate(sampleToolCall(), {
+        rules: [
+          {
+            ruleId: "invalid-result-snake-guard-class",
+            description: "Valid rule metadata with an invalid snake_case result classification.",
+            guardClass: "authority",
+            evaluate: () => ({
+              decision: "deny",
+              reason: "result guard_class is invalid",
+              remediation: sampleRemediation(),
+              guard_class: "temporary"
+            })
+          } as never
+        ]
+      })
+    ).toThrow(
+      /Policy gate guard_class lint failed: invalid-result-snake-guard-class: invalid result guard_class/
+    );
+  });
+
+  test("guard_class lint rejects snake_case deny result classifications that conflict with rule metadata", () => {
+    expect(() =>
+      evaluatePolicyGate(sampleToolCall(), {
+        rules: [
+          {
+            ruleId: "conflicting-result-snake-guard-class",
+            description: "Valid rule metadata with a conflicting snake_case result classification.",
+            guardClass: "authority",
+            evaluate: () => ({
+              decision: "deny",
+              reason: "result guard_class conflicts with the rule source of truth",
+              remediation: sampleRemediation(),
+              guard_class: "capability"
+            })
+          }
+        ]
+      })
+    ).toThrow(
+      /Policy gate guard_class lint failed: conflicting-result-snake-guard-class: result guard_class capability conflicts with rule guardClass authority/
+    );
+  });
+
+  test("matching deny result guard aliases are accepted and normalized", () => {
+    const decision = evaluatePolicyGate(sampleToolCall(), {
+      rules: [
+        {
+          ruleId: "matching-result-guard-aliases",
+          description: "Returns matching result guard aliases.",
+          guardClass: "capability",
+          evaluate: () => ({
+            decision: "deny",
+            reason: "matching result guard aliases denied",
+            remediation: sampleRemediation(),
+            guardClass: "capability",
+            guard_class: "capability"
+          })
+        }
+      ]
+    });
+
+    expect(decision).toMatchObject({
+      decision: "deny",
+      ruleId: "matching-result-guard-aliases",
+      guardClass: "capability"
+    });
+  });
+
+  test("guard_class lint rejects conflicting deny result guard aliases", () => {
+    expect(() =>
+      evaluatePolicyGate(sampleToolCall(), {
+        rules: [
+          {
+            ruleId: "conflicting-result-guard-aliases",
+            description: "Returns conflicting result guard aliases.",
+            guardClass: "authority",
+            evaluate: () => ({
+              decision: "deny",
+              reason: "conflicting result guard aliases denied",
+              remediation: sampleRemediation(),
+              guardClass: "authority",
+              guard_class: "capability"
+            })
+          }
+        ]
+      })
+    ).toThrow(
+      /Policy gate guard_class lint failed: conflicting-result-guard-aliases: conflicting result guardClass, guard_class/
+    );
+  });
+
+  test("ruleId lint rejects empty and whitespace context rule identities", () => {
+    expect(() =>
+      evaluatePolicyGate(sampleToolCall(), {
+        rules: [
+          {
+            ruleId: " ",
+            description: "Missing stable identity.",
+            guardClass: "authority",
+            evaluate: () => ({ decision: "allow" })
+          }
+        ]
+      })
+    ).toThrow(/Policy gate ruleId lint failed: <rule-0>: ruleId must be a non-empty string/);
+  });
+
+  test("ruleId lint rejects duplicate context rule identities after trimming", () => {
+    expect(() =>
+      evaluatePolicyGate(sampleToolCall(), {
+        rules: [
+          {
+            ruleId: "duplicate-rule",
+            description: "First identity.",
+            guardClass: "authority",
+            evaluate: () => ({ decision: "allow" })
+          },
+          {
+            ruleId: " duplicate-rule ",
+            description: "Duplicate identity.",
+            guardClass: "authority",
+            evaluate: () => ({ decision: "allow" })
+          }
+        ]
+      })
+    ).toThrow(
+      /Policy gate ruleId lint failed: duplicate-rule: duplicate ruleId also used by duplicate-rule/
+    );
+  });
+
   test("snake_case guard_class metadata propagates into deny decisions", () => {
     const decision = evaluatePolicyGate(sampleToolCall(), {
       rules: [
@@ -165,7 +373,7 @@ describe("policy gate pure evaluator", () => {
               ref: "openspec/changes/m1-foundation/specs/tool-registry-governance/spec.md"
             }
           })
-        } as never
+        }
       ]
     });
 
@@ -955,6 +1163,14 @@ function sampleToolCall(): PolicyGateToolCall {
       command: "printf nope > data/raw/input.csv"
     },
     workDir: "/workspace/tasks/TASK-M1-SPIKE"
+  };
+}
+
+function sampleRemediation() {
+  return {
+    next_action: "adjust_scope" as const,
+    hint: "Use a governed scope.",
+    ref: "openspec/changes/m1-foundation/specs/tool-registry-governance/spec.md"
   };
 }
 

--- a/packages/core/src/tools/policy-gate-core.test.ts
+++ b/packages/core/src/tools/policy-gate-core.test.ts
@@ -185,6 +185,29 @@ describe("policy gate pure evaluator", () => {
     }
   });
 
+  test("evaluatePolicyGate rejects reserved authority rule prefix impersonation for every guard class", () => {
+    for (const reservedRuleId of RESERVED_AUTHORITY_POLICY_RULE_IDS) {
+      for (const guardClass of ["authority", "capability"] as const) {
+        const impersonatedRuleId = `${reservedRuleId}:caller-minted`;
+
+        expect(() =>
+          evaluatePolicyGate(sampleToolCall(), {
+            rules: [
+              {
+                ruleId: impersonatedRuleId,
+                description: "Attempts to mint a reserved authority rule prefix.",
+                guardClass,
+                evaluate: () => ({ decision: "allow" })
+              }
+            ]
+          })
+        ).toThrow(
+          `Policy gate ruleId lint failed: ${impersonatedRuleId}: reserved authority policy rule prefixes are reserved for error_id`
+        );
+      }
+    }
+  });
+
   test("reserved authority identity helpers are field-specific", () => {
     for (const ruleId of RESERVED_AUTHORITY_POLICY_RULE_IDS) {
       expect(isReservedAuthorityPolicyRuleId(ruleId)).toBe(true);

--- a/packages/core/src/tools/policy-gate-core.test.ts
+++ b/packages/core/src/tools/policy-gate-core.test.ts
@@ -97,6 +97,58 @@ describe("policy gate pure evaluator", () => {
     );
   });
 
+  test("guard_class lint rejects invalid deny result classifications", () => {
+    expect(() =>
+      evaluatePolicyGate(sampleToolCall(), {
+        rules: [
+          {
+            ruleId: "invalid-result-guard-class",
+            description: "Valid rule metadata with an invalid result-level classification.",
+            guardClass: "authority",
+            evaluate: () => ({
+              decision: "deny",
+              reason: "result guard class is invalid",
+              remediation: {
+                next_action: "adjust_scope",
+                hint: "Use a valid guard class.",
+                ref: "openspec/changes/m1-foundation/specs/tool-registry-governance/spec.md"
+              },
+              guardClass: "temporary"
+            })
+          } as never
+        ]
+      })
+    ).toThrow(
+      /Policy gate guard_class lint failed: invalid-result-guard-class: invalid result guardClass/
+    );
+  });
+
+  test("guard_class lint rejects deny result classifications that conflict with rule metadata", () => {
+    expect(() =>
+      evaluatePolicyGate(sampleToolCall(), {
+        rules: [
+          {
+            ruleId: "conflicting-result-guard-class",
+            description: "Valid rule metadata with a conflicting result-level classification.",
+            guardClass: "authority",
+            evaluate: () => ({
+              decision: "deny",
+              reason: "result guard class conflicts with the rule source of truth",
+              remediation: {
+                next_action: "adjust_scope",
+                hint: "Align the result guard class with the owning rule.",
+                ref: "openspec/changes/m1-foundation/specs/tool-registry-governance/spec.md"
+              },
+              guardClass: "capability"
+            })
+          }
+        ]
+      })
+    ).toThrow(
+      /Policy gate guard_class lint failed: conflicting-result-guard-class: result guardClass capability conflicts with rule guardClass authority/
+    );
+  });
+
   test("snake_case guard_class metadata propagates into deny decisions", () => {
     const decision = evaluatePolicyGate(sampleToolCall(), {
       rules: [

--- a/packages/core/src/tools/policy-gate-core.test.ts
+++ b/packages/core/src/tools/policy-gate-core.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "bun:test";
 import {
   assertPolicyGateContextGuardClasses,
   evaluatePolicyGate,
+  isReservedAuthorityPolicyRuleId,
   normalizeSpawnAgentInput,
   PolicyGateRemediationSchema,
+  RESERVED_AUTHORITY_POLICY_RULE_IDS,
   SPAWN_PROFILE_ALLOWLIST_MAX_ITEMS,
   SPAWN_PROFILE_ALLOWLIST_MAX_TOTAL_CHARS,
   SPAWN_PROFILE_MAX_EXCESS_TOOL_SAMPLES,
@@ -11,6 +13,7 @@ import {
   SPAWN_PROFILE_SUBSET_RULE,
   SPAWN_PROFILE_SUBSET_RULE_ID,
   SPAWN_PROFILE_TOOL_ID_MAX_CHARS,
+  TOOL_PARAMETER_SCHEMA_RULE_ID,
   type PolicyGateToolCall,
   type PolicyRule
 } from "./policy-gate-core";
@@ -132,6 +135,28 @@ describe("policy gate pure evaluator", () => {
       })
     ).toThrow(
       /Policy gate guard_class lint failed: spawn-profile-subset: known authority rule cannot be classified as capability/
+    );
+  });
+
+  test("guard_class lint treats Zod schema validation as reserved authority", () => {
+    expect(RESERVED_AUTHORITY_POLICY_RULE_IDS).toContain(TOOL_PARAMETER_SCHEMA_RULE_ID);
+    expect(isReservedAuthorityPolicyRuleId(TOOL_PARAMETER_SCHEMA_RULE_ID)).toBe(true);
+
+    expect(() =>
+      assertPolicyGateContextGuardClasses({
+        rules: [
+          {
+            ruleId: TOOL_PARAMETER_SCHEMA_RULE_ID,
+            description: "Attempts to downgrade built-in Zod parameter schema authority.",
+            guardClass: "capability",
+            evaluate: () => ({ decision: "allow" })
+          }
+        ]
+      })
+    ).toThrow(
+      new RegExp(
+        `Policy gate guard_class lint failed: ${TOOL_PARAMETER_SCHEMA_RULE_ID}: known authority rule cannot be classified as capability`
+      )
     );
   });
 

--- a/packages/core/src/tools/policy-gate-core.test.ts
+++ b/packages/core/src/tools/policy-gate-core.test.ts
@@ -97,6 +97,39 @@ describe("policy gate pure evaluator", () => {
     );
   });
 
+  test("snake_case guard_class metadata propagates into deny decisions", () => {
+    const decision = evaluatePolicyGate(sampleToolCall(), {
+      rules: [
+        {
+          ruleId: "snake-case-guard",
+          description: "Uses spec-shaped guard_class metadata.",
+          guard_class: "authority",
+          evaluate: () => ({
+            decision: "deny",
+            reason: "snake_case guard denied",
+            remediation: {
+              next_action: "adjust_scope",
+              hint: "Use a governed scope.",
+              ref: "openspec/changes/m1-foundation/specs/tool-registry-governance/spec.md"
+            }
+          })
+        } as never
+      ]
+    });
+
+    expect(decision).toEqual({
+      decision: "deny",
+      ruleId: "snake-case-guard",
+      reason: "snake_case guard denied",
+      remediation: {
+        next_action: "adjust_scope",
+        hint: "Use a governed scope.",
+        ref: "openspec/changes/m1-foundation/specs/tool-registry-governance/spec.md"
+      },
+      guardClass: "authority"
+    });
+  });
+
   test("remediation payload requires legal next_action plus hint and ref", () => {
     const valid = PolicyGateRemediationSchema.safeParse({
       next_action: "fix_and_retry",

--- a/packages/core/src/tools/policy-gate-core.ts
+++ b/packages/core/src/tools/policy-gate-core.ts
@@ -20,6 +20,7 @@ export const PolicyGuardClassSchema = z.enum(["authority", "capability"]);
 export type PolicyGuardClass = z.infer<typeof PolicyGuardClassSchema>;
 
 export const SPAWN_PROFILE_SUBSET_RULE_ID = "spawn-profile-subset";
+export const TOOL_PARAMETER_SCHEMA_RULE_ID = "tool-parameter-schema-validation";
 export const SPAWN_PROFILE_SUBSET_POLICY_REF =
   "docs/02_ARCHITECTURE/Roles_and_Boundaries.md#0-canonical-agent-role-registry";
 export const SPAWN_PROFILE_ALLOWLIST_MAX_ITEMS = 64;
@@ -30,7 +31,8 @@ export const SPAWN_PROFILE_TOOL_ID_SAMPLE_MAX_CHARS = 64;
 export const SPAWN_PROFILE_TEXT_FIELD_MAX_CHARS = 65536;
 export const RESERVED_AUTHORITY_POLICY_RULE_IDS = Object.freeze([
   "raw-data-write",
-  SPAWN_PROFILE_SUBSET_RULE_ID
+  SPAWN_PROFILE_SUBSET_RULE_ID,
+  TOOL_PARAMETER_SCHEMA_RULE_ID
 ] as const);
 
 export interface PolicyGateToolCall {

--- a/packages/core/src/tools/policy-gate-core.ts
+++ b/packages/core/src/tools/policy-gate-core.ts
@@ -45,6 +45,7 @@ export type PolicyRuleDecision =
       reason: string;
       remediation: PolicyGateRemediation;
       guardClass?: PolicyGuardClass;
+      guard_class?: PolicyGuardClass;
     };
 
 export type PolicyGateDecision =
@@ -67,16 +68,37 @@ export type PolicyGateInputNormalization =
     }
   | Extract<PolicyGateDecision, { decision: "deny" }>;
 
-export interface PolicyRule {
+type PolicyRuleGuardClassMetadata =
+  | {
+      guardClass: PolicyGuardClass;
+      guard_class?: PolicyGuardClass;
+    }
+  | {
+      guardClass?: PolicyGuardClass;
+      guard_class: PolicyGuardClass;
+    };
+
+export type PolicyRule = {
   ruleId: string;
   description: string;
-  guardClass: PolicyGuardClass;
   evaluate(call: PolicyGateToolCall, context: PolicyGateContext): PolicyRuleDecision;
-}
+} & PolicyRuleGuardClassMetadata;
 
-type PolicyRuleGuardClassCarrier = Pick<PolicyRule, "ruleId"> & {
-  guardClass?: unknown;
-  guard_class?: unknown;
+type PolicyGuardClassAliasRead =
+  | { state: "missing" }
+  | { state: "invalid"; fields: readonly string[] }
+  | { state: "conflicting"; fields: readonly string[] }
+  | { state: "valid"; guardClass: PolicyGuardClass; field: string };
+
+type PolicyGuardClassAliasValueRead =
+  | { state: "missing" }
+  | { state: "invalid" }
+  | { state: "valid"; guardClass: PolicyGuardClass };
+
+type ValidatedPolicyRuleMetadata = {
+  rule: PolicyRule;
+  ruleId: string;
+  guardClass: PolicyGuardClass;
 };
 
 export interface PolicyGateContext {
@@ -87,26 +109,32 @@ export const EMPTY_POLICY_GATE_CONTEXT: PolicyGateContext = {
   rules: []
 };
 
+const KNOWN_AUTHORITY_POLICY_RULE_IDS = new Set(["raw-data-write"]);
+
 export function evaluatePolicyGate(
   call: PolicyGateToolCall,
   context: PolicyGateContext = EMPTY_POLICY_GATE_CONTEXT
 ): PolicyGateDecision {
-  assertPolicyGateContextGuardClasses(context);
+  const metadata = validatePolicyGateContextMetadata(context);
 
-  for (const [index, rule] of context.rules.entries()) {
+  for (const { rule, ruleId, guardClass } of metadata) {
     const result = rule.evaluate(call, context);
     if (result.decision === "allow") {
       continue;
     }
 
-    validatePolicyGateRemediation(rule.ruleId, result.remediation);
-    const guardClass = normalizePolicyRuleDenyGuardClass(rule, index, result);
+    validatePolicyGateRemediation(ruleId, result.remediation);
+    const normalizedGuardClass = normalizePolicyRuleDenyGuardClass(
+      ruleId,
+      guardClass,
+      result
+    );
     return {
       decision: "deny",
-      ruleId: rule.ruleId,
+      ruleId,
       reason: result.reason,
       remediation: result.remediation,
-      guardClass
+      guardClass: normalizedGuardClass
     };
   }
 
@@ -114,32 +142,27 @@ export function evaluatePolicyGate(
 }
 
 function normalizePolicyRuleDenyGuardClass(
-  rule: PolicyRuleGuardClassCarrier,
-  index: number,
+  ruleId: string,
+  ruleGuardClass: PolicyGuardClass,
   result: Extract<PolicyRuleDecision, { decision: "deny" }>
 ): PolicyGuardClass {
-  const ruleGuardClass = readPolicyRuleGuardClass(rule);
-  const ruleId = formatPolicyRuleId(rule, index);
-  if (!ruleGuardClass) {
-    throw new Error(
-      `Policy gate guard_class lint failed: ${ruleId}: missing or invalid guardClass/guard_class.`
-    );
-  }
-
-  if (result.guardClass === undefined) {
+  const resultGuardClass = readPolicyGuardClassAliases(result);
+  if (resultGuardClass.state === "missing") {
     return ruleGuardClass;
   }
-
-  const parsedResultGuardClass = PolicyGuardClassSchema.safeParse(result.guardClass);
-  if (!parsedResultGuardClass.success) {
+  if (resultGuardClass.state === "invalid") {
     throw new Error(
-      `Policy gate guard_class lint failed: ${ruleId}: invalid result guardClass.`
+      `Policy gate guard_class lint failed: ${ruleId}: invalid result ${resultGuardClass.fields.join(", ")}.`
     );
   }
-
-  if (parsedResultGuardClass.data !== ruleGuardClass) {
+  if (resultGuardClass.state === "conflicting") {
     throw new Error(
-      `Policy gate guard_class lint failed: ${ruleId}: result guardClass ${parsedResultGuardClass.data} conflicts with rule guardClass ${ruleGuardClass}.`
+      `Policy gate guard_class lint failed: ${ruleId}: conflicting result ${resultGuardClass.fields.join(", ")}.`
+    );
+  }
+  if (resultGuardClass.guardClass !== ruleGuardClass) {
+    throw new Error(
+      `Policy gate guard_class lint failed: ${ruleId}: result ${resultGuardClass.field} ${resultGuardClass.guardClass} conflicts with rule guardClass ${ruleGuardClass}.`
     );
   }
 
@@ -147,42 +170,152 @@ function normalizePolicyRuleDenyGuardClass(
 }
 
 export function assertPolicyGateContextGuardClasses(context: PolicyGateContext): void {
-  const failures: string[] = [];
+  validatePolicyGateContextMetadata(context);
+}
+
+export function snapshotPolicyGateContext(context: PolicyGateContext): PolicyGateContext {
+  const metadata = validatePolicyGateContextMetadata(context);
+  const rules = metadata.map(({ rule, ruleId, guardClass }) => {
+    const evaluate = rule.evaluate.bind(rule);
+    return Object.freeze({
+      ruleId,
+      description: rule.description,
+      guardClass,
+      evaluate(call: PolicyGateToolCall, snapshotContext: PolicyGateContext): PolicyRuleDecision {
+        return evaluate(call, snapshotContext);
+      }
+    });
+  });
+
+  return Object.freeze({
+    rules: Object.freeze(rules)
+  });
+}
+
+function validatePolicyGateContextMetadata(
+  context: PolicyGateContext
+): ValidatedPolicyRuleMetadata[] {
+  const ruleIdFailures: string[] = [];
+  const guardClassFailures: string[] = [];
+  const metadata: ValidatedPolicyRuleMetadata[] = [];
+  const seenRuleIds = new Map<string, string>();
 
   context.rules.forEach((rule, index) => {
-    const ruleId = formatPolicyRuleId(rule, index);
-    if (!readPolicyRuleGuardClass(rule)) {
-      failures.push(`${ruleId}: missing or invalid guardClass/guard_class`);
+    const ruleLabel = formatPolicyRuleId(rule, index);
+    const ruleId = normalizePolicyRuleId(rule.ruleId);
+    if (!ruleId) {
+      ruleIdFailures.push(`${ruleLabel}: ruleId must be a non-empty string`);
+    } else {
+      const previousRuleLabel = seenRuleIds.get(ruleId);
+      if (previousRuleLabel) {
+        ruleIdFailures.push(
+          `${ruleId}: duplicate ruleId also used by ${previousRuleLabel}`
+        );
+      } else {
+        seenRuleIds.set(ruleId, ruleLabel);
+      }
+    }
+
+    const guardClass = readPolicyGuardClassAliases(rule);
+    if (guardClass.state === "missing" || guardClass.state === "invalid") {
+      guardClassFailures.push(`${ruleLabel}: missing or invalid guardClass/guard_class`);
+      return;
+    }
+    if (guardClass.state === "conflicting") {
+      guardClassFailures.push(`${ruleLabel}: conflicting guardClass/guard_class`);
+      return;
+    }
+
+    if (
+      ruleId &&
+      KNOWN_AUTHORITY_POLICY_RULE_IDS.has(ruleId) &&
+      guardClass.guardClass !== "authority"
+    ) {
+      guardClassFailures.push(
+        `${ruleId}: known authority rule cannot be classified as ${guardClass.guardClass}`
+      );
+      return;
+    }
+
+    if (ruleId) {
+      metadata.push({ rule, ruleId, guardClass: guardClass.guardClass });
     }
   });
 
-  if (failures.length > 0) {
-    throw new Error(`Policy gate guard_class lint failed: ${failures.join("; ")}.`);
+  if (ruleIdFailures.length > 0) {
+    throw new Error(`Policy gate ruleId lint failed: ${ruleIdFailures.join("; ")}.`);
   }
+
+  if (guardClassFailures.length > 0) {
+    throw new Error(
+      `Policy gate guard_class lint failed: ${guardClassFailures.join("; ")}.`
+    );
+  }
+
+  return metadata;
 }
 
-function readPolicyRuleGuardClass(rule: PolicyRuleGuardClassCarrier): PolicyGuardClass | undefined {
-  const parsedGuardClass = parsePolicyRuleGuardClassValue(rule.guardClass);
-  const parsedSnakeGuardClass = parsePolicyRuleGuardClassValue(rule.guard_class);
+function readPolicyGuardClassAliases(carrier: {
+  guardClass?: unknown;
+  guard_class?: unknown;
+}): PolicyGuardClassAliasRead {
+  const camelGuardClass = parsePolicyRuleGuardClassValue(carrier.guardClass);
+  const snakeGuardClass = parsePolicyRuleGuardClassValue(carrier.guard_class);
+  const invalidFields: string[] = [];
+  if (camelGuardClass.state === "invalid") {
+    invalidFields.push("guardClass");
+  }
+  if (snakeGuardClass.state === "invalid") {
+    invalidFields.push("guard_class");
+  }
+  if (invalidFields.length > 0) {
+    return { state: "invalid", fields: invalidFields };
+  }
 
-  if (parsedGuardClass && parsedSnakeGuardClass) {
-    return parsedGuardClass === parsedSnakeGuardClass ? parsedGuardClass : undefined;
+  if (camelGuardClass.state === "valid" && snakeGuardClass.state === "valid") {
+    if (camelGuardClass.guardClass !== snakeGuardClass.guardClass) {
+      return { state: "conflicting", fields: ["guardClass", "guard_class"] };
+    }
+    return {
+      state: "valid",
+      guardClass: camelGuardClass.guardClass,
+      field: "guardClass/guard_class"
+    };
   }
-  if (parsedGuardClass) {
-    return rule.guard_class === undefined ? parsedGuardClass : undefined;
+  if (camelGuardClass.state === "valid") {
+    return {
+      state: "valid",
+      guardClass: camelGuardClass.guardClass,
+      field: "guardClass"
+    };
   }
-  if (parsedSnakeGuardClass) {
-    return rule.guardClass === undefined ? parsedSnakeGuardClass : undefined;
+  if (snakeGuardClass.state === "valid") {
+    return {
+      state: "valid",
+      guardClass: snakeGuardClass.guardClass,
+      field: "guard_class"
+    };
   }
-  return undefined;
+
+  return { state: "missing" };
 }
 
-function parsePolicyRuleGuardClassValue(value: unknown): PolicyGuardClass | undefined {
+function parsePolicyRuleGuardClassValue(value: unknown): PolicyGuardClassAliasValueRead {
   if (value === undefined) {
-    return undefined;
+    return { state: "missing" };
   }
   const parsed = PolicyGuardClassSchema.safeParse(value);
-  return parsed.success ? parsed.data : undefined;
+  return parsed.success
+    ? { state: "valid", guardClass: parsed.data }
+    : { state: "invalid" };
+}
+
+function normalizePolicyRuleId(ruleId: unknown): string | undefined {
+  if (typeof ruleId !== "string") {
+    return undefined;
+  }
+  const trimmedRuleId = ruleId.trim();
+  return trimmedRuleId === "" ? undefined : trimmedRuleId;
 }
 
 function formatPolicyRuleId(rule: Pick<PolicyRule, "ruleId">, index: number): string {
@@ -742,7 +875,7 @@ function toSpawnProfileGateDeny(
     ruleId: SPAWN_PROFILE_SUBSET_RULE_ID,
     reason: decision.reason,
     remediation: decision.remediation,
-    guardClass: decision.guardClass ?? SPAWN_PROFILE_SUBSET_RULE.guardClass
+    guardClass: decision.guardClass ?? "authority"
   };
 }
 

--- a/packages/core/src/tools/policy-gate-core.ts
+++ b/packages/core/src/tools/policy-gate-core.ts
@@ -294,6 +294,11 @@ function validatePolicyGateContextMetadata(
       } else {
         seenRuleIds.set(ruleId, ruleLabel);
       }
+      if (isReservedAuthorityPolicyRuleIdPrefixImpersonation(ruleId)) {
+        ruleIdFailures.push(
+          `${ruleId}: reserved authority policy rule prefixes are reserved for error_id`
+        );
+      }
     }
 
     const guardClass = readPolicyGuardClassAliases(rule);

--- a/packages/core/src/tools/policy-gate-core.ts
+++ b/packages/core/src/tools/policy-gate-core.ts
@@ -70,7 +70,7 @@ export type PolicyGateInputNormalization =
 export interface PolicyRule {
   ruleId: string;
   description: string;
-  guardClass?: PolicyGuardClass;
+  guardClass: PolicyGuardClass;
   evaluate(call: PolicyGateToolCall, context: PolicyGateContext): PolicyRuleDecision;
 }
 
@@ -86,6 +86,8 @@ export function evaluatePolicyGate(
   call: PolicyGateToolCall,
   context: PolicyGateContext = EMPTY_POLICY_GATE_CONTEXT
 ): PolicyGateDecision {
+  assertPolicyGateContextGuardClasses(context);
+
   for (const rule of context.rules) {
     const result = rule.evaluate(call, context);
     if (result.decision === "allow") {
@@ -104,6 +106,31 @@ export function evaluatePolicyGate(
   }
 
   return { decision: "allow" };
+}
+
+export function assertPolicyGateContextGuardClasses(context: PolicyGateContext): void {
+  const failures: string[] = [];
+
+  context.rules.forEach((rule, index) => {
+    const ruleId = formatPolicyRuleId(rule, index);
+    const parsedGuardClass = PolicyGuardClassSchema.safeParse(
+      (rule as PolicyRule & { guard_class?: unknown }).guardClass ??
+        (rule as PolicyRule & { guard_class?: unknown }).guard_class
+    );
+    if (!parsedGuardClass.success) {
+      failures.push(`${ruleId}: missing or invalid guardClass/guard_class`);
+    }
+  });
+
+  if (failures.length > 0) {
+    throw new Error(`Policy gate guard_class lint failed: ${failures.join("; ")}.`);
+  }
+}
+
+function formatPolicyRuleId(rule: Pick<PolicyRule, "ruleId">, index: number): string {
+  return typeof rule.ruleId === "string" && rule.ruleId.trim() !== ""
+    ? rule.ruleId
+    : `<rule-${index}>`;
 }
 
 export const SPAWN_PROFILE_SUBSET_RULE: PolicyRule = Object.freeze({

--- a/packages/core/src/tools/policy-gate-core.ts
+++ b/packages/core/src/tools/policy-gate-core.ts
@@ -28,6 +28,10 @@ export const SPAWN_PROFILE_ALLOWLIST_MAX_TOTAL_CHARS = 4096;
 export const SPAWN_PROFILE_MAX_EXCESS_TOOL_SAMPLES = 5;
 export const SPAWN_PROFILE_TOOL_ID_SAMPLE_MAX_CHARS = 64;
 export const SPAWN_PROFILE_TEXT_FIELD_MAX_CHARS = 65536;
+export const RESERVED_AUTHORITY_POLICY_RULE_IDS = Object.freeze([
+  "raw-data-write",
+  SPAWN_PROFILE_SUBSET_RULE_ID
+] as const);
 
 export interface PolicyGateToolCall {
   toolId: string;
@@ -59,6 +63,27 @@ export type PolicyGateDecision =
       remediation: PolicyGateRemediation;
       guardClass: PolicyGuardClass;
     };
+
+type PolicyGateDenyGuardClassInput =
+  | {
+      guardClass: PolicyGuardClass;
+      guard_class?: PolicyGuardClass;
+    }
+  | {
+      guardClass?: PolicyGuardClass;
+      guard_class: PolicyGuardClass;
+    };
+
+export type PolicyGateDecisionInput =
+  | {
+      decision: "allow";
+    }
+  | ({
+      decision: "deny";
+      ruleId: string;
+      reason: string;
+      remediation: PolicyGateRemediation;
+    } & PolicyGateDenyGuardClassInput);
 
 export type PolicyGateInputNormalization =
   | {
@@ -109,7 +134,11 @@ export const EMPTY_POLICY_GATE_CONTEXT: PolicyGateContext = {
   rules: []
 };
 
-const KNOWN_AUTHORITY_POLICY_RULE_IDS = new Set(["raw-data-write"]);
+const KNOWN_AUTHORITY_POLICY_RULE_IDS = new Set<string>(RESERVED_AUTHORITY_POLICY_RULE_IDS);
+
+export function isReservedAuthorityPolicyRuleId(ruleId: string): boolean {
+  return KNOWN_AUTHORITY_POLICY_RULE_IDS.has(ruleId);
+}
 
 export function evaluatePolicyGate(
   call: PolicyGateToolCall,
@@ -228,7 +257,7 @@ function validatePolicyGateContextMetadata(
 
     if (
       ruleId &&
-      KNOWN_AUTHORITY_POLICY_RULE_IDS.has(ruleId) &&
+      isReservedAuthorityPolicyRuleId(ruleId) &&
       guardClass.guardClass !== "authority"
     ) {
       guardClassFailures.push(

--- a/packages/core/src/tools/policy-gate-core.ts
+++ b/packages/core/src/tools/policy-gate-core.ts
@@ -100,12 +100,7 @@ export function evaluatePolicyGate(
     }
 
     validatePolicyGateRemediation(rule.ruleId, result.remediation);
-    const guardClass = result.guardClass ?? readPolicyRuleGuardClass(rule);
-    if (!guardClass) {
-      throw new Error(
-        `Policy gate guard_class lint failed: ${formatPolicyRuleId(rule, index)}: missing or invalid guardClass/guard_class.`
-      );
-    }
+    const guardClass = normalizePolicyRuleDenyGuardClass(rule, index, result);
     return {
       decision: "deny",
       ruleId: rule.ruleId,
@@ -116,6 +111,39 @@ export function evaluatePolicyGate(
   }
 
   return { decision: "allow" };
+}
+
+function normalizePolicyRuleDenyGuardClass(
+  rule: PolicyRuleGuardClassCarrier,
+  index: number,
+  result: Extract<PolicyRuleDecision, { decision: "deny" }>
+): PolicyGuardClass {
+  const ruleGuardClass = readPolicyRuleGuardClass(rule);
+  const ruleId = formatPolicyRuleId(rule, index);
+  if (!ruleGuardClass) {
+    throw new Error(
+      `Policy gate guard_class lint failed: ${ruleId}: missing or invalid guardClass/guard_class.`
+    );
+  }
+
+  if (result.guardClass === undefined) {
+    return ruleGuardClass;
+  }
+
+  const parsedResultGuardClass = PolicyGuardClassSchema.safeParse(result.guardClass);
+  if (!parsedResultGuardClass.success) {
+    throw new Error(
+      `Policy gate guard_class lint failed: ${ruleId}: invalid result guardClass.`
+    );
+  }
+
+  if (parsedResultGuardClass.data !== ruleGuardClass) {
+    throw new Error(
+      `Policy gate guard_class lint failed: ${ruleId}: result guardClass ${parsedResultGuardClass.data} conflicts with rule guardClass ${ruleGuardClass}.`
+    );
+  }
+
+  return ruleGuardClass;
 }
 
 export function assertPolicyGateContextGuardClasses(context: PolicyGateContext): void {

--- a/packages/core/src/tools/policy-gate-core.ts
+++ b/packages/core/src/tools/policy-gate-core.ts
@@ -138,18 +138,58 @@ export const EMPTY_POLICY_GATE_CONTEXT: PolicyGateContext = {
 
 const KNOWN_AUTHORITY_POLICY_RULE_IDS = new Set<string>(RESERVED_AUTHORITY_POLICY_RULE_IDS);
 
+export class PolicyGateDecisionValidationError extends Error {
+  constructor(error: unknown) {
+    super(formatPolicyGateDecisionValidationErrorMessage(error));
+    this.name = "PolicyGateDecisionValidationError";
+  }
+}
+
+export function isPolicyGateDecisionValidationError(
+  error: unknown
+): error is PolicyGateDecisionValidationError {
+  return error instanceof PolicyGateDecisionValidationError;
+}
+
+function policyGateDecisionValidationError(message: string): PolicyGateDecisionValidationError {
+  return new PolicyGateDecisionValidationError(message);
+}
+
+function formatPolicyGateDecisionValidationErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return String(error);
+}
+
 export function isReservedAuthorityPolicyRuleId(ruleId: string): boolean {
   return KNOWN_AUTHORITY_POLICY_RULE_IDS.has(ruleId);
 }
 
-export function isReservedAuthorityPolicyEvidenceId(id: string | undefined): boolean {
+export function isReservedAuthorityPolicyErrorId(errorId: string | undefined): boolean {
   return (
-    id !== undefined &&
+    errorId !== undefined &&
     RESERVED_AUTHORITY_POLICY_RULE_IDS.some(
-      (ruleId) => id === ruleId || id.startsWith(`${ruleId}:`)
+      (ruleId) => errorId === ruleId || errorId.startsWith(`${ruleId}:`)
     )
   );
 }
+
+export function isReservedAuthorityPolicyRuleIdPrefixImpersonation(
+  ruleId: string | undefined
+): boolean {
+  return (
+    ruleId !== undefined &&
+    RESERVED_AUTHORITY_POLICY_RULE_IDS.some(
+      (reservedRuleId) => ruleId.startsWith(`${reservedRuleId}:`)
+    )
+  );
+}
+
+export const isReservedAuthorityPolicyEvidenceId = isReservedAuthorityPolicyErrorId;
 
 export function evaluatePolicyGate(
   call: PolicyGateToolCall,
@@ -191,17 +231,17 @@ function normalizePolicyRuleDenyGuardClass(
     return ruleGuardClass;
   }
   if (resultGuardClass.state === "invalid") {
-    throw new Error(
+    throw policyGateDecisionValidationError(
       `Policy gate guard_class lint failed: ${ruleId}: invalid result ${resultGuardClass.fields.join(", ")}.`
     );
   }
   if (resultGuardClass.state === "conflicting") {
-    throw new Error(
+    throw policyGateDecisionValidationError(
       `Policy gate guard_class lint failed: ${ruleId}: conflicting result ${resultGuardClass.fields.join(", ")}.`
     );
   }
   if (resultGuardClass.guardClass !== ruleGuardClass) {
-    throw new Error(
+    throw policyGateDecisionValidationError(
       `Policy gate guard_class lint failed: ${ruleId}: result ${resultGuardClass.field} ${resultGuardClass.guardClass} conflicts with rule guardClass ${ruleGuardClass}.`
     );
   }
@@ -283,11 +323,13 @@ function validatePolicyGateContextMetadata(
   });
 
   if (ruleIdFailures.length > 0) {
-    throw new Error(`Policy gate ruleId lint failed: ${ruleIdFailures.join("; ")}.`);
+    throw policyGateDecisionValidationError(
+      `Policy gate ruleId lint failed: ${ruleIdFailures.join("; ")}.`
+    );
   }
 
   if (guardClassFailures.length > 0) {
-    throw new Error(
+    throw policyGateDecisionValidationError(
       `Policy gate guard_class lint failed: ${guardClassFailures.join("; ")}.`
     );
   }
@@ -1159,5 +1201,7 @@ function validatePolicyGateRemediation(ruleId: string, remediation: PolicyGateRe
     .filter((path) => path.length > 0)
     .join(", ");
 
-  throw new Error(`Invalid policy gate remediation for ${ruleId}: ${fieldPaths || "remediation"}`);
+  throw policyGateDecisionValidationError(
+    `Invalid policy gate remediation for ${ruleId}: ${fieldPaths || "remediation"}`
+  );
 }

--- a/packages/core/src/tools/policy-gate-core.ts
+++ b/packages/core/src/tools/policy-gate-core.ts
@@ -142,6 +142,15 @@ export function isReservedAuthorityPolicyRuleId(ruleId: string): boolean {
   return KNOWN_AUTHORITY_POLICY_RULE_IDS.has(ruleId);
 }
 
+export function isReservedAuthorityPolicyEvidenceId(id: string | undefined): boolean {
+  return (
+    id !== undefined &&
+    RESERVED_AUTHORITY_POLICY_RULE_IDS.some(
+      (ruleId) => id === ruleId || id.startsWith(`${ruleId}:`)
+    )
+  );
+}
+
 export function evaluatePolicyGate(
   call: PolicyGateToolCall,
   context: PolicyGateContext = EMPTY_POLICY_GATE_CONTEXT

--- a/packages/core/src/tools/policy-gate-core.ts
+++ b/packages/core/src/tools/policy-gate-core.ts
@@ -56,7 +56,7 @@ export type PolicyGateDecision =
       ruleId: string;
       reason: string;
       remediation: PolicyGateRemediation;
-      guardClass?: PolicyGuardClass;
+      guardClass: PolicyGuardClass;
     };
 
 export type PolicyGateInputNormalization =
@@ -74,6 +74,11 @@ export interface PolicyRule {
   evaluate(call: PolicyGateToolCall, context: PolicyGateContext): PolicyRuleDecision;
 }
 
+type PolicyRuleGuardClassCarrier = Pick<PolicyRule, "ruleId"> & {
+  guardClass?: unknown;
+  guard_class?: unknown;
+};
+
 export interface PolicyGateContext {
   rules: readonly PolicyRule[];
 }
@@ -88,20 +93,25 @@ export function evaluatePolicyGate(
 ): PolicyGateDecision {
   assertPolicyGateContextGuardClasses(context);
 
-  for (const rule of context.rules) {
+  for (const [index, rule] of context.rules.entries()) {
     const result = rule.evaluate(call, context);
     if (result.decision === "allow") {
       continue;
     }
 
     validatePolicyGateRemediation(rule.ruleId, result.remediation);
-    const guardClass = result.guardClass ?? rule.guardClass;
+    const guardClass = result.guardClass ?? readPolicyRuleGuardClass(rule);
+    if (!guardClass) {
+      throw new Error(
+        `Policy gate guard_class lint failed: ${formatPolicyRuleId(rule, index)}: missing or invalid guardClass/guard_class.`
+      );
+    }
     return {
       decision: "deny",
       ruleId: rule.ruleId,
       reason: result.reason,
       remediation: result.remediation,
-      ...(guardClass ? { guardClass } : {})
+      guardClass
     };
   }
 
@@ -113,11 +123,7 @@ export function assertPolicyGateContextGuardClasses(context: PolicyGateContext):
 
   context.rules.forEach((rule, index) => {
     const ruleId = formatPolicyRuleId(rule, index);
-    const parsedGuardClass = PolicyGuardClassSchema.safeParse(
-      (rule as PolicyRule & { guard_class?: unknown }).guardClass ??
-        (rule as PolicyRule & { guard_class?: unknown }).guard_class
-    );
-    if (!parsedGuardClass.success) {
+    if (!readPolicyRuleGuardClass(rule)) {
       failures.push(`${ruleId}: missing or invalid guardClass/guard_class`);
     }
   });
@@ -125,6 +131,30 @@ export function assertPolicyGateContextGuardClasses(context: PolicyGateContext):
   if (failures.length > 0) {
     throw new Error(`Policy gate guard_class lint failed: ${failures.join("; ")}.`);
   }
+}
+
+function readPolicyRuleGuardClass(rule: PolicyRuleGuardClassCarrier): PolicyGuardClass | undefined {
+  const parsedGuardClass = parsePolicyRuleGuardClassValue(rule.guardClass);
+  const parsedSnakeGuardClass = parsePolicyRuleGuardClassValue(rule.guard_class);
+
+  if (parsedGuardClass && parsedSnakeGuardClass) {
+    return parsedGuardClass === parsedSnakeGuardClass ? parsedGuardClass : undefined;
+  }
+  if (parsedGuardClass) {
+    return rule.guard_class === undefined ? parsedGuardClass : undefined;
+  }
+  if (parsedSnakeGuardClass) {
+    return rule.guardClass === undefined ? parsedSnakeGuardClass : undefined;
+  }
+  return undefined;
+}
+
+function parsePolicyRuleGuardClassValue(value: unknown): PolicyGuardClass | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = PolicyGuardClassSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
 }
 
 function formatPolicyRuleId(rule: Pick<PolicyRule, "ruleId">, index: number): string {

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -42,7 +42,9 @@ import {
   createShudSandboxedBashTool,
   isPolicyGatedTool,
   wrapAllRegisteredTools,
-  wrapToolWithPolicyGate
+  wrapToolWithPolicyGate,
+  type PolicyGateEvaluator,
+  type PolicyGateExecutionInputValidator
 } from "./policy-gate-registry";
 import {
   RAW_DATA_WRITE_RULE_ID,
@@ -118,6 +120,60 @@ describe("policy-gated zero tool registry", () => {
     };
     expect(payload.ruleId).toBe("registry-snake-guard");
     expect(payload.guard_class).toBe("authority");
+  });
+
+  test("policy gate producer types accept snake_case and matching guard aliases", () => {
+    const snakeCaseOnlyEvaluator = (() => ({
+      decision: "deny" as const,
+      ruleId: "typed-snake-evaluator",
+      reason: "typed evaluator deny uses spec-shaped guard_class only",
+      remediation: {
+        next_action: "fix_and_retry" as const,
+        hint: "Fix the evaluator-owned input before retrying.",
+        ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+      },
+      guard_class: "capability" as const
+    })) satisfies PolicyGateEvaluator;
+    const matchingAliasEvaluator = (() => ({
+      decision: "deny" as const,
+      ruleId: "typed-matching-evaluator",
+      reason: "typed evaluator deny uses matching aliases",
+      remediation: {
+        next_action: "fix_and_retry" as const,
+        hint: "Fix the evaluator-owned input before retrying.",
+        ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+      },
+      guardClass: "capability" as const,
+      guard_class: "capability" as const
+    })) satisfies PolicyGateEvaluator;
+    const snakeCaseOnlyValidator = (() => ({
+      decision: "deny" as const,
+      ruleId: "typed-snake-validator",
+      reason: "typed validator deny uses spec-shaped guard_class only",
+      remediation: {
+        next_action: "fix_and_retry" as const,
+        hint: "Fix the validator-owned input before retrying.",
+        ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+      },
+      guard_class: "capability" as const
+    })) satisfies PolicyGateExecutionInputValidator;
+    const matchingAliasValidator = (() => ({
+      decision: "deny" as const,
+      ruleId: "typed-matching-validator",
+      reason: "typed validator deny uses matching aliases",
+      remediation: {
+        next_action: "fix_and_retry" as const,
+        hint: "Fix the validator-owned input before retrying.",
+        ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+      },
+      guardClass: "capability" as const,
+      guard_class: "capability" as const
+    })) satisfies PolicyGateExecutionInputValidator;
+
+    expect(typeof snakeCaseOnlyEvaluator).toBe("function");
+    expect(typeof matchingAliasEvaluator).toBe("function");
+    expect(typeof snakeCaseOnlyValidator).toBe("function");
+    expect(typeof matchingAliasValidator).toBe("function");
   });
 
   test("policy gate evaluator snapshots retained context guard metadata", async () => {
@@ -1984,6 +2040,34 @@ describe("policy-gated zero tool registry", () => {
     });
   });
 
+  test("spawn-profile authority impersonation from custom evaluator fails closed", async () => {
+    const bashTool = new RecordingTool("bash");
+    const wrapped = wrapToolWithPolicyGate(bashTool, {
+      evaluate: async () => ({
+        decision: "deny",
+        ruleId: SPAWN_PROFILE_SUBSET_RULE_ID,
+        reason: "custom evaluator attempted to impersonate spawn-profile authority",
+        remediation: {
+          next_action: "adjust_scope",
+          hint: "Use a custom evaluator-owned policy rule id.",
+          ref: SPAWN_PROFILE_SUBSET_POLICY_REF
+        },
+        guardClass: "authority"
+      })
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), {
+      command: "printf nope > workspace/out.txt"
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Invalid policy gate decision");
+    expect(result.output).toContain(SPAWN_PROFILE_SUBSET_RULE_ID);
+    expect(result.output).toContain("ruleId");
+    expect(result.output).not.toContain("policy_gate_denied");
+    expect(bashTool.calls).toBe(0);
+  });
+
   test("empty ruleId from custom evaluator fails without policy_gate_denied payload", async () => {
     const bashTool = new RecordingTool("bash");
     const wrapped = wrapToolWithPolicyGate(bashTool, {
@@ -2191,6 +2275,49 @@ describe("policy-gated zero tool registry", () => {
     expect(tool.calls).toBe(0);
   });
 
+  test("SHUD policy evaluator rejects direct custom reserved authority rule ids", async () => {
+    const cases = [
+      {
+        name: "spawn",
+        ruleId: SPAWN_PROFILE_SUBSET_RULE_ID,
+        ref: SPAWN_PROFILE_SUBSET_POLICY_REF
+      },
+      {
+        name: "raw",
+        ruleId: RAW_DATA_WRITE_RULE_ID,
+        ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
+      }
+    ] as const;
+
+    for (const testCase of cases) {
+      const tool = new RecordingTool(`direct.${testCase.name}.authority`);
+      const evaluator = createShudPolicyGateEvaluator(async () => ({
+        decision: "deny",
+        ruleId: testCase.ruleId,
+        reason: "direct custom evaluator attempted to impersonate reserved authority",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Use a custom evaluator-owned policy rule id.",
+          ref: testCase.ref
+        },
+        guardClass: "authority"
+      }));
+
+      await expect(
+        evaluator(
+          {
+            toolId: tool.name,
+            role: "worker",
+            input: { blocked: true },
+            workDir: "/tmp/shud-harness-test"
+          },
+          { tool, toolContext: createToolContext("worker") }
+        )
+      ).rejects.toThrow(new RegExp(`Invalid policy gate decision.*${testCase.ruleId}.*ruleId`));
+      expect(tool.calls).toBe(0);
+    }
+  });
+
   test("missing guardClass from execution validator fails closed without policy_gate_denied payload", async () => {
     const tool = new RecordingTool("validator.missing.guard");
     const wrapped = wrapToolWithPolicyGate(tool, {
@@ -2311,23 +2438,80 @@ describe("policy-gated zero tool registry", () => {
     expect(tool.calls).toBe(0);
   });
 
+  test("raw-data authority impersonation from execution validator fails closed", async () => {
+    const tool = new RecordingTool("validator.raw.authority");
+    const wrapped = wrapToolWithPolicyGate(tool, {
+      evaluate: async () => ({ decision: "allow" }),
+      validateExecutionInput: () => ({
+        decision: "deny",
+        ruleId: RAW_DATA_WRITE_RULE_ID,
+        reason: "execution validator attempted to own raw-data write evidence",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Let RawDataSandboxedBashTool own raw-data write evidence.",
+          ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
+        },
+        guardClass: "authority"
+      })
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), {
+      command: "printf nope > data/raw/input.csv"
+    });
+
+    expect(result.success).toBe(false);
+    expect(tool.calls).toBe(0);
+    expect(result.output).toContain("Invalid policy gate decision");
+    expect(result.output).toContain(RAW_DATA_WRITE_RULE_ID);
+    expect(result.output).toContain("ruleId");
+    expect(result.output).not.toContain("policy_gate_denied");
+    expect(result.output).not.toContain("policy_gate_raw_data_rule_misconfigured");
+    expect(result.output).not.toContain("raw_data_write_denied");
+  });
+
+  test("spawn-profile authority impersonation from execution validator fails closed", async () => {
+    const tool = new RecordingTool("validator.spawn.authority");
+    const wrapped = wrapToolWithPolicyGate(tool, {
+      evaluate: async () => ({ decision: "allow" }),
+      validateExecutionInput: () => ({
+        decision: "deny",
+        ruleId: SPAWN_PROFILE_SUBSET_RULE_ID,
+        reason: "execution validator attempted to impersonate spawn authority",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Use a validator-owned policy rule id.",
+          ref: SPAWN_PROFILE_SUBSET_POLICY_REF
+        },
+        guardClass: "authority"
+      })
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), { blocked: true });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Invalid policy gate decision");
+    expect(result.output).toContain(SPAWN_PROFILE_SUBSET_RULE_ID);
+    expect(result.output).toContain("ruleId");
+    expect(result.output).not.toContain("policy_gate_denied");
+    expect(tool.calls).toBe(0);
+  });
+
   test("matching guard aliases from execution validator emit classified policy_gate_denied", async () => {
     const tool = new RecordingTool("validator.matching.guard");
     const wrapped = wrapToolWithPolicyGate(tool, {
       evaluate: async () => ({ decision: "allow" }),
-      validateExecutionInput: () =>
-        ({
-          decision: "deny",
-          ruleId: "validator-matching-guard-class",
-          reason: "validator denied with matching classifications",
-          remediation: {
-            next_action: "fix_and_retry",
-            hint: "Fix the validator-owned input contract before retrying.",
-            ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
-          },
-          guardClass: "capability",
-          guard_class: "capability"
-        }) as never
+      validateExecutionInput: () => ({
+        decision: "deny",
+        ruleId: "validator-matching-guard-class",
+        reason: "validator denied with matching classifications",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Fix the validator-owned input contract before retrying.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        },
+        guardClass: "capability",
+        guard_class: "capability"
+      })
     });
 
     const result = await wrapped.run(createToolContext("worker"), { blocked: true });
@@ -2474,7 +2658,7 @@ describe("policy-gated zero tool registry", () => {
     expect(bashTool.calls).toBe(0);
   });
 
-  test("raw-data rule misconfiguration deny redacts registered secrets before returning", async () => {
+  test("reserved raw-data custom deny fails closed without leaking registered secrets", async () => {
     const secret = "fake-raw-rule-secret";
     const secretFilter = new TestSecretFilter();
     secretFilter.addSecret("raw-rule-secret", secret);
@@ -2506,16 +2690,12 @@ describe("policy-gated zero tool registry", () => {
     expect(result.success).toBe(false);
     expect(result.output).not.toContain(secret);
     expect(result.outputSummary).not.toContain(secret);
-    expect(result.output).toContain("[redacted:raw-rule-secret]");
-    expect(result.outputSummary).toContain("[redacted:raw-rule-secret]");
-    const payload = JSON.parse(result.output) as {
-      outer_reason?: string;
-      remediation?: {
-        ref?: string;
-      };
-    };
-    expect(payload.outer_reason).toContain("[redacted:raw-rule-secret]");
-    expect(payload.remediation?.ref).toContain("[redacted:raw-rule-secret]");
+    expect(result.output).toContain("Invalid policy gate decision");
+    expect(result.output).toContain(RAW_DATA_WRITE_RULE_ID);
+    expect(result.output).toContain("ruleId");
+    expect(result.output).not.toContain("policy_gate_denied");
+    expect(result.output).not.toContain("policy_gate_raw_data_rule_misconfigured");
+    expect(result.output).not.toContain("raw_data_write_denied");
     expect(bashTool.calls).toBe(0);
   });
 
@@ -3646,6 +3826,85 @@ describe("policy-gated zero tool registry", () => {
     expect(result.output).not.toContain("Expected string");
     expect(evaluatorCalls).toBe(1);
     expect(zodTool.calls).toBe(0);
+  });
+
+  test("policy evaluator metadata errors win before invalid Zod schema details", async () => {
+    const cases: Array<{
+      name: string;
+      evaluate: PolicyGateEvaluator;
+      expectedRuleId: string;
+    }> = [
+      {
+        name: "missing-guard-class",
+        evaluate: async () =>
+          ({
+            decision: "deny",
+            ruleId: "zod-evaluator-missing-guard-class",
+            reason: "evaluator denied without guard identity",
+            remediation: {
+              next_action: "adjust_scope",
+              hint: "Add guardClass before returning a policy denial.",
+              ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+            }
+          }) as never,
+        expectedRuleId: "zod-evaluator-missing-guard-class"
+      },
+      {
+        name: "conflicting-aliases",
+        evaluate: async () => ({
+          decision: "deny",
+          ruleId: "zod-evaluator-conflicting-guard-aliases",
+          reason: "evaluator denied with conflicting guard identity aliases",
+          remediation: {
+            next_action: "adjust_scope",
+            hint: "Return matching guardClass and guard_class values before retrying.",
+            ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+          },
+          guardClass: "authority",
+          guard_class: "capability"
+        }),
+        expectedRuleId: "zod-evaluator-conflicting-guard-aliases"
+      },
+      {
+        name: "reserved-authority-downgrade",
+        evaluate: async () => ({
+          decision: "deny",
+          ruleId: SPAWN_PROFILE_SUBSET_RULE_ID,
+          reason: "evaluator attempted to downgrade spawn-profile authority",
+          remediation: {
+            next_action: "adjust_scope",
+            hint: "Keep spawn-profile-subset classified as authority.",
+            ref: SPAWN_PROFILE_SUBSET_POLICY_REF
+          },
+          guardClass: "capability"
+        }),
+        expectedRuleId: SPAWN_PROFILE_SUBSET_RULE_ID
+      }
+    ];
+
+    for (const testCase of cases) {
+      const zodTool = new ZodRecordingTool(
+        `zod.invalid.${testCase.name}`,
+        z.object({
+          command: z.string()
+        })
+      );
+      const wrapped = wrapToolWithPolicyGate(zodTool, {
+        evaluate: testCase.evaluate
+      });
+
+      const result = await wrapped.run(createToolContext("worker"), {
+        command: 42
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("Invalid policy gate decision");
+      expect(result.output).toContain(testCase.expectedRuleId);
+      expect(result.output).toContain("guardClass");
+      expect(result.output).not.toContain("tool-parameter-schema-validation");
+      expect(result.output).not.toContain("policy_gate_denied");
+      expect(zodTool.calls).toBe(0);
+    }
   });
 
   test("valid Zod path runs evaluator once and executes with parsed input", async () => {
@@ -6329,7 +6588,7 @@ describe("policy-gated zero tool registry", () => {
       });
 
       expect(result?.success).toBe(false);
-      expectOuterRawRuleMisconfiguration(result);
+      expectReservedRawRuleProducerRejected(result);
       expect(result?.output).not.toContain("raw_data_write_denied");
       expect(result?.output).not.toContain("policy_gate_denied");
       await expect(readFile(join(fixture.rawRoot, "outer-raw-advisory.txt"), "utf8")).rejects.toThrow();
@@ -6360,7 +6619,7 @@ describe("policy-gated zero tool registry", () => {
       });
 
       expect(result?.success).toBe(false);
-      expectOuterRawRuleMisconfiguration(result);
+      expectReservedRawRuleProducerRejected(result);
       expect(result?.output).not.toContain("raw_data_write_denied");
       expect(result?.output).not.toContain("policy_gate_denied");
       await expect(readFile(join(fixture.workspaceRoot, "outer-disabled-side-effect.txt"), "utf8")).rejects.toThrow();
@@ -6392,8 +6651,7 @@ describe("policy-gated zero tool registry", () => {
       });
 
       expect(result?.success).toBe(false);
-      expect(result?.output).toContain("policy_gate_raw_data_rule_misconfigured");
-      expectOuterRawRuleMisconfiguration(result);
+      expectReservedRawRuleProducerRejected(result);
       expect(result?.output).not.toContain("raw_data_write_denied");
       expect(result?.output).not.toContain("policy_gate_denied");
       await expect(readFile(join(fixture.workspaceRoot, "outer-disabled-sandbox-side-effect.txt"), "utf8")).rejects.toThrow();
@@ -6426,7 +6684,7 @@ describe("policy-gated zero tool registry", () => {
       });
 
       expect(result?.success).toBe(false);
-      expectOuterRawRuleMisconfiguration(result);
+      expectReservedRawRuleProducerRejected(result);
       expect(result?.output).not.toContain("raw_data_write_denied");
       expect(result?.output).not.toContain("policy_gate_denied");
       await expect(readFile(join(fixture.workspaceRoot, "mismatch-side-effect.txt"), "utf8")).rejects.toThrow();
@@ -7101,32 +7359,12 @@ function createToolContext(role: string): ToolContext & { role: string } {
   };
 }
 
-function expectOuterRawRuleMisconfiguration(result: ToolResult | undefined): void {
-  const payload = JSON.parse(result?.output ?? "{}") as {
-    error?: string;
-    rule?: string;
-    guard_class?: string;
-    reason?: string;
-    outer_reason?: string;
-    profile_id?: string;
-    profile_path?: string;
-    remediation?: {
-      next_action?: string;
-      hint?: string;
-      ref?: string;
-    };
-  };
-
-  expect(payload.error).toBe("policy_gate_raw_data_rule_misconfigured");
-  expect(payload.rule).toBe(RAW_DATA_WRITE_RULE_ID);
-  expect(payload.guard_class).toBe("authority");
-  expect(payload.reason).toContain("RawDataSandboxedBashTool");
-  expect(payload.outer_reason).toBe("obvious static raw-data write target");
-  expect(payload.profile_id).toBeUndefined();
-  expect(payload.profile_path).toBeUndefined();
-  expect(payload.remediation?.next_action).toBe("fix_and_retry");
-  expect(payload.remediation?.hint).toContain("RawDataSandboxedBashTool");
-  expect(PolicyGateRemediationSchema.safeParse(payload.remediation).success).toBe(true);
+function expectReservedRawRuleProducerRejected(result: ToolResult | undefined): void {
+  expect(result?.output).toContain("Invalid policy gate decision");
+  expect(result?.output).toContain(RAW_DATA_WRITE_RULE_ID);
+  expect(result?.output).toContain("ruleId");
+  expect(result?.output).not.toContain("policy_gate_raw_data_rule_misconfigured");
+  expect(result?.output).not.toContain("raw_data_write_denied");
 }
 
 function expectToolParameterSchemaValidationDenial(result: ToolResult | undefined): void {

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -3894,6 +3894,45 @@ describe("policy-gated zero tool registry", () => {
     expect(zodTool.calls).toBe(0);
   });
 
+  test("SHUD evaluator decision validation errors win before invalid Zod schema denial", async () => {
+    const zodTool = new ZodRecordingTool(
+      "zod.invalid.shud.decision.validation",
+      z.object({
+        command: z.string()
+      })
+    );
+    let evaluatorCalls = 0;
+    const wrapped = wrapToolWithPolicyGate(zodTool, {
+      evaluate: createShudPolicyGateEvaluator(async () => {
+        evaluatorCalls += 1;
+        return {
+          decision: "deny",
+          ruleId: SPAWN_PROFILE_SUBSET_RULE_ID,
+          reason: "custom evaluator attempted to downgrade spawn-profile authority",
+          remediation: {
+            next_action: "adjust_scope",
+            hint: "Keep spawn-profile-subset classified as authority.",
+            ref: SPAWN_PROFILE_SUBSET_POLICY_REF
+          },
+          guardClass: "capability"
+        };
+      })
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), {
+      command: 42
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Invalid policy gate decision");
+    expect(result.output).toContain(SPAWN_PROFILE_SUBSET_RULE_ID);
+    expect(result.output).toContain("guardClass");
+    expect(result.output).not.toContain("policy_gate_denied");
+    expect(result.output).not.toContain(TOOL_PARAMETER_SCHEMA_RULE_ID);
+    expect(evaluatorCalls).toBe(1);
+    expect(zodTool.calls).toBe(0);
+  });
+
   test("policy evaluator denial wins before invalid Zod schema details", async () => {
     const zodTool = new ZodRecordingTool(
       "zod.denied.first",

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -4116,6 +4116,102 @@ describe("policy-gated zero tool registry", () => {
     expect(tool.calls).toBe(0);
   });
 
+  test("non-Zod execution validator errors win over evaluator denial", async () => {
+    const cases = [
+      {
+        name: "missing-guard",
+        decision: {
+          decision: "deny",
+          ruleId: "validator-missing-guard-class",
+          reason: "validator denied without classification",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Classify the validator denial before retrying.",
+            ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+          }
+        },
+        expectedRule: "validator-missing-guard-class",
+        expectedField: "guardClass"
+      },
+      {
+        name: "invalid-guard",
+        decision: {
+          decision: "deny",
+          ruleId: "validator-invalid-guard-class",
+          reason: "validator denied with an invalid classification",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Classify the validator denial as authority or capability before retrying.",
+            ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+          },
+          guardClass: "temporary"
+        },
+        expectedRule: "validator-invalid-guard-class",
+        expectedField: "guardClass"
+      },
+      {
+        name: "reserved-rule",
+        decision: {
+          decision: "deny",
+          ruleId: RAW_DATA_WRITE_RULE_ID,
+          reason: "validator attempted to mint exact reserved authority evidence",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Use a validator-owned policy rule id.",
+            ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
+          },
+          guardClass: "authority"
+        },
+        expectedRule: RAW_DATA_WRITE_RULE_ID,
+        expectedField: "ruleId"
+      },
+      {
+        name: "reserved-prefix",
+        decision: {
+          decision: "deny",
+          ruleId: `${RAW_DATA_WRITE_RULE_ID}:caller-minted`,
+          reason: "validator attempted to mint reserved authority prefix evidence",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Use a validator-owned policy rule id.",
+            ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
+          },
+          guardClass: "authority"
+        },
+        expectedRule: `${RAW_DATA_WRITE_RULE_ID}:caller-minted`,
+        expectedField: "ruleId"
+      }
+    ] as const;
+
+    for (const testCase of cases) {
+      const tool = new RecordingTool(`non-zod.validator.error.before.evaluator.${testCase.name}`);
+      const wrapped = wrapToolWithPolicyGate(tool, {
+        evaluate: async () => ({
+          decision: "deny",
+          ruleId: "evaluator-capability-denial",
+          reason: "legal evaluator denial should not mask validator validation errors",
+          remediation: {
+            next_action: "adjust_scope",
+            hint: "Use a tool input allowed by the evaluator policy.",
+            ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+          },
+          guardClass: "capability"
+        }),
+        validateExecutionInput: () => testCase.decision as never
+      });
+
+      const result = await wrapped.run(createToolContext("worker"), { blocked: true });
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("Invalid policy gate decision");
+      expect(result.output).toContain(testCase.expectedRule);
+      expect(result.output).toContain(testCase.expectedField);
+      expect(result.output).not.toContain("evaluator-capability-denial");
+      expect(result.output).not.toContain("policy_gate_denied");
+      expect(tool.calls).toBe(0);
+    }
+  });
+
   test("non-Zod evaluator denials win over execution validator denial", async () => {
     const tool = new RecordingTool("non-zod.evaluator.denial.before.validator");
     const wrapped = wrapToolWithPolicyGate(tool, {

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -101,7 +101,7 @@ describe("policy-gated zero tool registry", () => {
                 ref: "openspec/changes/m1-foundation/specs/tool-registry-governance/spec.md"
               }
             })
-          } as never
+          }
         ]
       })
     });
@@ -117,6 +117,43 @@ describe("policy-gated zero tool registry", () => {
       guard_class?: string;
     };
     expect(payload.ruleId).toBe("registry-snake-guard");
+    expect(payload.guard_class).toBe("authority");
+  });
+
+  test("policy gate evaluator snapshots retained context guard metadata", async () => {
+    const bashTool = new RecordingTool("bash");
+    const rule = {
+      ruleId: "registry-retained-context-guard",
+      description: "Denies with metadata captured at evaluator construction.",
+      guardClass: "authority" as "authority" | "capability",
+      evaluate: () => ({
+        decision: "deny" as const,
+        reason: "retained context denied",
+        remediation: {
+          next_action: "adjust_scope" as const,
+          hint: "Use a governed input.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        }
+      })
+    };
+    const context = { rules: [rule] };
+    const evaluate = createPolicyGateEvaluator(context);
+    rule.guardClass = "capability";
+    const registry = createPolicyGatedToolRegistry([bashTool], { evaluate });
+
+    const result = await registry.get("bash")?.run(createToolContext("worker"), {
+      command: "printf nope > workspace/out.txt"
+    });
+
+    expect(result?.success).toBe(false);
+    expect(bashTool.calls).toBe(0);
+    const payload = JSON.parse(result?.output ?? "{}") as {
+      error?: string;
+      ruleId?: string;
+      guard_class?: string;
+    };
+    expect(payload.error).toBe("policy_gate_denied");
+    expect(payload.ruleId).toBe("registry-retained-context-guard");
     expect(payload.guard_class).toBe("authority");
   });
 
@@ -1947,6 +1984,93 @@ describe("policy-gated zero tool registry", () => {
     });
   });
 
+  test("empty ruleId from custom evaluator fails without policy_gate_denied payload", async () => {
+    const bashTool = new RecordingTool("bash");
+    const wrapped = wrapToolWithPolicyGate(bashTool, {
+      evaluate: async () =>
+        ({
+          decision: "deny",
+          ruleId: "   ",
+          reason: "bad generic deny",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Return a stable rule identity before retrying.",
+            ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+          },
+          guardClass: "authority"
+        }) as never
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), {
+      command: "printf nope > workspace/out.txt"
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Invalid policy gate decision");
+    expect(result.output).toContain("ruleId");
+    expect(result.output).not.toContain("policy_gate_denied");
+    expect(result.outputSummary).toContain("Error: Invalid policy gate decision");
+    expect(bashTool.calls).toBe(0);
+  });
+
+  test("empty ruleId from execution validator fails without policy_gate_denied payload", async () => {
+    const tool = new RecordingTool("validator.empty.rule");
+    const wrapped = wrapToolWithPolicyGate(tool, {
+      evaluate: async () => ({ decision: "allow" }),
+      validateExecutionInput: () =>
+        ({
+          decision: "deny",
+          ruleId: "\t",
+          reason: "validator denied without stable identity",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Return a stable validator rule identity before retrying.",
+            ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+          },
+          guardClass: "capability"
+        }) as never
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), { blocked: true });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Invalid policy gate decision");
+    expect(result.output).toContain("ruleId");
+    expect(result.output).not.toContain("policy_gate_denied");
+    expect(result.outputSummary).toContain("Error: Invalid policy gate decision");
+    expect(tool.calls).toBe(0);
+  });
+
+  test("SHUD policy evaluator rejects direct custom empty ruleId", async () => {
+    const tool = new RecordingTool("direct.empty.rule");
+    const evaluator = createShudPolicyGateEvaluator(async () =>
+      ({
+        decision: "deny",
+        ruleId: "",
+        reason: "direct custom evaluator denied without stable identity",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Return a stable rule identity before retrying.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        },
+        guardClass: "authority"
+      }) as never
+    );
+
+    await expect(
+      evaluator(
+        {
+          toolId: tool.name,
+          role: "worker",
+          input: { blocked: true },
+          workDir: "/tmp/shud-harness-test"
+        },
+        { tool, toolContext: createToolContext("worker") }
+      )
+    ).rejects.toThrow(/Invalid policy gate decision.*ruleId/);
+    expect(tool.calls).toBe(0);
+  });
+
   test("SHUD policy evaluator rejects direct custom missing guardClass", async () => {
     const tool = new RecordingTool("direct.missing.guard");
     const evaluator = createShudPolicyGateEvaluator(async () =>
@@ -2037,6 +2161,36 @@ describe("policy-gated zero tool registry", () => {
     expect(tool.calls).toBe(0);
   });
 
+  test("SHUD policy evaluator rejects direct custom raw-data authority downgrade", async () => {
+    const tool = new RecordingTool("direct.raw.downgrade");
+    const evaluator = createShudPolicyGateEvaluator(async () =>
+      ({
+        decision: "deny",
+        ruleId: RAW_DATA_WRITE_RULE_ID,
+        reason: "direct custom evaluator attempted to downgrade raw-data authority",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Keep raw-data-write classified as authority.",
+          ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
+        },
+        guardClass: "capability"
+      }) as never
+    );
+
+    await expect(
+      evaluator(
+        {
+          toolId: tool.name,
+          role: "worker",
+          input: { blocked: true },
+          workDir: "/tmp/shud-harness-test"
+        },
+        { tool, toolContext: createToolContext("worker") }
+      )
+    ).rejects.toThrow(/Invalid policy gate decision.*raw-data-write.*guardClass/);
+    expect(tool.calls).toBe(0);
+  });
+
   test("missing guardClass from execution validator fails closed without policy_gate_denied payload", async () => {
     const tool = new RecordingTool("validator.missing.guard");
     const wrapped = wrapToolWithPolicyGate(tool, {
@@ -2120,6 +2274,39 @@ describe("policy-gated zero tool registry", () => {
     expect(result.output).toContain("validator-conflicting-guard-class");
     expect(result.output).toContain("guardClass");
     expect(result.output).not.toContain("policy_gate_denied");
+    expect(result.outputSummary).toContain("Error: Invalid policy gate decision");
+    expect(tool.calls).toBe(0);
+  });
+
+  test("raw-data authority downgrade from execution validator fails closed without policy payload", async () => {
+    const tool = new RecordingTool("validator.raw.downgrade");
+    const wrapped = wrapToolWithPolicyGate(tool, {
+      evaluate: async () => ({ decision: "allow" }),
+      validateExecutionInput: () =>
+        ({
+          decision: "deny",
+          ruleId: RAW_DATA_WRITE_RULE_ID,
+          reason: "execution validator attempted to downgrade raw-data authority",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Keep raw-data-write classified as authority.",
+            ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
+          },
+          guardClass: "capability"
+        }) as never
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), {
+      command: "printf nope > data/raw/input.csv"
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Invalid policy gate decision");
+    expect(result.output).toContain(RAW_DATA_WRITE_RULE_ID);
+    expect(result.output).toContain("guardClass");
+    expect(result.output).not.toContain("policy_gate_denied");
+    expect(result.output).not.toContain("policy_gate_raw_data_rule_misconfigured");
+    expect(result.output).not.toContain("raw_data_write_denied");
     expect(result.outputSummary).toContain("Error: Invalid policy gate decision");
     expect(tool.calls).toBe(0);
   });
@@ -6083,6 +6270,46 @@ describe("policy-gated zero tool registry", () => {
     }
   });
 
+  test("SHUD runtime rejects custom raw-data authority downgrade before raw telemetry", async () => {
+    const fixture = await createRawFixture();
+    try {
+      const registry = createShudRuntimeToolRegistry({
+        protectedRawPaths: [fixture.rawRoot],
+        allowedWriteRoots: [fixture.root],
+        tempRoot: fixture.tempRoot,
+        profileRoot: fixture.profileRoot,
+        fuseRules: [],
+        evaluate: async () => ({
+          decision: "deny",
+          ruleId: RAW_DATA_WRITE_RULE_ID,
+          reason: "custom evaluator attempted to downgrade raw-data authority",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Keep raw-data-write classified as authority.",
+            ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
+          },
+          guardClass: "capability"
+        })
+      });
+
+      const result = await registry.get("bash")?.run(fixture.context, {
+        command: "printf nope > data/raw/downgraded-raw.txt"
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.output).toContain("Invalid policy gate decision");
+      expect(result?.output).toContain(RAW_DATA_WRITE_RULE_ID);
+      expect(result?.output).toContain("guardClass");
+      expect(result?.output).not.toContain("policy_gate_denied");
+      expect(result?.output).not.toContain("policy_gate_raw_data_rule_misconfigured");
+      expect(result?.output).not.toContain("raw_data_write_denied");
+      await expect(readFile(join(fixture.rawRoot, "downgraded-raw.txt"), "utf8")).rejects.toThrow();
+      await expect(readRawAuditRows(fixture.root)).rejects.toThrow();
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   test("SHUD runtime fails closed when custom outer evaluator owns raw advisory composition", async () => {
     const fixture = await createRawFixture();
     try {
@@ -6878,6 +7105,7 @@ function expectOuterRawRuleMisconfiguration(result: ToolResult | undefined): voi
   const payload = JSON.parse(result?.output ?? "{}") as {
     error?: string;
     rule?: string;
+    guard_class?: string;
     reason?: string;
     outer_reason?: string;
     profile_id?: string;
@@ -6891,6 +7119,7 @@ function expectOuterRawRuleMisconfiguration(result: ToolResult | undefined): voi
 
   expect(payload.error).toBe("policy_gate_raw_data_rule_misconfigured");
   expect(payload.rule).toBe(RAW_DATA_WRITE_RULE_ID);
+  expect(payload.guard_class).toBe("authority");
   expect(payload.reason).toContain("RawDataSandboxedBashTool");
   expect(payload.outer_reason).toBe("obvious static raw-data write target");
   expect(payload.profile_id).toBeUndefined();

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -82,6 +82,43 @@ describe("policy-gated zero tool registry", () => {
     );
   });
 
+  test("policy gate evaluator propagates snake_case rule guard_class to denial payloads", async () => {
+    const bashTool = new RecordingTool("bash");
+    const registry = createPolicyGatedToolRegistry([bashTool], {
+      evaluate: createPolicyGateEvaluator({
+        rules: [
+          {
+            ruleId: "registry-snake-guard",
+            description: "Uses spec-shaped guard_class metadata.",
+            guard_class: "authority",
+            evaluate: () => ({
+              decision: "deny",
+              reason: "snake_case rule metadata denied",
+              remediation: {
+                next_action: "adjust_scope",
+                hint: "Use a governed tool input.",
+                ref: "openspec/changes/m1-foundation/specs/tool-registry-governance/spec.md"
+              }
+            })
+          } as never
+        ]
+      })
+    });
+
+    const result = await registry.get("bash")?.run(createToolContext("worker"), {
+      command: "printf nope > workspace/out.txt"
+    });
+
+    expect(result?.success).toBe(false);
+    expect(bashTool.calls).toBe(0);
+    const payload = JSON.parse(result?.output ?? "{}") as {
+      ruleId?: string;
+      guard_class?: string;
+    };
+    expect(payload.ruleId).toBe("registry-snake-guard");
+    expect(payload.guard_class).toBe("authority");
+  });
+
   test("denies before executing the underlying bash BaseTool", async () => {
     const bashTool = new RecordingTool("bash");
     const registry = createPolicyGatedToolRegistry([bashTool], {
@@ -2012,7 +2049,8 @@ describe("policy-gated zero tool registry", () => {
           next_action: "fix_and_retry",
           hint: `Remove the outer raw rule containing ${secret}.`,
           ref: `openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md#${secret}`
-        }
+        },
+        guardClass: "authority"
       })
     });
 
@@ -2217,7 +2255,8 @@ describe("policy-gated zero tool registry", () => {
               next_action: "adjust_scope",
               hint: "Use a registry-authorized input.",
               ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
-            }
+            },
+            guardClass: "authority"
           };
         }
         return { decision: "allow" };
@@ -2409,7 +2448,8 @@ describe("policy-gated zero tool registry", () => {
           next_action: "adjust_scope",
           hint: "Use a tool allowed by the registry owner.",
           ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
-        }
+        },
+        guardClass: "authority"
       })
     });
     const staleReplacementInnerTool = new RecordingTool("edit");
@@ -2440,7 +2480,8 @@ describe("policy-gated zero tool registry", () => {
           next_action: "adjust_scope",
           hint: "Use a registry-authorized input.",
           ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
-        }
+        },
+        guardClass: "authority"
       })
     });
     const fakeOptions = {
@@ -2495,7 +2536,8 @@ describe("policy-gated zero tool registry", () => {
           next_action: "adjust_scope",
           hint: "Use a registry-authorized input.",
           ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
-        }
+        },
+        guardClass: "authority"
       })
     });
     const registeredTool = registry.get("generic.tools.authority");
@@ -3149,7 +3191,8 @@ describe("policy-gated zero tool registry", () => {
             next_action: "adjust_scope",
             hint: "Use a tool allowed for this role.",
             ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
-          }
+          },
+          guardClass: "authority"
         };
       }
     });
@@ -3230,7 +3273,8 @@ describe("policy-gated zero tool registry", () => {
               next_action: "adjust_scope",
               hint: "Lower the parsed count before retrying.",
               ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
-            }
+            },
+            guardClass: "authority"
           };
         }
         return { decision: "allow" };
@@ -5039,7 +5083,8 @@ describe("policy-gated zero tool registry", () => {
                 next_action: "adjust_scope",
                 hint: "Use a different reviewer delegation path.",
                 ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
-              }
+              },
+              guardClass: "authority"
             };
           }
           return { decision: "allow" };
@@ -5341,7 +5386,8 @@ describe("policy-gated zero tool registry", () => {
             next_action: "adjust_scope",
             hint: "Use a different canonical subset for this task.",
             ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
-          }
+          },
+          guardClass: "authority"
         })
       });
 
@@ -5366,8 +5412,63 @@ describe("policy-gated zero tool registry", () => {
         reason?: string;
       };
       expect(payload.ruleId).toBe("custom-canonical-subset-deny");
-      expect(payload.guard_class).toBeUndefined();
+      expect(payload.guard_class).toBe("authority");
       expect(payload.reason).toBe("custom evaluator denied canonical subset");
+      expect(agentControl.getSpawnCalls()).toBe(0);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("SHUD runtime custom evaluator deny requires guard classification", async () => {
+    const fixture = await createRawFixture();
+    try {
+      await writeWorkerRoleFixture(fixture.root);
+      const modelRouter = createSpawnModelRouterStub();
+      const zeroLikeRegistry = new ToolRegistry();
+      zeroLikeRegistry.register(new RecordingTool("spawn_agent"));
+      zeroLikeRegistry.register(new RecordingTool("read"));
+      const agentControl = createAgentControlSpy();
+
+      const registry = createShudRuntimeToolRegistry({
+        tools: zeroLikeRegistry.list(),
+        protectedRawPaths: [fixture.rawRoot],
+        allowedWriteRoots: [fixture.root],
+        tempRoot: fixture.tempRoot,
+        profileRoot: fixture.profileRoot,
+        fuseRules: [],
+        modelRouter,
+        evaluate: async () =>
+          ({
+            decision: "deny",
+            ruleId: "custom-unclassified-deny",
+            reason: "custom evaluator denied without classification",
+            remediation: {
+              next_action: "adjust_scope",
+              hint: "Add guardClass before returning a policy denial.",
+              ref: "openspec/changes/m1-foundation/specs/tool-registry-governance/spec.md"
+            }
+          }) as never
+      });
+
+      const result = await registry.get("spawn_agent")?.run(
+        {
+          ...fixture.context,
+          agentControl: agentControl.control,
+          projectRoot: fixture.root
+        },
+        {
+          instruction: "Run a worker task.",
+          role: "worker",
+          tools: ["read"]
+        }
+      );
+
+      expect(result?.success).toBe(false);
+      expect(result?.output).toContain("Invalid policy gate decision");
+      expect(result?.output).toContain("custom-unclassified-deny");
+      expect(result?.output).toContain("guardClass");
+      expect(result?.output).not.toContain("policy_gate_denied");
       expect(agentControl.getSpawnCalls()).toBe(0);
     } finally {
       await fixture.cleanup();
@@ -5703,7 +5804,8 @@ describe("policy-gated zero tool registry", () => {
             next_action: "adjust_scope",
             hint: "Use an allowed tool for this role.",
             ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
-          }
+          },
+          guardClass: "authority"
         })
       });
 
@@ -5994,7 +6096,8 @@ describe("policy-gated zero tool registry", () => {
             next_action: "adjust_scope",
             hint: "Use an allowed tool for this role.",
             ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
-          }
+          },
+          guardClass: "authority"
         })
       });
 
@@ -6029,7 +6132,8 @@ describe("policy-gated zero tool registry", () => {
             next_action: "adjust_scope",
             hint: "Use an allowed tool for this runtime role.",
             ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
-          }
+          },
+          guardClass: "authority"
         })
       });
       const staleReplacementInnerTool = new RecordingTool("edit");

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -66,6 +66,22 @@ if (requireSeatbeltTests) {
 const seatbeltTest = hasSeatbelt ? test : test.skip;
 
 describe("policy-gated zero tool registry", () => {
+  test("policy gate evaluator assembly rejects unclassified hard guard rules", () => {
+    expect(() =>
+      createPolicyGateEvaluator({
+        rules: [
+          {
+            ruleId: "registry-unclassified-guard",
+            description: "Missing guard_class metadata.",
+            evaluate: () => ({ decision: "allow" })
+          } as never
+        ]
+      })
+    ).toThrow(
+      /Policy gate guard_class lint failed: registry-unclassified-guard: missing or invalid guardClass\/guard_class/
+    );
+  });
+
   test("denies before executing the underlying bash BaseTool", async () => {
     const bashTool = new RecordingTool("bash");
     const registry = createPolicyGatedToolRegistry([bashTool], {
@@ -74,6 +90,7 @@ describe("policy-gated zero tool registry", () => {
           {
             ruleId: "workspace-write-deny",
             description: "Reject writes to raw data.",
+            guardClass: "authority",
             evaluate: () => ({
               decision: "deny",
               reason: "raw data writes are blocked",
@@ -1900,6 +1917,7 @@ describe("policy-gated zero tool registry", () => {
           {
             ruleId: "invalid-remediation-rule",
             description: "Returns invalid remediation.",
+            guardClass: "authority",
             evaluate: () => ({
               decision: "deny",
               reason: "invalid remediation",
@@ -1937,6 +1955,7 @@ describe("policy-gated zero tool registry", () => {
           {
             ruleId: "workspace-write-deny",
             description: "Reject writes to raw data.",
+            guardClass: "authority",
             evaluate: () => ({
               decision: "deny",
               reason: `blocked because ${secret}`,

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -30,7 +30,8 @@ import {
   SPAWN_PROFILE_ALLOWLIST_MAX_ITEMS,
   SPAWN_PROFILE_MAX_EXCESS_TOOL_SAMPLES,
   SPAWN_PROFILE_SUBSET_POLICY_REF,
-  SPAWN_PROFILE_SUBSET_RULE_ID
+  SPAWN_PROFILE_SUBSET_RULE_ID,
+  TOOL_PARAMETER_SCHEMA_RULE_ID
 } from "./policy-gate-core";
 import {
   assertAllToolsPolicyGated,
@@ -2068,6 +2069,36 @@ describe("policy-gated zero tool registry", () => {
     expect(bashTool.calls).toBe(0);
   });
 
+  test("schema validation authority impersonation from custom evaluator fails closed", async () => {
+    for (const guardClass of ["authority", "capability"] as const) {
+      const tool = new RecordingTool(`custom.schema.${guardClass}`);
+      const wrapped = wrapToolWithPolicyGate(tool, {
+        evaluate: async () => ({
+          decision: "deny",
+          ruleId: TOOL_PARAMETER_SCHEMA_RULE_ID,
+          reason: "custom evaluator attempted to impersonate built-in schema validation",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Use a custom evaluator-owned policy rule id.",
+            ref: "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定"
+          },
+          guardClass
+        })
+      });
+
+      const result = await wrapped.run(createToolContext("worker"), {
+        command: "printf nope > workspace/out.txt"
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("Invalid policy gate decision");
+      expect(result.output).toContain(TOOL_PARAMETER_SCHEMA_RULE_ID);
+      expect(result.output).toContain("ruleId");
+      expect(result.output).not.toContain("policy_gate_denied");
+      expect(tool.calls).toBe(0);
+    }
+  });
+
   test("empty ruleId from custom evaluator fails without policy_gate_denied payload", async () => {
     const bashTool = new RecordingTool("bash");
     const wrapped = wrapToolWithPolicyGate(bashTool, {
@@ -2275,6 +2306,38 @@ describe("policy-gated zero tool registry", () => {
     expect(tool.calls).toBe(0);
   });
 
+  test("SHUD policy evaluator rejects direct custom schema validation authority downgrade", async () => {
+    const tool = new RecordingTool("direct.schema.downgrade");
+    const evaluator = createShudPolicyGateEvaluator(async () =>
+      ({
+        decision: "deny",
+        ruleId: TOOL_PARAMETER_SCHEMA_RULE_ID,
+        reason: "direct custom evaluator attempted to downgrade schema validation authority",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Keep built-in schema validation classified as authority.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定"
+        },
+        guardClass: "capability"
+      }) as never
+    );
+
+    await expect(
+      evaluator(
+        {
+          toolId: tool.name,
+          role: "worker",
+          input: { blocked: true },
+          workDir: "/tmp/shud-harness-test"
+        },
+        { tool, toolContext: createToolContext("worker") }
+      )
+    ).rejects.toThrow(
+      new RegExp(`Invalid policy gate decision.*${TOOL_PARAMETER_SCHEMA_RULE_ID}.*guardClass`)
+    );
+    expect(tool.calls).toBe(0);
+  });
+
   test("SHUD policy evaluator rejects direct custom reserved authority rule ids", async () => {
     const cases = [
       {
@@ -2286,6 +2349,11 @@ describe("policy-gated zero tool registry", () => {
         name: "raw",
         ruleId: RAW_DATA_WRITE_RULE_ID,
         ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
+      },
+      {
+        name: "schema",
+        ruleId: TOOL_PARAMETER_SCHEMA_RULE_ID,
+        ref: "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定"
       }
     ] as const;
 
@@ -2494,6 +2562,35 @@ describe("policy-gated zero tool registry", () => {
     expect(result.output).toContain("ruleId");
     expect(result.output).not.toContain("policy_gate_denied");
     expect(tool.calls).toBe(0);
+  });
+
+  test("schema validation authority impersonation from execution validator fails closed", async () => {
+    for (const guardClass of ["authority", "capability"] as const) {
+      const tool = new RecordingTool(`validator.schema.${guardClass}`);
+      const wrapped = wrapToolWithPolicyGate(tool, {
+        evaluate: async () => ({ decision: "allow" }),
+        validateExecutionInput: () => ({
+          decision: "deny",
+          ruleId: TOOL_PARAMETER_SCHEMA_RULE_ID,
+          reason: "execution validator attempted to impersonate built-in schema validation",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Use a validator-owned policy rule id.",
+            ref: "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定"
+          },
+          guardClass
+        })
+      });
+
+      const result = await wrapped.run(createToolContext("worker"), { blocked: true });
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("Invalid policy gate decision");
+      expect(result.output).toContain(TOOL_PARAMETER_SCHEMA_RULE_ID);
+      expect(result.output).toContain("ruleId");
+      expect(result.output).not.toContain("policy_gate_denied");
+      expect(tool.calls).toBe(0);
+    }
   });
 
   test("matching guard aliases from execution validator emit classified policy_gate_denied", async () => {
@@ -3487,10 +3584,11 @@ describe("policy-gated zero tool registry", () => {
 
     expect(result.success).toBe(false);
     expect(result.output).toContain("policy_gate_denied");
-    expect(result.output).toContain("tool-parameter-schema-validation");
+    expect(result.output).toContain(TOOL_PARAMETER_SCHEMA_RULE_ID);
     const payload = JSON.parse(result.output) as {
       error?: string;
       ruleId?: string;
+      guard_class?: string;
       reason?: string;
       remediation?: {
         next_action?: string;
@@ -3499,7 +3597,8 @@ describe("policy-gated zero tool registry", () => {
       };
     };
     expect(payload.error).toBe("policy_gate_denied");
-    expect(payload.ruleId).toBe("tool-parameter-schema-validation");
+    expect(payload.ruleId).toBe(TOOL_PARAMETER_SCHEMA_RULE_ID);
+    expect(payload.guard_class).toBe("authority");
     expect(payload.reason).toContain("command");
     expect(payload.remediation?.next_action).toBe("fix_and_retry");
     expect(payload.remediation?.hint).toContain("Zod parameter schema");
@@ -3542,10 +3641,11 @@ describe("policy-gated zero tool registry", () => {
 
     expect(result?.success).toBe(false);
     expect(result?.output).toContain("policy_gate_denied");
-    expect(result?.output).toContain("tool-parameter-schema-validation");
+    expect(result?.output).toContain(TOOL_PARAMETER_SCHEMA_RULE_ID);
     const payload = JSON.parse(result?.output ?? "{}") as {
       error?: string;
       ruleId?: string;
+      guard_class?: string;
       reason?: string;
       remediation?: {
         next_action?: string;
@@ -3554,7 +3654,8 @@ describe("policy-gated zero tool registry", () => {
       };
     };
     expect(payload.error).toBe("policy_gate_denied");
-    expect(payload.ruleId).toBe("tool-parameter-schema-validation");
+    expect(payload.ruleId).toBe(TOOL_PARAMETER_SCHEMA_RULE_ID);
+    expect(payload.guard_class).toBe("authority");
     expect(payload.reason).toContain("command");
     expect(payload.remediation?.next_action).toBe("fix_and_retry");
     expect(payload.remediation?.hint).toContain("Zod parameter schema");
@@ -3768,11 +3869,12 @@ describe("policy-gated zero tool registry", () => {
 
     expect(result.success).toBe(false);
     expect(result.output).toContain("policy_gate_denied");
-    expect(result.output).toContain("tool-parameter-schema-validation");
+    expect(result.output).toContain(TOOL_PARAMETER_SCHEMA_RULE_ID);
     expect(result.output).not.toContain("throwing evaluator");
     const payload = JSON.parse(result.output) as {
       error?: string;
       ruleId?: string;
+      guard_class?: string;
       remediation?: {
         next_action?: string;
         hint?: string;
@@ -3780,7 +3882,8 @@ describe("policy-gated zero tool registry", () => {
       };
     };
     expect(payload.error).toBe("policy_gate_denied");
-    expect(payload.ruleId).toBe("tool-parameter-schema-validation");
+    expect(payload.ruleId).toBe(TOOL_PARAMETER_SCHEMA_RULE_ID);
+    expect(payload.guard_class).toBe("authority");
     expect(payload.remediation?.next_action).toBe("fix_and_retry");
     expect(payload.remediation?.hint).toContain("Zod parameter schema");
     expect(payload.remediation?.ref).toBe(
@@ -3822,7 +3925,7 @@ describe("policy-gated zero tool registry", () => {
 
     expect(result.success).toBe(false);
     expect(result.output).toContain("authorization-deny");
-    expect(result.output).not.toContain("tool-parameter-schema-validation");
+    expect(result.output).not.toContain(TOOL_PARAMETER_SCHEMA_RULE_ID);
     expect(result.output).not.toContain("Expected string");
     expect(evaluatorCalls).toBe(1);
     expect(zodTool.calls).toBe(0);
@@ -3901,7 +4004,7 @@ describe("policy-gated zero tool registry", () => {
       expect(result.output).toContain("Invalid policy gate decision");
       expect(result.output).toContain(testCase.expectedRuleId);
       expect(result.output).toContain("guardClass");
-      expect(result.output).not.toContain("tool-parameter-schema-validation");
+      expect(result.output).not.toContain(TOOL_PARAMETER_SCHEMA_RULE_ID);
       expect(result.output).not.toContain("policy_gate_denied");
       expect(zodTool.calls).toBe(0);
     }
@@ -7370,10 +7473,11 @@ function expectReservedRawRuleProducerRejected(result: ToolResult | undefined): 
 function expectToolParameterSchemaValidationDenial(result: ToolResult | undefined): void {
   expect(result?.success).toBe(false);
   expect(result?.output).toContain("policy_gate_denied");
-  expect(result?.output).toContain("tool-parameter-schema-validation");
+  expect(result?.output).toContain(TOOL_PARAMETER_SCHEMA_RULE_ID);
   const payload = JSON.parse(result?.output ?? "{}") as {
     error?: string;
     ruleId?: string;
+    guard_class?: string;
     reason?: string;
     remediation?: {
       next_action?: string;
@@ -7382,7 +7486,8 @@ function expectToolParameterSchemaValidationDenial(result: ToolResult | undefine
     };
   };
   expect(payload.error).toBe("policy_gate_denied");
-  expect(payload.ruleId).toBe("tool-parameter-schema-validation");
+  expect(payload.ruleId).toBe(TOOL_PARAMETER_SCHEMA_RULE_ID);
+  expect(payload.guard_class).toBe("authority");
   expect(payload.reason).toContain("command");
   expect(payload.remediation?.next_action).toBe("fix_and_retry");
   expect(payload.remediation?.hint).toContain("Zod parameter schema");

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -27,6 +27,7 @@ import type {
 import { z } from "zod";
 import {
   PolicyGateRemediationSchema,
+  RESERVED_AUTHORITY_POLICY_RULE_IDS,
   SPAWN_PROFILE_ALLOWLIST_MAX_ITEMS,
   SPAWN_PROFILE_MAX_EXCESS_TOOL_SAMPLES,
   SPAWN_PROFILE_SUBSET_POLICY_REF,
@@ -3933,6 +3934,263 @@ describe("policy-gated zero tool registry", () => {
     expect(zodTool.calls).toBe(0);
   });
 
+  test("core evaluator guard lint errors win before invalid Zod schema denial", async () => {
+    const zodTool = new ZodRecordingTool(
+      "zod.invalid.core.guard.lint",
+      z.object({
+        command: z.string()
+      })
+    );
+    let evaluatorCalls = 0;
+    const wrapped = wrapToolWithPolicyGate(zodTool, {
+      evaluate: createPolicyGateEvaluator({
+        rules: [
+          {
+            ruleId: SPAWN_PROFILE_SUBSET_RULE_ID,
+            description: "Attempts to downgrade reserved spawn authority at deny time.",
+            guardClass: "authority",
+            evaluate: () => {
+              evaluatorCalls += 1;
+              return {
+                decision: "deny",
+                reason: "core evaluator attempted to downgrade spawn-profile authority",
+                remediation: {
+                  next_action: "adjust_scope",
+                  hint: "Keep spawn-profile-subset classified as authority.",
+                  ref: SPAWN_PROFILE_SUBSET_POLICY_REF
+                },
+                guardClass: "capability"
+              };
+            }
+          }
+        ]
+      })
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), {
+      command: 42
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Policy gate guard_class lint failed");
+    expect(result.output).toContain(SPAWN_PROFILE_SUBSET_RULE_ID);
+    expect(result.output).toContain("guardClass");
+    expect(result.output).not.toContain("policy_gate_denied");
+    expect(result.output).not.toContain(TOOL_PARAMETER_SCHEMA_RULE_ID);
+    expect(evaluatorCalls).toBe(1);
+    expect(zodTool.calls).toBe(0);
+  });
+
+  test("reserved ruleId prefixes from custom evaluators fail as invalid decisions", async () => {
+    const cases = [
+      {
+        name: "raw",
+        ruleId: RAW_DATA_WRITE_RULE_ID,
+        ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
+      },
+      {
+        name: "spawn",
+        ruleId: SPAWN_PROFILE_SUBSET_RULE_ID,
+        ref: SPAWN_PROFILE_SUBSET_POLICY_REF
+      },
+      {
+        name: "schema",
+        ruleId: TOOL_PARAMETER_SCHEMA_RULE_ID,
+        ref: "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定"
+      }
+    ] as const;
+
+    expect(cases.map((testCase) => testCase.ruleId).sort()).toEqual(
+      [...RESERVED_AUTHORITY_POLICY_RULE_IDS].sort()
+    );
+
+    for (const testCase of cases) {
+      const tool = new RecordingTool(`evaluator.prefix.${testCase.name}`);
+      const wrapped = wrapToolWithPolicyGate(tool, {
+        evaluate: async () => ({
+          decision: "deny",
+          ruleId: `${testCase.ruleId}:caller-minted`,
+          reason: "custom evaluator attempted to mint reserved authority prefix evidence",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Use an evaluator-owned policy rule id.",
+            ref: testCase.ref
+          },
+          guardClass: "authority"
+        })
+      });
+
+      const result = await wrapped.run(createToolContext("worker"), { blocked: true });
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("Invalid policy gate decision");
+      expect(result.output).toContain(`${testCase.ruleId}:caller-minted`);
+      expect(result.output).toContain("ruleId");
+      expect(result.output).not.toContain("policy_gate_denied");
+      expect(tool.calls).toBe(0);
+    }
+  });
+
+  test("reserved ruleId prefixes from execution validators fail as invalid decisions", async () => {
+    const cases = [
+      {
+        name: "raw",
+        ruleId: RAW_DATA_WRITE_RULE_ID,
+        ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
+      },
+      {
+        name: "spawn",
+        ruleId: SPAWN_PROFILE_SUBSET_RULE_ID,
+        ref: SPAWN_PROFILE_SUBSET_POLICY_REF
+      },
+      {
+        name: "schema",
+        ruleId: TOOL_PARAMETER_SCHEMA_RULE_ID,
+        ref: "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定"
+      }
+    ] as const;
+
+    for (const testCase of cases) {
+      const tool = new RecordingTool(`validator.prefix.${testCase.name}`);
+      const wrapped = wrapToolWithPolicyGate(tool, {
+        evaluate: async () => ({ decision: "allow" }),
+        validateExecutionInput: () => ({
+          decision: "deny",
+          ruleId: `${testCase.ruleId}:caller-minted`,
+          reason: "execution validator attempted to mint reserved authority prefix evidence",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Use a validator-owned policy rule id.",
+            ref: testCase.ref
+          },
+          guardClass: "authority"
+        })
+      });
+
+      const result = await wrapped.run(createToolContext("worker"), { blocked: true });
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("Invalid policy gate decision");
+      expect(result.output).toContain(`${testCase.ruleId}:caller-minted`);
+      expect(result.output).toContain("ruleId");
+      expect(result.output).not.toContain("policy_gate_denied");
+      expect(tool.calls).toBe(0);
+    }
+  });
+
+  test("non-Zod evaluator decision validation errors win over execution validator denial", async () => {
+    const tool = new RecordingTool("non-zod.validator.masked.invalid.evaluator");
+    const wrapped = wrapToolWithPolicyGate(tool, {
+      evaluate: async () => ({
+        decision: "deny",
+        ruleId: RAW_DATA_WRITE_RULE_ID,
+        reason: "custom evaluator attempted to downgrade raw-data authority",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Keep raw-data-write classified as authority.",
+          ref: "openspec/changes/m1-foundation/specs/policy-gate-spike/spec.md"
+        },
+        guardClass: "capability"
+      }),
+      validateExecutionInput: () => ({
+        decision: "deny",
+        ruleId: "validator-capability-denial",
+        reason: "validator would deny with a non-reserved capability rule",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Fix the validator-owned input before retrying.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        },
+        guardClass: "capability"
+      })
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), { blocked: true });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Invalid policy gate decision");
+    expect(result.output).toContain(RAW_DATA_WRITE_RULE_ID);
+    expect(result.output).toContain("guardClass");
+    expect(result.output).not.toContain("validator-capability-denial");
+    expect(result.output).not.toContain("policy_gate_denied");
+    expect(tool.calls).toBe(0);
+  });
+
+  test("non-Zod evaluator denials win over execution validator denial", async () => {
+    const tool = new RecordingTool("non-zod.evaluator.denial.before.validator");
+    const wrapped = wrapToolWithPolicyGate(tool, {
+      evaluate: async () => ({
+        decision: "deny",
+        ruleId: "evaluator-authority-denial",
+        reason: "evaluator denial should win before validator denial",
+        remediation: {
+          next_action: "adjust_scope",
+          hint: "Use a tool input allowed by the evaluator policy.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        },
+        guardClass: "authority"
+      }),
+      validateExecutionInput: () => ({
+        decision: "deny",
+        ruleId: "validator-capability-denial",
+        reason: "validator would deny after evaluator policy",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Fix the validator-owned input before retrying.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        },
+        guardClass: "capability"
+      })
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), { blocked: true });
+    const payload = JSON.parse(result.output) as {
+      error?: string;
+      ruleId?: string;
+    };
+
+    expect(result.success).toBe(false);
+    expect(payload.error).toBe("policy_gate_denied");
+    expect(payload.ruleId).toBe("evaluator-authority-denial");
+    expect(result.output).not.toContain("validator-capability-denial");
+    expect(tool.calls).toBe(0);
+  });
+
+  test("non-Zod execution validator denial survives an ordinary throwing evaluator", async () => {
+    const tool = new RecordingTool("non-zod.validator.denial.throwing.evaluator");
+    let evaluatorCalls = 0;
+    const wrapped = wrapToolWithPolicyGate(tool, {
+      evaluate: async () => {
+        evaluatorCalls += 1;
+        throw new Error("ordinary evaluator failure should not replace validator denial");
+      },
+      validateExecutionInput: () => ({
+        decision: "deny",
+        ruleId: "validator-capability-denial",
+        reason: "validator denied before evaluator execution completed",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Fix the validator-owned input before retrying.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        },
+        guardClass: "capability"
+      })
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), { blocked: true });
+    const payload = JSON.parse(result.output) as {
+      error?: string;
+      ruleId?: string;
+    };
+
+    expect(result.success).toBe(false);
+    expect(payload.error).toBe("policy_gate_denied");
+    expect(payload.ruleId).toBe("validator-capability-denial");
+    expect(result.output).not.toContain("ordinary evaluator failure should not replace");
+    expect(evaluatorCalls).toBe(1);
+    expect(tool.calls).toBe(0);
+  });
+
   test("policy evaluator denial wins before invalid Zod schema details", async () => {
     const zodTool = new ZodRecordingTool(
       "zod.denied.first",
@@ -4608,7 +4866,7 @@ describe("policy-gated zero tool registry", () => {
     }
   });
 
-  test("SHUD runtime denies missing explicit spawn tools before custom evaluator and spawn", async () => {
+  test("SHUD runtime denies missing explicit spawn tools after custom evaluator allow", async () => {
     const fixture = await createRawFixture();
     try {
       const modelRouter = createSpawnModelRouterStub();
@@ -4665,14 +4923,14 @@ describe("policy-gated zero tool registry", () => {
       expect(payload.remediation?.next_action).toBe("adjust_scope");
       expect(payload.remediation?.hint).toContain("shud.run");
       expect(payload.remediation?.ref).toBe(SPAWN_PROFILE_SUBSET_POLICY_REF);
-      expect(customCalls).toBe(0);
+      expect(customCalls).toBe(1);
       expect(agentControl.getSpawnCalls()).toBe(0);
     } finally {
       await fixture.cleanup();
     }
   });
 
-  test("SHUD runtime denies missing injected canonical spawn tools before custom evaluator and spawn", async () => {
+  test("SHUD runtime denies missing injected canonical spawn tools after custom evaluator allow", async () => {
     const fixture = await createRawFixture();
     try {
       const modelRouter = createSpawnModelRouterStub();
@@ -4730,7 +4988,7 @@ describe("policy-gated zero tool registry", () => {
       expect(payload.remediation?.hint).toContain("artifact.write");
       expect(payload.remediation?.ref).toBe(SPAWN_PROFILE_SUBSET_POLICY_REF);
       expect(result?.output.length).toBeLessThan(900);
-      expect(customCalls).toBe(0);
+      expect(customCalls).toBe(1);
       expect(agentControl.getSpawnCalls()).toBe(0);
     } finally {
       await fixture.cleanup();
@@ -6362,7 +6620,7 @@ describe("policy-gated zero tool registry", () => {
     }
   });
 
-  test("SHUD runtime denies Zero-blocked canonical spawn tools before custom evaluator and spawn", async () => {
+  test("SHUD runtime denies Zero-blocked canonical spawn tools after custom evaluator allow", async () => {
     const fixture = await createRawFixture();
     try {
       await writeHarnessRoleFixture(fixture.root, "coordinator", ["read"]);
@@ -6455,7 +6713,7 @@ describe("policy-gated zero tool registry", () => {
         expect(payload.remediation?.hint).toContain(expectedToolId);
         expect(payload.remediation?.ref).toBe(SPAWN_PROFILE_SUBSET_POLICY_REF);
       }
-      expect(customCalls).toBe(0);
+      expect(customCalls).toBe(4);
       expect(agentControl.getSpawnCalls()).toBe(0);
     } finally {
       await fixture.cleanup();

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -37,6 +37,7 @@ import {
   assertPolicyGatedToolRegistry,
   createPolicyGateEvaluator,
   createPolicyGatedToolRegistry,
+  createShudPolicyGateEvaluator,
   createShudRuntimeToolRegistry,
   createShudSandboxedBashTool,
   isPolicyGatedTool,
@@ -1944,6 +1945,257 @@ describe("policy-gated zero tool registry", () => {
       success: false,
       outputSummary: result.outputSummary
     });
+  });
+
+  test("SHUD policy evaluator rejects direct custom missing guardClass", async () => {
+    const tool = new RecordingTool("direct.missing.guard");
+    const evaluator = createShudPolicyGateEvaluator(async () =>
+      ({
+        decision: "deny",
+        ruleId: "direct-missing-guard-class",
+        reason: "direct custom evaluator denied without classification",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Classify the direct custom denial before returning it.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        }
+      }) as never
+    );
+
+    await expect(
+      evaluator(
+        {
+          toolId: tool.name,
+          role: "worker",
+          input: { blocked: true },
+          workDir: "/tmp/shud-harness-test"
+        },
+        { tool, toolContext: createToolContext("worker") }
+      )
+    ).rejects.toThrow(/Invalid policy gate decision.*direct-missing-guard-class.*guardClass/);
+    expect(tool.calls).toBe(0);
+  });
+
+  test("SHUD policy evaluator rejects direct custom invalid guardClass", async () => {
+    const tool = new RecordingTool("direct.invalid.guard");
+    const evaluator = createShudPolicyGateEvaluator(async () =>
+      ({
+        decision: "deny",
+        ruleId: "direct-invalid-guard-class",
+        reason: "direct custom evaluator denied with invalid classification",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Classify the direct custom denial as authority or capability.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        },
+        guardClass: "temporary"
+      }) as never
+    );
+
+    await expect(
+      evaluator(
+        {
+          toolId: tool.name,
+          role: "worker",
+          input: { blocked: true },
+          workDir: "/tmp/shud-harness-test"
+        },
+        { tool, toolContext: createToolContext("worker") }
+      )
+    ).rejects.toThrow(/Invalid policy gate decision.*direct-invalid-guard-class.*guardClass/);
+    expect(tool.calls).toBe(0);
+  });
+
+  test("SHUD policy evaluator rejects direct custom conflicting guard aliases", async () => {
+    const tool = new RecordingTool("direct.conflicting.guard");
+    const evaluator = createShudPolicyGateEvaluator(async () =>
+      ({
+        decision: "deny",
+        ruleId: "direct-conflicting-guard-class",
+        reason: "direct custom evaluator denied with conflicting classifications",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Return one consistent guard classification before retrying.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        },
+        guardClass: "authority",
+        guard_class: "capability"
+      }) as never
+    );
+
+    await expect(
+      evaluator(
+        {
+          toolId: tool.name,
+          role: "worker",
+          input: { blocked: true },
+          workDir: "/tmp/shud-harness-test"
+        },
+        { tool, toolContext: createToolContext("worker") }
+      )
+    ).rejects.toThrow(/Invalid policy gate decision.*direct-conflicting-guard-class.*guardClass/);
+    expect(tool.calls).toBe(0);
+  });
+
+  test("missing guardClass from execution validator fails closed without policy_gate_denied payload", async () => {
+    const tool = new RecordingTool("validator.missing.guard");
+    const wrapped = wrapToolWithPolicyGate(tool, {
+      evaluate: async () => ({ decision: "allow" }),
+      validateExecutionInput: () =>
+        ({
+          decision: "deny",
+          ruleId: "validator-missing-guard-class",
+          reason: "validator denied without classification",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Classify the validator denial before retrying.",
+            ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+          }
+        }) as never
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), { blocked: true });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Invalid policy gate decision");
+    expect(result.output).toContain("validator-missing-guard-class");
+    expect(result.output).toContain("guardClass");
+    expect(result.output).not.toContain("policy_gate_denied");
+    expect(result.outputSummary).toContain("Error: Invalid policy gate decision");
+    expect(tool.calls).toBe(0);
+  });
+
+  test("invalid guardClass from execution validator fails closed without policy_gate_denied payload", async () => {
+    const tool = new RecordingTool("validator.invalid.guard");
+    const wrapped = wrapToolWithPolicyGate(tool, {
+      evaluate: async () => ({ decision: "allow" }),
+      validateExecutionInput: () =>
+        ({
+          decision: "deny",
+          ruleId: "validator-invalid-guard-class",
+          reason: "validator denied with an invalid classification",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Classify the validator denial as authority or capability before retrying.",
+            ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+          },
+          guardClass: "temporary"
+        }) as never
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), { blocked: true });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Invalid policy gate decision");
+    expect(result.output).toContain("validator-invalid-guard-class");
+    expect(result.output).toContain("guardClass");
+    expect(result.output).not.toContain("policy_gate_denied");
+    expect(result.outputSummary).toContain("Error: Invalid policy gate decision");
+    expect(tool.calls).toBe(0);
+  });
+
+  test("conflicting guard aliases from execution validator fail closed without policy_gate_denied payload", async () => {
+    const tool = new RecordingTool("validator.conflicting.guard");
+    const wrapped = wrapToolWithPolicyGate(tool, {
+      evaluate: async () => ({ decision: "allow" }),
+      validateExecutionInput: () =>
+        ({
+          decision: "deny",
+          ruleId: "validator-conflicting-guard-class",
+          reason: "validator denied with conflicting classifications",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Return matching guardClass and guard_class values before retrying.",
+            ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+          },
+          guardClass: "authority",
+          guard_class: "capability"
+        }) as never
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), { blocked: true });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Invalid policy gate decision");
+    expect(result.output).toContain("validator-conflicting-guard-class");
+    expect(result.output).toContain("guardClass");
+    expect(result.output).not.toContain("policy_gate_denied");
+    expect(result.outputSummary).toContain("Error: Invalid policy gate decision");
+    expect(tool.calls).toBe(0);
+  });
+
+  test("matching guard aliases from execution validator emit classified policy_gate_denied", async () => {
+    const tool = new RecordingTool("validator.matching.guard");
+    const wrapped = wrapToolWithPolicyGate(tool, {
+      evaluate: async () => ({ decision: "allow" }),
+      validateExecutionInput: () =>
+        ({
+          decision: "deny",
+          ruleId: "validator-matching-guard-class",
+          reason: "validator denied with matching classifications",
+          remediation: {
+            next_action: "fix_and_retry",
+            hint: "Fix the validator-owned input contract before retrying.",
+            ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+          },
+          guardClass: "capability",
+          guard_class: "capability"
+        }) as never
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), { blocked: true });
+
+    expect(result.success).toBe(false);
+    expect(tool.calls).toBe(0);
+    expect(result.output).toContain("policy_gate_denied");
+    const payload = JSON.parse(result.output) as {
+      error?: string;
+      ruleId?: string;
+      guard_class?: string;
+    };
+    expect(payload.error).toBe("policy_gate_denied");
+    expect(payload.ruleId).toBe("validator-matching-guard-class");
+    expect(payload.guard_class).toBe("capability");
+  });
+
+  test("classified execution validator denial emits policy_gate_denied with guard_class", async () => {
+    const tool = new RecordingTool("validator.classified.guard");
+    const wrapped = wrapToolWithPolicyGate(tool, {
+      evaluate: async () => ({ decision: "allow" }),
+      validateExecutionInput: () => ({
+        decision: "deny",
+        ruleId: "validator-classified-guard-class",
+        reason: "validator denied with a valid classification",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Fix the validator-owned input contract before retrying.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        },
+        guardClass: "capability"
+      })
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), { blocked: true });
+
+    expect(result.success).toBe(false);
+    expect(tool.calls).toBe(0);
+    expect(result.output).toContain("policy_gate_denied");
+    const payload = JSON.parse(result.output) as {
+      error?: string;
+      ruleId?: string;
+      guard_class?: string;
+      reason?: string;
+      remediation?: {
+        next_action?: string;
+        hint?: string;
+        ref?: string;
+      };
+    };
+    expect(payload.error).toBe("policy_gate_denied");
+    expect(payload.ruleId).toBe("validator-classified-guard-class");
+    expect(payload.guard_class).toBe("capability");
+    expect(payload.reason).toBe("validator denied with a valid classification");
+    expect(payload.remediation?.next_action).toBe("fix_and_retry");
   });
 
   test("invalid remediation from policy evaluator returns failed ToolResult", async () => {

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -1476,7 +1476,8 @@ function buildToolParameterSchemaValidationDeny(
       next_action: "fix_and_retry",
       hint: `Adjust the tool input to match its Zod parameter schema before retrying; ${issueSummary}.`,
       ref: CONTROL_KERNEL_TOOL_GOVERNANCE_REF
-    }
+    },
+    guardClass: "authority"
   };
 }
 
@@ -1525,7 +1526,8 @@ function validatePolicyGateDecision(toolId: string, candidate: unknown): PolicyG
 
   const parsedGuardClass =
     rawGuardClass === undefined ? undefined : PolicyGuardClassSchema.safeParse(rawGuardClass);
-  if (parsedGuardClass && !parsedGuardClass.success) {
+  const guardClass = parsedGuardClass?.success ? parsedGuardClass.data : undefined;
+  if (!guardClass) {
     issuePaths.push("guardClass");
   }
 
@@ -1533,7 +1535,8 @@ function validatePolicyGateDecision(toolId: string, candidate: unknown): PolicyG
     issuePaths.length > 0 ||
     validRuleId === undefined ||
     validReason === undefined ||
-    !remediation
+    !remediation ||
+    !guardClass
   ) {
     const ruleLabel = validRuleId && validRuleId.trim() !== "" ? validRuleId : "<missing>";
     const invalidFields = issuePaths.length > 0 ? issuePaths : ["decision"];
@@ -1547,7 +1550,7 @@ function validatePolicyGateDecision(toolId: string, candidate: unknown): PolicyG
     ruleId: validRuleId,
     reason: validReason,
     remediation,
-    ...(parsedGuardClass?.success ? { guardClass: parsedGuardClass.data } : {})
+    guardClass
   };
 }
 

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -24,6 +24,7 @@ import {
   SPAWN_PROFILE_SUBSET_RULE_ID,
   SPAWN_PROFILE_TOOL_ID_SAMPLE_MAX_CHARS,
   type HarnessRole,
+  type PolicyGuardClass,
   type PolicyGateContext,
   type PolicyGateDecision,
   type PolicyGateRemediation,
@@ -196,7 +197,7 @@ export function createShudPolicyGateEvaluator(
       return authorityDecision;
     }
 
-    return customEvaluate(call, context);
+    return validatePolicyGateDecision(call.toolId, await customEvaluate(call, context));
   };
 }
 
@@ -818,14 +819,18 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
         );
       }
 
-      const executionValidationDecision = this.#validateExecutionInput?.(
+      const executionValidation = this.validatePolicyGateExecutionInput(
         parsedPreparedInput.executionInput
       );
-      if (executionValidationDecision) {
+      if (executionValidation.status === "error") {
+        const durationMs = Date.now() - startTime;
+        return this.finalizePolicyGateResult(toolContext, executionValidation.result, durationMs);
+      }
+      if (executionValidation.status === "decision") {
         const durationMs = Date.now() - startTime;
         return this.finalizePolicyGateResult(
           toolContext,
-          buildPolicyGateDeniedResult(this.#policyGateToolId, executionValidationDecision),
+          buildPolicyGateDeniedResult(this.#policyGateToolId, executionValidation.decision),
           durationMs
         );
       }
@@ -833,14 +838,16 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       return this.#innerTool.run(toolContext, parsedPreparedInput.executionInput);
     }
 
-    const executionValidationDecision = this.#validateExecutionInput?.(
-      preparedInput.executionInput
-    );
-    if (executionValidationDecision) {
+    const executionValidation = this.validatePolicyGateExecutionInput(preparedInput.executionInput);
+    if (executionValidation.status === "error") {
+      const durationMs = Date.now() - startTime;
+      return this.finalizePolicyGateResult(toolContext, executionValidation.result, durationMs);
+    }
+    if (executionValidation.status === "decision") {
       const durationMs = Date.now() - startTime;
       return this.finalizePolicyGateResult(
         toolContext,
-        buildPolicyGateDeniedResult(this.#policyGateToolId, executionValidationDecision),
+        buildPolicyGateDeniedResult(this.#policyGateToolId, executionValidation.decision),
         durationMs
       );
     }
@@ -868,6 +875,35 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
 
   protected async execute(): Promise<ToolResult> {
     throw new Error("PolicyGatedBaseToolAdapter delegates through run().");
+  }
+
+  private validatePolicyGateExecutionInput(
+    executionInput: unknown
+  ):
+    | { status: "allow" }
+    | { status: "decision"; decision: Extract<PolicyGateDecision, { decision: "deny" }> }
+    | { status: "error"; result: ToolResult } {
+    try {
+      const candidate = this.#validateExecutionInput?.(executionInput);
+      if (!candidate) {
+        return { status: "allow" };
+      }
+
+      return {
+        status: "decision",
+        decision: validatePolicyGateDenyDecision(this.#policyGateToolId, candidate)
+      };
+    } catch (error) {
+      const errorMessage = toErrorMessage(error);
+      return {
+        status: "error",
+        result: {
+          success: false,
+          output: errorMessage,
+          outputSummary: `Error: ${errorMessage.slice(0, 100)}`
+        }
+      };
+    }
   }
 
   private async finalizePolicyGateResult(
@@ -1501,7 +1537,6 @@ function validatePolicyGateDecision(toolId: string, candidate: unknown): PolicyG
 
   const ruleId = rawDecision.ruleId;
   const reason = rawDecision.reason;
-  const rawGuardClass = rawDecision.guardClass ?? rawDecision.guard_class;
   const validRuleId = typeof ruleId === "string" ? ruleId : undefined;
   const validReason = typeof reason === "string" ? reason : undefined;
   const issuePaths: string[] = [];
@@ -1524,12 +1559,7 @@ function validatePolicyGateDecision(toolId: string, candidate: unknown): PolicyG
     remediation = parsedRemediation.data;
   }
 
-  const parsedGuardClass =
-    rawGuardClass === undefined ? undefined : PolicyGuardClassSchema.safeParse(rawGuardClass);
-  const guardClass = parsedGuardClass?.success ? parsedGuardClass.data : undefined;
-  if (!guardClass) {
-    issuePaths.push("guardClass");
-  }
+  const guardClass = readPolicyGateDecisionGuardClass(rawDecision, issuePaths);
 
   if (
     issuePaths.length > 0 ||
@@ -1552,6 +1582,71 @@ function validatePolicyGateDecision(toolId: string, candidate: unknown): PolicyG
     remediation,
     guardClass
   };
+}
+
+type PolicyGateDecisionGuardClassAlias =
+  | { state: "missing" }
+  | { state: "invalid" }
+  | { state: "valid"; guardClass: PolicyGuardClass };
+
+function readPolicyGateDecisionGuardClass(
+  rawDecision: Record<string, unknown>,
+  issuePaths: string[]
+): PolicyGuardClass | undefined {
+  const camelGuardClass = parsePolicyGateDecisionGuardClassAlias(rawDecision.guardClass);
+  const snakeGuardClass = parsePolicyGateDecisionGuardClassAlias(rawDecision.guard_class);
+
+  if (camelGuardClass.state === "invalid") {
+    issuePaths.push("guardClass");
+  }
+  if (snakeGuardClass.state === "invalid") {
+    issuePaths.push("guard_class");
+  }
+  if (camelGuardClass.state === "invalid" || snakeGuardClass.state === "invalid") {
+    return undefined;
+  }
+
+  if (camelGuardClass.state === "valid" && snakeGuardClass.state === "valid") {
+    if (camelGuardClass.guardClass !== snakeGuardClass.guardClass) {
+      issuePaths.push("guardClass", "guard_class");
+      return undefined;
+    }
+    return camelGuardClass.guardClass;
+  }
+
+  if (camelGuardClass.state === "valid") {
+    return camelGuardClass.guardClass;
+  }
+  if (snakeGuardClass.state === "valid") {
+    return snakeGuardClass.guardClass;
+  }
+
+  issuePaths.push("guardClass");
+  return undefined;
+}
+
+function parsePolicyGateDecisionGuardClassAlias(
+  value: unknown
+): PolicyGateDecisionGuardClassAlias {
+  if (value === undefined) {
+    return { state: "missing" };
+  }
+  const parsed = PolicyGuardClassSchema.safeParse(value);
+  if (!parsed.success) {
+    return { state: "invalid" };
+  }
+  return { state: "valid", guardClass: parsed.data };
+}
+
+function validatePolicyGateDenyDecision(
+  toolId: string,
+  candidate: unknown
+): Extract<PolicyGateDecision, { decision: "deny" }> {
+  const decision = validatePolicyGateDecision(toolId, candidate);
+  if (decision.decision !== "deny") {
+    throw new Error(`Invalid policy gate decision for ${toolId}: execution validator must deny`);
+  }
+  return decision;
 }
 
 function snapshotRawDataSeatbeltProfileOptions(
@@ -1631,9 +1726,9 @@ function buildPolicyGateDeniedResult(
     error: "policy_gate_denied",
     tool_id: toolId,
     reason: decision.reason,
-    ...(decision.ruleId ? { ruleId: decision.ruleId } : {}),
-    ...(decision.guardClass ? { guard_class: decision.guardClass } : {}),
-    ...(decision.remediation ? { remediation: decision.remediation } : {})
+    ruleId: decision.ruleId,
+    guard_class: decision.guardClass,
+    remediation: decision.remediation
   };
 
   return {

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -13,6 +13,7 @@ import type { FuseRule, ToolContext, ToolDefinition, ToolResult } from "@zero-os
 import { types as nodeUtilTypes } from "node:util";
 import { ZodType } from "zod";
 import {
+  assertPolicyGateContextGuardClasses,
   evaluatePolicyGate,
   normalizeSpawnAgentInput,
   PolicyGuardClassSchema,
@@ -154,6 +155,7 @@ const SHUD_WAIT_AGENT_DESCRIPTION = [
 ].join("\n");
 
 export function createPolicyGateEvaluator(context: PolicyGateContext): PolicyGateEvaluator {
+  assertPolicyGateContextGuardClasses(context);
   return (call) => evaluatePolicyGate(call, context);
 }
 

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -219,6 +219,20 @@ const ZOD_PARAMETER_SCHEMA_MAX_NODES = 20_000;
 const ZOD_PARAMETER_SCHEMA_MAX_OWN_KEYS = 512;
 const ZOD_PARAMETER_SCHEMA_MAX_PROPERTIES = 50_000;
 const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+class PolicyGateDecisionValidationError extends Error {
+  constructor(error: unknown) {
+    super(toErrorMessage(error));
+    this.name = "PolicyGateDecisionValidationError";
+  }
+}
+
+function isPolicyGateDecisionValidationError(
+  error: unknown
+): error is PolicyGateDecisionValidationError {
+  return error instanceof PolicyGateDecisionValidationError;
+}
+
 export function createShudPolicyGateEvaluator(
   customEvaluate?: PolicyGateEvaluator
 ): PolicyGateEvaluator {
@@ -233,7 +247,12 @@ export function createShudPolicyGateEvaluator(
       return authorityDecision;
     }
 
-    return validatePolicyGateDecision(call.toolId, await customEvaluate(call, context));
+    const customDecision = await customEvaluate(call, context);
+    try {
+      return validatePolicyGateDecision(call.toolId, customDecision);
+    } catch (error) {
+      throw new PolicyGateDecisionValidationError(error);
+    }
   });
 }
 
@@ -1055,7 +1074,9 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
     } catch (error) {
       return {
         status: "error",
-        source: "evaluation",
+        source: isPolicyGateDecisionValidationError(error)
+          ? "decision_validation"
+          : "evaluation",
         result: policyGateErrorToolResult(error)
       };
     }

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -24,6 +24,7 @@ import {
   SPAWN_PROFILE_SUBSET_RULE_ID,
   SPAWN_PROFILE_TOOL_ID_SAMPLE_MAX_CHARS,
   snapshotPolicyGateContext,
+  TOOL_PARAMETER_SCHEMA_RULE_ID,
   type HarnessRole,
   type PolicyGuardClass,
   type PolicyGateContext,
@@ -127,7 +128,6 @@ const reservedAuthorityPolicyGateExecutionValidators =
 const ROLE_VISIBLE_TOOL_COUNT_LIMIT = 20;
 const CONTROL_KERNEL_TOOL_GOVERNANCE_REF =
   "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定";
-const TOOL_PARAMETER_SCHEMA_RULE_ID = "tool-parameter-schema-validation";
 const TOOL_PARAMETER_SCHEMA_MAX_ISSUES = 3;
 const TOOL_PARAMETER_SCHEMA_ISSUE_MAX_CHARS = 240;
 const SHUD_TOOL_DESCRIPTION_REQUIRED_SECTIONS = Object.freeze([

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -14,8 +14,11 @@ import { types as nodeUtilTypes } from "node:util";
 import { ZodType } from "zod";
 import {
   evaluatePolicyGate,
+  isPolicyGateDecisionValidationError,
+  isReservedAuthorityPolicyRuleIdPrefixImpersonation,
   isReservedAuthorityPolicyRuleId,
   normalizeSpawnAgentInput,
+  PolicyGateDecisionValidationError,
   PolicyGuardClassSchema,
   PolicyGateRemediationSchema,
   SPAWN_PROFILE_MAX_EXCESS_TOOL_SAMPLES,
@@ -220,19 +223,6 @@ const ZOD_PARAMETER_SCHEMA_MAX_OWN_KEYS = 512;
 const ZOD_PARAMETER_SCHEMA_MAX_PROPERTIES = 50_000;
 const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
-class PolicyGateDecisionValidationError extends Error {
-  constructor(error: unknown) {
-    super(toErrorMessage(error));
-    this.name = "PolicyGateDecisionValidationError";
-  }
-}
-
-function isPolicyGateDecisionValidationError(
-  error: unknown
-): error is PolicyGateDecisionValidationError {
-  return error instanceof PolicyGateDecisionValidationError;
-}
-
 export function createShudPolicyGateEvaluator(
   customEvaluate?: PolicyGateEvaluator
 ): PolicyGateEvaluator {
@@ -251,6 +241,9 @@ export function createShudPolicyGateEvaluator(
     try {
       return validatePolicyGateDecision(call.toolId, customDecision);
     } catch (error) {
+      if (isPolicyGateDecisionValidationError(error)) {
+        throw error;
+      }
       throw new PolicyGateDecisionValidationError(error);
     }
   });
@@ -898,12 +891,29 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
     }
 
     const executionValidation = this.validatePolicyGateExecutionInput(preparedInput.executionInput);
-    if (executionValidation.status === "error") {
+    const evaluation = await this.evaluatePolicyGateInput(
+      toolContext,
+      role,
+      preparedInput.evaluatorInput
+    );
+    if (executionValidation.status !== "allow") {
+      if (evaluation.status === "error" && evaluation.source === "decision_validation") {
+        const durationMs = Date.now() - startTime;
+        return this.finalizePolicyGateResult(toolContext, evaluation.result, durationMs);
+      }
+      if (evaluation.status === "decision" && evaluation.decision.decision === "deny") {
+        const durationMs = Date.now() - startTime;
+        return this.finalizePolicyGateResult(
+          toolContext,
+          buildPolicyGateDeniedToolResult(this.#policyGateToolId, evaluation.decision),
+          durationMs
+        );
+      }
+
       const durationMs = Date.now() - startTime;
-      return this.finalizePolicyGateResult(toolContext, executionValidation.result, durationMs);
-    }
-    if (executionValidation.status === "decision") {
-      const durationMs = Date.now() - startTime;
+      if (executionValidation.status === "error") {
+        return this.finalizePolicyGateResult(toolContext, executionValidation.result, durationMs);
+      }
       return this.finalizePolicyGateResult(
         toolContext,
         buildPolicyGateDeniedToolResult(this.#policyGateToolId, executionValidation.decision),
@@ -911,11 +921,6 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       );
     }
 
-    const evaluation = await this.evaluatePolicyGateInput(
-      toolContext,
-      role,
-      preparedInput.evaluatorInput
-    );
     if (evaluation.status === "error") {
       const durationMs = Date.now() - startTime;
       return this.finalizePolicyGateResult(toolContext, evaluation.result, durationMs);
@@ -1621,7 +1626,9 @@ function validatePolicyGateDecision(
   options: PolicyGateDecisionValidationOptions = {}
 ): PolicyGateDecision {
   if (candidate === null || typeof candidate !== "object") {
-    throw new Error(`Invalid policy gate decision for ${toolId}: decision`);
+    throw new PolicyGateDecisionValidationError(
+      `Invalid policy gate decision for ${toolId}: decision`
+    );
   }
 
   const rawDecision = candidate as Record<string, unknown>;
@@ -1630,7 +1637,9 @@ function validatePolicyGateDecision(
   }
 
   if (rawDecision.decision !== "deny") {
-    throw new Error(`Invalid policy gate decision for ${toolId}: decision`);
+    throw new PolicyGateDecisionValidationError(
+      `Invalid policy gate decision for ${toolId}: decision`
+    );
   }
 
   const ruleId = rawDecision.ruleId;
@@ -1674,7 +1683,7 @@ function validatePolicyGateDecision(
   ) {
     const ruleLabel = validRuleId && validRuleId.trim() !== "" ? validRuleId : "<missing>";
     const invalidFields = issuePaths.length > 0 ? issuePaths : ["decision"];
-    throw new Error(
+    throw new PolicyGateDecisionValidationError(
       `Invalid policy gate decision for ${toolId} (rule ${ruleLabel}): ${invalidFields.join(", ")}`
     );
   }
@@ -1702,13 +1711,25 @@ function validateReservedAuthorityPolicyGateDecisionProducer(
   issuePaths: string[],
   options: PolicyGateDecisionValidationOptions
 ): void {
-  if (!ruleId || !guardClass || !isReservedAuthorityPolicyRuleId(ruleId)) {
+  if (!ruleId) {
+    return;
+  }
+
+  if (isReservedAuthorityPolicyRuleIdPrefixImpersonation(ruleId)) {
+    issuePaths.push("ruleId");
+    if (guardClass !== undefined && guardClass !== "authority") {
+      issuePaths.push("guardClass");
+    }
+    return;
+  }
+
+  if (!isReservedAuthorityPolicyRuleId(ruleId)) {
     return;
   }
 
   if (!options.allowReservedAuthorityRuleIds) {
     issuePaths.push("ruleId");
-    if (guardClass !== "authority") {
+    if (guardClass && guardClass !== "authority") {
       issuePaths.push("guardClass");
     }
     return;
@@ -1780,7 +1801,9 @@ function validatePolicyGateDenyDecision(
 ): Extract<PolicyGateDecision, { decision: "deny" }> {
   const decision = validatePolicyGateDecision(toolId, candidate, options);
   if (decision.decision !== "deny") {
-    throw new Error(`Invalid policy gate decision for ${toolId}: execution validator must deny`);
+    throw new PolicyGateDecisionValidationError(
+      `Invalid policy gate decision for ${toolId}: execution validator must deny`
+    );
   }
   return decision;
 }

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -14,6 +14,7 @@ import { types as nodeUtilTypes } from "node:util";
 import { ZodType } from "zod";
 import {
   evaluatePolicyGate,
+  isReservedAuthorityPolicyRuleId,
   normalizeSpawnAgentInput,
   PolicyGuardClassSchema,
   PolicyGateRemediationSchema,
@@ -27,6 +28,7 @@ import {
   type PolicyGuardClass,
   type PolicyGateContext,
   type PolicyGateDecision,
+  type PolicyGateDecisionInput,
   type PolicyGateRemediation,
   type PolicyGateToolCall
 } from "./policy-gate-core";
@@ -40,6 +42,7 @@ export type {
   HarnessRole,
   PolicyGateContext,
   PolicyGateDecision,
+  PolicyGateDecisionInput,
   PolicyGateRemediation,
   PolicyGateToolCall,
   PolicyRule,
@@ -54,11 +57,11 @@ export interface PolicyGateEvaluationContext {
 export type PolicyGateEvaluator = (
   call: PolicyGateToolCall,
   context: PolicyGateEvaluationContext
-) => PolicyGateDecision | Promise<PolicyGateDecision>;
+) => PolicyGateDecisionInput | Promise<PolicyGateDecisionInput>;
 
 export type PolicyGateExecutionInputValidator = (
   input: unknown
-) => Extract<PolicyGateDecision, { decision: "deny" }> | undefined;
+) => Extract<PolicyGateDecisionInput, { decision: "deny" }> | undefined;
 
 export interface PolicyGateWrapperOptions {
   toolId?: string;
@@ -118,6 +121,9 @@ export type PolicyGatedTool = BaseTool & {
 };
 
 const policyGatedTools = new WeakSet<BaseTool>();
+const reservedAuthorityPolicyGateEvaluators = new WeakSet<PolicyGateEvaluator>();
+const reservedAuthorityPolicyGateExecutionValidators =
+  new WeakSet<PolicyGateExecutionInputValidator>();
 const ROLE_VISIBLE_TOOL_COUNT_LIMIT = 20;
 const CONTROL_KERNEL_TOOL_GOVERNANCE_REF =
   "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定";
@@ -157,7 +163,38 @@ const SHUD_WAIT_AGENT_DESCRIPTION = [
 
 export function createPolicyGateEvaluator(context: PolicyGateContext): PolicyGateEvaluator {
   const contextSnapshot = snapshotPolicyGateContext(context);
-  return (call) => evaluatePolicyGate(call, contextSnapshot);
+  const evaluator: PolicyGateEvaluator = (call) => evaluatePolicyGate(call, contextSnapshot);
+  return context === DEFAULT_SHUD_POLICY_GATE_CONTEXT
+    ? trustReservedAuthorityPolicyGateEvaluator(evaluator)
+    : evaluator;
+}
+
+function trustReservedAuthorityPolicyGateEvaluator(
+  evaluator: PolicyGateEvaluator
+): PolicyGateEvaluator {
+  reservedAuthorityPolicyGateEvaluators.add(evaluator);
+  return evaluator;
+}
+
+function canEvaluatorReturnReservedAuthorityDecision(
+  evaluator: PolicyGateEvaluator
+): boolean {
+  return reservedAuthorityPolicyGateEvaluators.has(evaluator);
+}
+
+function trustReservedAuthorityPolicyGateExecutionValidator(
+  validator: PolicyGateExecutionInputValidator
+): PolicyGateExecutionInputValidator {
+  reservedAuthorityPolicyGateExecutionValidators.add(validator);
+  return validator;
+}
+
+function canExecutionValidatorReturnReservedAuthorityDecision(
+  validator: PolicyGateExecutionInputValidator | undefined
+): boolean {
+  return validator
+    ? reservedAuthorityPolicyGateExecutionValidators.has(validator)
+    : false;
 }
 
 export const DEFAULT_SHUD_POLICY_GATE_CONTEXT: PolicyGateContext = Object.freeze({
@@ -182,24 +219,22 @@ const ZOD_PARAMETER_SCHEMA_MAX_NODES = 20_000;
 const ZOD_PARAMETER_SCHEMA_MAX_OWN_KEYS = 512;
 const ZOD_PARAMETER_SCHEMA_MAX_PROPERTIES = 50_000;
 const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-const KNOWN_AUTHORITY_POLICY_GATE_DECISION_RULE_IDS = new Set([RAW_DATA_WRITE_RULE_ID]);
-
 export function createShudPolicyGateEvaluator(
   customEvaluate?: PolicyGateEvaluator
 ): PolicyGateEvaluator {
   const authorityEvaluate = createPolicyGateEvaluator(DEFAULT_SHUD_POLICY_GATE_CONTEXT);
   if (!customEvaluate) {
-    return authorityEvaluate;
+    return trustReservedAuthorityPolicyGateEvaluator(authorityEvaluate);
   }
 
-  return async (call, context) => {
+  return trustReservedAuthorityPolicyGateEvaluator(async (call, context) => {
     const authorityDecision = await authorityEvaluate(call, context);
     if (authorityDecision.decision === "deny") {
       return authorityDecision;
     }
 
     return validatePolicyGateDecision(call.toolId, await customEvaluate(call, context));
-  };
+  });
 }
 
 export function wrapToolWithPolicyGate(
@@ -770,6 +805,10 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
           role,
           preparedInput.evaluatorInput
         );
+        if (evaluation.status === "error" && evaluation.source === "decision_validation") {
+          const durationMs = Date.now() - startTime;
+          return this.finalizePolicyGateResult(toolContext, evaluation.result, durationMs);
+        }
         if (evaluation.status === "decision" && evaluation.decision.decision === "deny") {
           const durationMs = Date.now() - startTime;
           return this.finalizePolicyGateResult(
@@ -831,7 +870,7 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
         const durationMs = Date.now() - startTime;
         return this.finalizePolicyGateResult(
           toolContext,
-          buildPolicyGateDeniedResult(this.#policyGateToolId, executionValidation.decision),
+          buildPolicyGateDeniedToolResult(this.#policyGateToolId, executionValidation.decision),
           durationMs
         );
       }
@@ -848,7 +887,7 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       const durationMs = Date.now() - startTime;
       return this.finalizePolicyGateResult(
         toolContext,
-        buildPolicyGateDeniedResult(this.#policyGateToolId, executionValidation.decision),
+        buildPolicyGateDeniedToolResult(this.#policyGateToolId, executionValidation.decision),
         durationMs
       );
     }
@@ -892,7 +931,11 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
 
       return {
         status: "decision",
-        decision: validatePolicyGateDenyDecision(this.#policyGateToolId, candidate)
+        decision: validatePolicyGateDenyDecision(this.#policyGateToolId, candidate, {
+          allowReservedAuthorityRuleIds: canExecutionValidatorReturnReservedAuthorityDecision(
+            this.#validateExecutionInput
+          )
+        })
       };
     } catch (error) {
       const errorMessage = toErrorMessage(error);
@@ -989,10 +1032,15 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
     evaluatorInput: unknown
   ): Promise<
     | { status: "decision"; decision: PolicyGateDecision }
-    | { status: "error"; result: ToolResult }
+    | {
+        status: "error";
+        source: "evaluation" | "decision_validation";
+        result: ToolResult;
+      }
   > {
+    let candidate: PolicyGateDecisionInput;
     try {
-      const candidate = await this.#evaluate(
+      candidate = await this.#evaluate(
         {
           toolId: this.#policyGateToolId,
           role,
@@ -1004,22 +1052,40 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
           toolContext
         }
       );
-      return {
-        status: "decision",
-        decision: validatePolicyGateDecision(this.#policyGateToolId, candidate)
-      };
     } catch (error) {
-      const errorMessage = toErrorMessage(error);
       return {
         status: "error",
-        result: {
-          success: false,
-          output: errorMessage,
-          outputSummary: `Error: ${errorMessage.slice(0, 100)}`
-        }
+        source: "evaluation",
+        result: policyGateErrorToolResult(error)
+      };
+    }
+
+    try {
+      return {
+        status: "decision",
+        decision: validatePolicyGateDecision(this.#policyGateToolId, candidate, {
+          allowReservedAuthorityRuleIds: canEvaluatorReturnReservedAuthorityDecision(
+            this.#evaluate
+          )
+        })
+      };
+    } catch (error) {
+      return {
+        status: "error",
+        source: "decision_validation",
+        result: policyGateErrorToolResult(error)
       };
     }
   }
+}
+
+function policyGateErrorToolResult(error: unknown): ToolResult {
+  const errorMessage = toErrorMessage(error);
+  return {
+    success: false,
+    output: errorMessage,
+    outputSummary: `Error: ${errorMessage.slice(0, 100)}`
+  };
 }
 
 function buildPolicyGateDeniedToolResult(
@@ -1035,7 +1101,9 @@ function buildPolicyGateDeniedToolResult(
 function createSpawnAgentToolAvailabilityValidator(
   registry: ToolRegistry
 ): PolicyGateExecutionInputValidator {
-  return (input) => validateSpawnAgentToolAvailability(input, registry);
+  return trustReservedAuthorityPolicyGateExecutionValidator((input) =>
+    validateSpawnAgentToolAvailability(input, registry)
+  );
 }
 
 function validateSpawnAgentToolAvailability(
@@ -1522,7 +1590,15 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function validatePolicyGateDecision(toolId: string, candidate: unknown): PolicyGateDecision {
+interface PolicyGateDecisionValidationOptions {
+  allowReservedAuthorityRuleIds?: boolean;
+}
+
+function validatePolicyGateDecision(
+  toolId: string,
+  candidate: unknown,
+  options: PolicyGateDecisionValidationOptions = {}
+): PolicyGateDecision {
   if (candidate === null || typeof candidate !== "object") {
     throw new Error(`Invalid policy gate decision for ${toolId}: decision`);
   }
@@ -1561,7 +1637,12 @@ function validatePolicyGateDecision(toolId: string, candidate: unknown): PolicyG
   }
 
   const guardClass = readPolicyGateDecisionGuardClass(rawDecision, issuePaths);
-  validateKnownAuthorityPolicyGateDecisionGuardClass(validRuleId, guardClass, issuePaths);
+  validateReservedAuthorityPolicyGateDecisionProducer(
+    validRuleId,
+    guardClass,
+    issuePaths,
+    options
+  );
 
   if (
     issuePaths.length > 0 ||
@@ -1594,17 +1675,25 @@ function normalizePolicyGateDecisionRuleId(ruleId: unknown): string | undefined 
   return trimmedRuleId === "" ? undefined : trimmedRuleId;
 }
 
-function validateKnownAuthorityPolicyGateDecisionGuardClass(
+function validateReservedAuthorityPolicyGateDecisionProducer(
   ruleId: string | undefined,
   guardClass: PolicyGuardClass | undefined,
-  issuePaths: string[]
+  issuePaths: string[],
+  options: PolicyGateDecisionValidationOptions
 ): void {
-  if (
-    ruleId &&
-    guardClass &&
-    KNOWN_AUTHORITY_POLICY_GATE_DECISION_RULE_IDS.has(ruleId) &&
-    guardClass !== "authority"
-  ) {
+  if (!ruleId || !guardClass || !isReservedAuthorityPolicyRuleId(ruleId)) {
+    return;
+  }
+
+  if (!options.allowReservedAuthorityRuleIds) {
+    issuePaths.push("ruleId");
+    if (guardClass !== "authority") {
+      issuePaths.push("guardClass");
+    }
+    return;
+  }
+
+  if (guardClass !== "authority") {
     issuePaths.push("guardClass");
   }
 }
@@ -1665,9 +1754,10 @@ function parsePolicyGateDecisionGuardClassAlias(
 
 function validatePolicyGateDenyDecision(
   toolId: string,
-  candidate: unknown
+  candidate: unknown,
+  options?: PolicyGateDecisionValidationOptions
 ): Extract<PolicyGateDecision, { decision: "deny" }> {
-  const decision = validatePolicyGateDecision(toolId, candidate);
+  const decision = validatePolicyGateDecision(toolId, candidate, options);
   if (decision.decision !== "deny") {
     throw new Error(`Invalid policy gate decision for ${toolId}: execution validator must deny`);
   }

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -13,7 +13,6 @@ import type { FuseRule, ToolContext, ToolDefinition, ToolResult } from "@zero-os
 import { types as nodeUtilTypes } from "node:util";
 import { ZodType } from "zod";
 import {
-  assertPolicyGateContextGuardClasses,
   evaluatePolicyGate,
   normalizeSpawnAgentInput,
   PolicyGuardClassSchema,
@@ -23,6 +22,7 @@ import {
   SPAWN_PROFILE_SUBSET_RULE,
   SPAWN_PROFILE_SUBSET_RULE_ID,
   SPAWN_PROFILE_TOOL_ID_SAMPLE_MAX_CHARS,
+  snapshotPolicyGateContext,
   type HarnessRole,
   type PolicyGuardClass,
   type PolicyGateContext,
@@ -156,8 +156,8 @@ const SHUD_WAIT_AGENT_DESCRIPTION = [
 ].join("\n");
 
 export function createPolicyGateEvaluator(context: PolicyGateContext): PolicyGateEvaluator {
-  assertPolicyGateContextGuardClasses(context);
-  return (call) => evaluatePolicyGate(call, context);
+  const contextSnapshot = snapshotPolicyGateContext(context);
+  return (call) => evaluatePolicyGate(call, contextSnapshot);
 }
 
 export const DEFAULT_SHUD_POLICY_GATE_CONTEXT: PolicyGateContext = Object.freeze({
@@ -182,6 +182,7 @@ const ZOD_PARAMETER_SCHEMA_MAX_NODES = 20_000;
 const ZOD_PARAMETER_SCHEMA_MAX_OWN_KEYS = 512;
 const ZOD_PARAMETER_SCHEMA_MAX_PROPERTIES = 50_000;
 const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+const KNOWN_AUTHORITY_POLICY_GATE_DECISION_RULE_IDS = new Set([RAW_DATA_WRITE_RULE_ID]);
 
 export function createShudPolicyGateEvaluator(
   customEvaluate?: PolicyGateEvaluator
@@ -1537,7 +1538,7 @@ function validatePolicyGateDecision(toolId: string, candidate: unknown): PolicyG
 
   const ruleId = rawDecision.ruleId;
   const reason = rawDecision.reason;
-  const validRuleId = typeof ruleId === "string" ? ruleId : undefined;
+  const validRuleId = normalizePolicyGateDecisionRuleId(ruleId);
   const validReason = typeof reason === "string" ? reason : undefined;
   const issuePaths: string[] = [];
   if (validRuleId === undefined) {
@@ -1560,6 +1561,7 @@ function validatePolicyGateDecision(toolId: string, candidate: unknown): PolicyG
   }
 
   const guardClass = readPolicyGateDecisionGuardClass(rawDecision, issuePaths);
+  validateKnownAuthorityPolicyGateDecisionGuardClass(validRuleId, guardClass, issuePaths);
 
   if (
     issuePaths.length > 0 ||
@@ -1582,6 +1584,29 @@ function validatePolicyGateDecision(toolId: string, candidate: unknown): PolicyG
     remediation,
     guardClass
   };
+}
+
+function normalizePolicyGateDecisionRuleId(ruleId: unknown): string | undefined {
+  if (typeof ruleId !== "string") {
+    return undefined;
+  }
+  const trimmedRuleId = ruleId.trim();
+  return trimmedRuleId === "" ? undefined : trimmedRuleId;
+}
+
+function validateKnownAuthorityPolicyGateDecisionGuardClass(
+  ruleId: string | undefined,
+  guardClass: PolicyGuardClass | undefined,
+  issuePaths: string[]
+): void {
+  if (
+    ruleId &&
+    guardClass &&
+    KNOWN_AUTHORITY_POLICY_GATE_DECISION_RULE_IDS.has(ruleId) &&
+    guardClass !== "authority"
+  ) {
+    issuePaths.push("guardClass");
+  }
 }
 
 type PolicyGateDecisionGuardClassAlias =
@@ -1685,6 +1710,7 @@ function buildRawDataRuleMisconfiguredResult(
     error: "policy_gate_raw_data_rule_misconfigured",
     tool_id: toolId,
     rule: RAW_DATA_WRITE_RULE_ID,
+    guard_class: decision.guardClass,
     reason:
       "Outer policy gate attempted to deny raw-data writes. Raw advisory and raw-denial evidence ownership belongs inside RawDataSandboxedBashTool.",
     outer_reason: decision.reason,

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -896,13 +896,16 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       role,
       preparedInput.evaluatorInput
     );
+    if (evaluation.status === "error" && evaluation.source === "decision_validation") {
+      const durationMs = Date.now() - startTime;
+      return this.finalizePolicyGateResult(toolContext, evaluation.result, durationMs);
+    }
     if (executionValidation.status !== "allow") {
-      if (evaluation.status === "error" && evaluation.source === "decision_validation") {
-        const durationMs = Date.now() - startTime;
-        return this.finalizePolicyGateResult(toolContext, evaluation.result, durationMs);
+      const durationMs = Date.now() - startTime;
+      if (executionValidation.status === "error") {
+        return this.finalizePolicyGateResult(toolContext, executionValidation.result, durationMs);
       }
       if (evaluation.status === "decision" && evaluation.decision.decision === "deny") {
-        const durationMs = Date.now() - startTime;
         return this.finalizePolicyGateResult(
           toolContext,
           buildPolicyGateDeniedToolResult(this.#policyGateToolId, evaluation.decision),
@@ -910,10 +913,6 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
         );
       }
 
-      const durationMs = Date.now() - startTime;
-      if (executionValidation.status === "error") {
-        return this.finalizePolicyGateResult(toolContext, executionValidation.result, durationMs);
-      }
       return this.finalizePolicyGateResult(
         toolContext,
         buildPolicyGateDeniedToolResult(this.#policyGateToolId, executionValidation.decision),

--- a/packages/core/src/tools/raw-data-sandbox.test.ts
+++ b/packages/core/src/tools/raw-data-sandbox.test.ts
@@ -29,6 +29,7 @@ import {
   RAW_DATA_WRITE_RULE_ID,
   RawDataSandboxedBashTool,
   buildRawDataSeatbeltProfile,
+  createRawDataWriteAdvisoryRule,
   evaluateRawDataWriteAdvisory,
   rawDataSandboxProfileFileName,
   rawDataWriteRemediation,
@@ -142,6 +143,10 @@ describe("raw data seatbelt sandbox", () => {
         import.meta.dir
       )
     ).toThrow();
+  });
+
+  test("raw data advisory rule carries authority guard classification", () => {
+    expect(createRawDataWriteAdvisoryRule(["/tmp/raw"]).guardClass).toBe("authority");
   });
 
   test("normal completion cleanup does not sample or signal a reused root PID", async () => {

--- a/packages/core/src/tools/raw-data-sandbox.test.ts
+++ b/packages/core/src/tools/raw-data-sandbox.test.ts
@@ -500,6 +500,65 @@ describe("raw data seatbelt sandbox", () => {
     }
   });
 
+  test("public audit append rejects missing or downgraded raw-data authority guard_class", async () => {
+    const fixture = await createFixture();
+    try {
+      await expect(
+        appendPolicyGateAuditRow({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          row: rawDataAuditRowWithoutGuard()
+        })
+      ).rejects.toThrow("Raw-data authority audit rows require guard_class authority");
+
+      await expect(
+        appendPolicyGateAuditRow({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          row: {
+            ...minimalAuditRow(),
+            guard_class: "capability"
+          }
+        })
+      ).rejects.toThrow("Raw-data authority audit rows require guard_class authority");
+
+      const missingGuardByErrorId = auditRowWithoutRule(rawDataAuditRowWithoutGuard());
+      missingGuardByErrorId.error_id = `${RAW_DATA_WRITE_RULE_ID}:failed:public-lifecycle`;
+      await expect(
+        appendPolicyGateAuditRow({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          row: missingGuardByErrorId
+        })
+      ).rejects.toThrow("Raw-data authority audit rows require guard_class authority");
+
+      await expect(
+        appendPolicyGateAuditRow({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          row: {
+            ...minimalAuditRow(),
+            rule: "workspace-quota",
+            guard_class: "capability",
+            error_id: `${RAW_DATA_WRITE_RULE_ID}:failed:other-rule`
+          }
+        })
+      ).rejects.toThrow("Raw-data authority audit rows require guard_class authority");
+
+      await expectMissing(
+        join(
+          fixture.workspaceRoot,
+          "tasks",
+          "TASK-M1-SPIKE",
+          "audit",
+          "policy-gate.ndjson"
+        )
+      );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   test("public audit append keeps lifecycle and non-raw denial rows available", async () => {
     const fixture = await createFixture();
     try {
@@ -511,6 +570,15 @@ describe("raw data seatbelt sandbox", () => {
           ...minimalAuditRow(),
           error_id: `${RAW_DATA_WRITE_RULE_ID}:failed:lifecycle`
         }
+      });
+      const lifecycleWithoutRulePath = await appendPolicyGateAuditRow({
+        workspaceRoot: fixture.root,
+        protectedRawPaths: [fixture.rawRoot],
+        fileName: "lifecycle-without-rule.ndjson",
+        row: auditRowWithoutRule({
+          ...minimalAuditRow(),
+          error_id: `${RAW_DATA_WRITE_RULE_ID}:failed:lifecycle-without-rule`
+        })
       });
       const nonRawPath = await appendPolicyGateAuditRow({
         workspaceRoot: fixture.root,
@@ -526,6 +594,12 @@ describe("raw data seatbelt sandbox", () => {
       expect(await readFile(lifecyclePath, "utf8")).toContain('"decision":"failed"');
       expect(await readFile(lifecyclePath, "utf8")).toContain(
         `"error_id":"${RAW_DATA_WRITE_RULE_ID}:failed:lifecycle"`
+      );
+      expect(await readFile(lifecycleWithoutRulePath, "utf8")).toContain(
+        `"error_id":"${RAW_DATA_WRITE_RULE_ID}:failed:lifecycle-without-rule"`
+      );
+      expect(await readFile(lifecycleWithoutRulePath, "utf8")).toContain(
+        '"guard_class":"authority"'
       );
       expect(await readFile(nonRawPath, "utf8")).toContain('"rule":"workspace-quota"');
       expect(await readFile(nonRawPath, "utf8")).toContain('"decision":"quota_rejected"');
@@ -835,6 +909,14 @@ describe("raw data seatbelt sandbox", () => {
         expect(result.success).toBe(false);
         expect(result.output).toContain("pathResolutionRoot");
         expect(result.outputSummary).toBe("Raw data sandbox path resolution failed");
+        const payload = JSON.parse(result.output) as {
+          error?: string;
+          rule?: string;
+          guard_class?: string;
+        };
+        expect(payload.error).toBe("raw_data_sandbox_path_resolution_failed");
+        expect(payload.rule).toBe(RAW_DATA_WRITE_RULE_ID);
+        expect(payload.guard_class).toBe("authority");
         await expectMissing(join(fixture.workspaceRoot, `${testCase.name}-side-effect.txt`));
         await expectMissing(
           join(
@@ -2097,6 +2179,7 @@ describe("raw data seatbelt sandbox", () => {
       expect(rows.at(-1)).toMatchObject({
         event: "tool.completed",
         decision: "allowed",
+        guard_class: "authority",
         profile_id: expect.stringMatching(/^shud-raw-seatbelt-/),
         profile_path: expect.stringContaining(".sb")
       });
@@ -5117,6 +5200,7 @@ function expectAuditReservationFailure(result: ToolResult): void {
   const payload = JSON.parse(result.output) as {
     error?: string;
     rule?: string;
+    guard_class?: string;
     remediation?: {
       next_action?: string;
       hint?: string;
@@ -5125,6 +5209,7 @@ function expectAuditReservationFailure(result: ToolResult): void {
   };
   expect(payload.error).toBe("policy_gate_audit_unavailable");
   expect(payload.rule).toBe(RAW_DATA_WRITE_RULE_ID);
+  expect(payload.guard_class).toBe("authority");
   expect(payload.remediation?.next_action).toBe("fix_and_retry");
   expect(payload.remediation?.hint).toContain("audit path");
   expect(payload.remediation?.ref).toContain("policy-gate-spike");
@@ -5135,6 +5220,7 @@ function expectInvalidTimeoutFailure(result: ToolResult): void {
   const payload = JSON.parse(result.output) as {
     error?: string;
     rule?: string;
+    guard_class?: string;
     remediation?: {
       next_action?: string;
       hint?: string;
@@ -5143,6 +5229,7 @@ function expectInvalidTimeoutFailure(result: ToolResult): void {
   };
   expect(payload.error).toBe("raw_data_sandbox_invalid_timeout");
   expect(payload.rule).toBe(RAW_DATA_WRITE_RULE_ID);
+  expect(payload.guard_class).toBe("authority");
   expect(payload.remediation?.next_action).toBe("fix_and_retry");
   expect(payload.remediation?.hint).toContain("timeout");
   expect(payload.remediation?.ref).toContain("policy-gate-spike");
@@ -5153,6 +5240,7 @@ function expectProfileSetupFailure(result: ToolResult): void {
   const payload = JSON.parse(result.output) as {
     error?: string;
     rule?: string;
+    guard_class?: string;
     reason?: string;
     remediation?: {
       next_action?: string;
@@ -5162,6 +5250,7 @@ function expectProfileSetupFailure(result: ToolResult): void {
   };
   expect(payload.error).toBe("raw_data_sandbox_profile_unavailable");
   expect(payload.rule).toBe(RAW_DATA_WRITE_RULE_ID);
+  expect(payload.guard_class).toBe("authority");
   expect(payload.reason).toMatch(/protected raw data path|Protected raw path unavailable/);
   expect(payload.remediation?.next_action).toBe("fix_and_retry");
   expect(payload.remediation?.hint).toContain("temp/profile roots");
@@ -5173,6 +5262,7 @@ function expectProcessContainmentFailure(result: ToolResult): void {
   const payload = JSON.parse(result.output) as {
     error?: string;
     rule?: string;
+    guard_class?: string;
     remediation?: {
       next_action?: string;
       hint?: string;
@@ -5181,6 +5271,7 @@ function expectProcessContainmentFailure(result: ToolResult): void {
   };
   expect(payload.error).toBe("policy_gate_process_containment_unavailable");
   expect(payload.rule).toBe(RAW_DATA_WRITE_RULE_ID);
+  expect(payload.guard_class).toBe("authority");
   expect(payload.remediation?.next_action).toBe("fix_and_retry");
   expect(payload.remediation?.hint).toContain("foreground");
   expect(payload.remediation?.ref).toContain("policy-gate-spike");
@@ -5209,6 +5300,7 @@ async function expectGenericSandboxLifecycle(
     event: result.success ? "tool.completed" : "tool.failed",
     decision: result.success ? "allowed" : "failed"
   });
+  expect(rows.at(-1)?.guard_class).toBe("authority");
   expectNoSandboxDenialAudit(rows.at(-1));
 }
 
@@ -5247,8 +5339,15 @@ function minimalAuditRow(): PolicyGateAuditRow {
     tool_id: "bash",
     rule: RAW_DATA_WRITE_RULE_ID,
     decision: "failed",
+    guard_class: "authority",
     ts: "2026-07-04T00:00:00.000Z"
   };
+}
+
+function rawDataAuditRowWithoutGuard(): PolicyGateAuditRow {
+  const copy = { ...minimalAuditRow() } as Partial<PolicyGateAuditRow>;
+  delete copy.guard_class;
+  return copy as PolicyGateAuditRow;
 }
 
 function auditRowWithoutRule(row: PolicyGateAuditRow): PolicyGateAuditRow {

--- a/packages/core/src/tools/raw-data-sandbox.test.ts
+++ b/packages/core/src/tools/raw-data-sandbox.test.ts
@@ -38,7 +38,11 @@ import {
   type PolicyGateAuditRow,
   type RawDataDenialPayload
 } from "./raw-data-sandbox";
-import { evaluatePolicyGate } from "./policy-gate-core";
+import {
+  evaluatePolicyGate,
+  SPAWN_PROFILE_SUBSET_RULE_ID,
+  TOOL_PARAMETER_SCHEMA_RULE_ID
+} from "./policy-gate-core";
 import {
   completeRawDataSandboxInvocationProcessesForTest,
   createRawDataSandboxInvocationDescendantTrackerForTest,
@@ -554,6 +558,215 @@ describe("raw data seatbelt sandbox", () => {
           "policy-gate.ndjson"
         )
       );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("public audit append rejects reserved non-raw rules without authority guard_class", async () => {
+    const fixture = await createFixture();
+    try {
+      const cases = [
+        {
+          name: "spawn-missing",
+          rule: SPAWN_PROFILE_SUBSET_RULE_ID,
+          row: auditRowWithGuardClass(
+            reservedNonRawAuditRow(SPAWN_PROFILE_SUBSET_RULE_ID),
+            undefined
+          ),
+          expected: "Reserved authority policy audit rows require guard_class authority"
+        },
+        {
+          name: "spawn-capability",
+          rule: SPAWN_PROFILE_SUBSET_RULE_ID,
+          row: auditRowWithGuardClass(
+            reservedNonRawAuditRow(SPAWN_PROFILE_SUBSET_RULE_ID),
+            "capability"
+          ),
+          expected: "Reserved authority policy audit rows require guard_class authority"
+        },
+        {
+          name: "spawn-invalid",
+          rule: SPAWN_PROFILE_SUBSET_RULE_ID,
+          row: auditRowWithGuardClass(
+            reservedNonRawAuditRow(SPAWN_PROFILE_SUBSET_RULE_ID),
+            "temporary" as never
+          ),
+          expected: "Policy gate audit rows guard_class must be authority or capability"
+        },
+        {
+          name: "schema-missing",
+          rule: TOOL_PARAMETER_SCHEMA_RULE_ID,
+          row: auditRowWithGuardClass(
+            reservedNonRawAuditRow(TOOL_PARAMETER_SCHEMA_RULE_ID),
+            undefined
+          ),
+          expected: "Reserved authority policy audit rows require guard_class authority"
+        },
+        {
+          name: "schema-capability",
+          rule: TOOL_PARAMETER_SCHEMA_RULE_ID,
+          row: auditRowWithGuardClass(
+            reservedNonRawAuditRow(TOOL_PARAMETER_SCHEMA_RULE_ID),
+            "capability"
+          ),
+          expected: "Reserved authority policy audit rows require guard_class authority"
+        },
+        {
+          name: "schema-invalid",
+          rule: TOOL_PARAMETER_SCHEMA_RULE_ID,
+          row: auditRowWithGuardClass(
+            reservedNonRawAuditRow(TOOL_PARAMETER_SCHEMA_RULE_ID),
+            "temporary" as never
+          ),
+          expected: "Policy gate audit rows guard_class must be authority or capability"
+        }
+      ] as const;
+
+      for (const testCase of cases) {
+        await expect(
+          appendPolicyGateAuditRow({
+            workspaceRoot: fixture.root,
+            protectedRawPaths: [fixture.rawRoot],
+            fileName: `reserved-rule-${testCase.name}.ndjson`,
+            row: testCase.row
+          })
+        ).rejects.toThrow(testCase.expected);
+      }
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("public audit append rejects reserved non-raw error_id prefixes without authority guard_class", async () => {
+    const fixture = await createFixture();
+    try {
+      const cases = [
+        {
+          name: "spawn-missing",
+          row: auditRowWithGuardClass(
+            reservedNonRawErrorIdAuditRow(SPAWN_PROFILE_SUBSET_RULE_ID),
+            undefined
+          ),
+          expected: "Reserved authority policy audit rows require guard_class authority"
+        },
+        {
+          name: "spawn-capability",
+          row: auditRowWithGuardClass(
+            reservedNonRawErrorIdAuditRow(SPAWN_PROFILE_SUBSET_RULE_ID),
+            "capability"
+          ),
+          expected: "Reserved authority policy audit rows require guard_class authority"
+        },
+        {
+          name: "spawn-invalid",
+          row: auditRowWithGuardClass(
+            reservedNonRawErrorIdAuditRow(SPAWN_PROFILE_SUBSET_RULE_ID),
+            "temporary" as never
+          ),
+          expected: "Policy gate audit rows guard_class must be authority or capability"
+        },
+        {
+          name: "schema-missing",
+          row: auditRowWithGuardClass(
+            reservedNonRawErrorIdAuditRow(TOOL_PARAMETER_SCHEMA_RULE_ID),
+            undefined
+          ),
+          expected: "Reserved authority policy audit rows require guard_class authority"
+        },
+        {
+          name: "schema-capability",
+          row: auditRowWithGuardClass(
+            reservedNonRawErrorIdAuditRow(TOOL_PARAMETER_SCHEMA_RULE_ID),
+            "capability"
+          ),
+          expected: "Reserved authority policy audit rows require guard_class authority"
+        },
+        {
+          name: "schema-invalid",
+          row: auditRowWithGuardClass(
+            reservedNonRawErrorIdAuditRow(TOOL_PARAMETER_SCHEMA_RULE_ID),
+            "temporary" as never
+          ),
+          expected: "Policy gate audit rows guard_class must be authority or capability"
+        }
+      ] as const;
+
+      for (const testCase of cases) {
+        await expect(
+          appendPolicyGateAuditRow({
+            workspaceRoot: fixture.root,
+            protectedRawPaths: [fixture.rawRoot],
+            fileName: `reserved-error-${testCase.name}.ndjson`,
+            row: testCase.row
+          })
+        ).rejects.toThrow(testCase.expected);
+      }
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("public audit append accepts reserved non-raw authority guard_class", async () => {
+    const fixture = await createFixture();
+    try {
+      for (const rule of [SPAWN_PROFILE_SUBSET_RULE_ID, TOOL_PARAMETER_SCHEMA_RULE_ID]) {
+        const ruleAuditPath = await appendPolicyGateAuditRow({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          fileName: `reserved-authority-${rule}.ndjson`,
+          row: reservedNonRawAuditRow(rule)
+        });
+        const ruleContent = await readFile(ruleAuditPath, "utf8");
+        expect(ruleContent).toContain(`"rule":"${rule}"`);
+        expect(ruleContent).toContain('"guard_class":"authority"');
+
+        const errorIdAuditPath = await appendPolicyGateAuditRow({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          fileName: `reserved-error-authority-${rule}.ndjson`,
+          row: reservedNonRawErrorIdAuditRow(rule)
+        });
+        const errorIdContent = await readFile(errorIdAuditPath, "utf8");
+        expect(errorIdContent).toContain('"rule":"workspace-quota"');
+        expect(errorIdContent).toContain(`"error_id":"${rule}:failed:test"`);
+        expect(errorIdContent).toContain('"guard_class":"authority"');
+      }
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("public audit append preserves non-reserved guard_class compatibility", async () => {
+    const fixture = await createFixture();
+    try {
+      const missingGuardPath = await appendPolicyGateAuditRow({
+        workspaceRoot: fixture.root,
+        protectedRawPaths: [fixture.rawRoot],
+        fileName: "non-reserved-missing-guard.ndjson",
+        row: auditRowWithGuardClass(nonReservedAuditRow(), undefined)
+      });
+      expect(await readFile(missingGuardPath, "utf8")).toContain('"rule":"workspace-quota"');
+      expect(await readFile(missingGuardPath, "utf8")).not.toContain('"guard_class"');
+
+      for (const guardClass of ["capability", "authority"] as const) {
+        const auditPath = await appendPolicyGateAuditRow({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          fileName: `non-reserved-${guardClass}.ndjson`,
+          row: auditRowWithGuardClass(nonReservedAuditRow(), guardClass)
+        });
+        expect(await readFile(auditPath, "utf8")).toContain(`"guard_class":"${guardClass}"`);
+      }
+
+      await expect(
+        appendPolicyGateAuditRow({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          fileName: "non-reserved-invalid.ndjson",
+          row: auditRowWithGuardClass(nonReservedAuditRow(), "temporary" as never)
+        })
+      ).rejects.toThrow("Policy gate audit rows guard_class must be authority or capability");
     } finally {
       await fixture.cleanup();
     }
@@ -5342,6 +5555,48 @@ function minimalAuditRow(): PolicyGateAuditRow {
     guard_class: "authority",
     ts: "2026-07-04T00:00:00.000Z"
   };
+}
+
+function reservedNonRawAuditRow(rule: string): PolicyGateAuditRow {
+  return {
+    ...minimalAuditRow(),
+    rule,
+    decision: "failed",
+    guard_class: "authority"
+  };
+}
+
+function reservedNonRawErrorIdAuditRow(rule: string): PolicyGateAuditRow {
+  return {
+    ...minimalAuditRow(),
+    rule: "workspace-quota",
+    decision: "failed",
+    guard_class: "authority",
+    error_id: `${rule}:failed:test`
+  };
+}
+
+function nonReservedAuditRow(): PolicyGateAuditRow {
+  return {
+    ...minimalAuditRow(),
+    rule: "workspace-quota",
+    decision: "failed",
+    guard_class: "authority",
+    error_id: "workspace-quota:failed:test"
+  };
+}
+
+function auditRowWithGuardClass(
+  row: PolicyGateAuditRow,
+  guardClass: PolicyGateAuditRow["guard_class"]
+): PolicyGateAuditRow {
+  const copy = { ...row } as Partial<PolicyGateAuditRow>;
+  if (guardClass === undefined) {
+    delete copy.guard_class;
+  } else {
+    copy.guard_class = guardClass;
+  }
+  return copy as PolicyGateAuditRow;
 }
 
 function rawDataAuditRowWithoutGuard(): PolicyGateAuditRow {

--- a/packages/core/src/tools/raw-data-sandbox.test.ts
+++ b/packages/core/src/tools/raw-data-sandbox.test.ts
@@ -1008,7 +1008,141 @@ describe("raw data seatbelt sandbox", () => {
     }
   });
 
-  test("public audit append normalizes row option getter traps", async () => {
+  test("public audit append rejects option proxies without reading traps", async () => {
+    const fixture = await createFixture();
+    try {
+      let traps = 0;
+      const options = new Proxy(
+        {
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          fileName: "proxy-options.ndjson",
+          row: nonReservedAuditRow()
+        },
+        {
+          get() {
+            traps += 1;
+            throw new Error("audit option proxy secret get");
+          },
+          getOwnPropertyDescriptor() {
+            traps += 1;
+            throw new Error("audit option proxy secret descriptor");
+          }
+        }
+      );
+
+      let message = "";
+      try {
+        await appendPolicyGateAuditRow(options);
+      } catch (error) {
+        message = error instanceof Error ? error.message : String(error);
+      }
+
+      expect(message).toContain(
+        "Policy gate audit options must be stable ordinary structured data"
+      );
+      expect(message).not.toContain("audit option proxy secret");
+      expect(traps).toBe(0);
+      await expectMissing(
+        join(
+          fixture.workspaceRoot,
+          "tasks",
+          "TASK-M1-SPIKE",
+          "audit",
+          "proxy-options.ndjson"
+        )
+      );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("public audit append rejects option accessors without reading them", async () => {
+    const fixture = await createFixture();
+    try {
+      for (const field of [
+        "workspaceRoot",
+        "protectedRawPaths",
+        "taskId",
+        "fileName",
+        "row"
+      ] as const) {
+        let fieldReads = 0;
+        let rowReads = 0;
+        const options = {
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          fileName: `accessor-${field}.ndjson`,
+          get row() {
+            rowReads += 1;
+            return nonReservedAuditRow();
+          }
+        };
+        Object.defineProperty(options, field, {
+          enumerable: true,
+          configurable: true,
+          get() {
+            fieldReads += 1;
+            throw new Error(`audit option ${field} secret`);
+          }
+        });
+
+        let message = "";
+        try {
+          await appendPolicyGateAuditRow(options as never);
+        } catch (error) {
+          message = error instanceof Error ? error.message : String(error);
+        }
+
+        expect(message).toContain("Policy gate audit options must contain only data fields");
+        expect(message).not.toContain(`audit option ${field} secret`);
+        expect(fieldReads).toBe(0);
+        if (field !== "row") {
+          expect(rowReads).toBe(0);
+        }
+      }
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("public audit append bounds protected raw path options before reading row", async () => {
+    const fixture = await createFixture();
+    try {
+      let rowReads = 0;
+      const row = {
+        get event() {
+          rowReads += 1;
+          throw new Error("audit row trap secret");
+        }
+      } as never;
+      await expect(
+        appendPolicyGateAuditRow({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: Array.from({ length: 1_100 }, () => fixture.rawRoot),
+          fileName: "over-root-budget.ndjson",
+          row
+        })
+      ).rejects.toThrow("protectedRawPaths exceeds array length budget");
+      expect(rowReads).toBe(0);
+
+      const sparseRoots = new Array<string>(2);
+      sparseRoots[0] = fixture.rawRoot;
+      await expect(
+        appendPolicyGateAuditRow({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: sparseRoots,
+          fileName: "sparse-root-budget.ndjson",
+          row
+        })
+      ).rejects.toThrow("protectedRawPaths must contain only strings");
+      expect(rowReads).toBe(0);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("public audit append rejects row option accessors without executing them", async () => {
     const fixture = await createFixture();
     try {
       const secret = "audit row option getter secret";
@@ -1030,10 +1164,8 @@ describe("raw data seatbelt sandbox", () => {
         message = error instanceof Error ? error.message : String(error);
       }
 
-      expect(reads).toBe(1);
-      expect(message).toContain(
-        "Policy gate audit rows must be stable ordinary structured data"
-      );
+      expect(reads).toBe(0);
+      expect(message).toContain("Policy gate audit options must contain only data fields");
       expect(message).not.toContain(secret);
     } finally {
       await fixture.cleanup();

--- a/packages/core/src/tools/raw-data-sandbox.test.ts
+++ b/packages/core/src/tools/raw-data-sandbox.test.ts
@@ -737,6 +737,75 @@ describe("raw data seatbelt sandbox", () => {
     }
   });
 
+  test("public audit append rejects reserved rule prefix impersonation", async () => {
+    const fixture = await createFixture();
+    try {
+      for (const rule of [
+        RAW_DATA_WRITE_RULE_ID,
+        SPAWN_PROFILE_SUBSET_RULE_ID,
+        TOOL_PARAMETER_SCHEMA_RULE_ID
+      ]) {
+        await expect(
+          appendPolicyGateAuditRow({
+            workspaceRoot: fixture.root,
+            protectedRawPaths: [fixture.rawRoot],
+            fileName: `reserved-rule-prefix-${rule}.ndjson`,
+            row: {
+              ...minimalAuditRow(),
+              rule: `${rule}:failed:caller-minted`,
+              decision: "failed",
+              guard_class: "authority"
+            }
+          })
+        ).rejects.toThrow("Reserved authority policy rule prefixes are reserved for error_id");
+      }
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("public audit append accepts exact reserved rules and legal reserved error_id prefixes", async () => {
+    const fixture = await createFixture();
+    try {
+      for (const rule of [
+        RAW_DATA_WRITE_RULE_ID,
+        SPAWN_PROFILE_SUBSET_RULE_ID,
+        TOOL_PARAMETER_SCHEMA_RULE_ID
+      ]) {
+        const exactRulePath = await appendPolicyGateAuditRow({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          fileName: `reserved-exact-rule-${rule}.ndjson`,
+          row: {
+            ...minimalAuditRow(),
+            rule,
+            decision: "failed",
+            guard_class: "authority"
+          }
+        });
+        expect(await readFile(exactRulePath, "utf8")).toContain(`"rule":"${rule}"`);
+
+        const errorIdPath = await appendPolicyGateAuditRow({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          fileName: `reserved-error-prefix-${rule}.ndjson`,
+          row: {
+            ...minimalAuditRow(),
+            rule: "workspace-quota",
+            decision: "failed",
+            guard_class: "authority",
+            error_id: `${rule}:failed:legal-prefix`
+          }
+        });
+        expect(await readFile(errorIdPath, "utf8")).toContain(
+          `"error_id":"${rule}:failed:legal-prefix"`
+        );
+      }
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   test("public audit append preserves non-reserved guard_class compatibility", async () => {
     const fixture = await createFixture();
     try {
@@ -841,6 +910,42 @@ describe("raw data seatbelt sandbox", () => {
       expect(content).toContain('"decision":"failed"');
       expect(content).not.toContain('"decision":"denied_by_sandbox"');
       expect(content).not.toContain(`${RAW_DATA_WRITE_RULE_ID}:denied_by_sandbox`);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("public audit append rejects enumerable toJSON forgery before writing", async () => {
+    const fixture = await createFixture();
+    try {
+      const row = {
+        ...nonReservedAuditRow(),
+        toJSON() {
+          return {
+            ...minimalAuditRow(),
+            decision: "denied_by_sandbox",
+            error_id: `${RAW_DATA_WRITE_RULE_ID}:denied_by_sandbox:reserved-profile:TOOL-CALL-1`
+          };
+        }
+      } as PolicyGateAuditRow;
+
+      await expect(
+        appendPolicyGateAuditRow({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          fileName: "to-json-forgery.ndjson",
+          row
+        })
+      ).rejects.toThrow("Policy gate audit rows must not define enumerable toJSON");
+      await expectMissing(
+        join(
+          fixture.workspaceRoot,
+          "tasks",
+          "TASK-M1-SPIKE",
+          "audit",
+          "to-json-forgery.ndjson"
+        )
+      );
     } finally {
       await fixture.cleanup();
     }

--- a/packages/core/src/tools/raw-data-sandbox.test.ts
+++ b/packages/core/src/tools/raw-data-sandbox.test.ts
@@ -520,7 +520,7 @@ describe("raw data seatbelt sandbox", () => {
           workspaceRoot: fixture.root,
           protectedRawPaths: [fixture.rawRoot],
           row: {
-            ...minimalAuditRow(),
+            ...rawDataAuditRow(),
             guard_class: "capability"
           }
         })
@@ -707,30 +707,31 @@ describe("raw data seatbelt sandbox", () => {
     }
   });
 
-  test("public audit append accepts reserved non-raw authority guard_class", async () => {
+  test("public audit append rejects reserved non-raw authority guard_class", async () => {
     const fixture = await createFixture();
     try {
       for (const rule of [SPAWN_PROFILE_SUBSET_RULE_ID, TOOL_PARAMETER_SCHEMA_RULE_ID]) {
-        const ruleAuditPath = await appendPolicyGateAuditRow({
-          workspaceRoot: fixture.root,
-          protectedRawPaths: [fixture.rawRoot],
-          fileName: `reserved-authority-${rule}.ndjson`,
-          row: reservedNonRawAuditRow(rule)
-        });
-        const ruleContent = await readFile(ruleAuditPath, "utf8");
-        expect(ruleContent).toContain(`"rule":"${rule}"`);
-        expect(ruleContent).toContain('"guard_class":"authority"');
+        await expect(
+          appendPolicyGateAuditRow({
+            workspaceRoot: fixture.root,
+            protectedRawPaths: [fixture.rawRoot],
+            fileName: `reserved-authority-${rule}.ndjson`,
+            row: reservedNonRawAuditRow(rule)
+          })
+        ).rejects.toThrow(
+          "Reserved authority policy audit rows require trusted producer evidence"
+        );
 
-        const errorIdAuditPath = await appendPolicyGateAuditRow({
-          workspaceRoot: fixture.root,
-          protectedRawPaths: [fixture.rawRoot],
-          fileName: `reserved-error-authority-${rule}.ndjson`,
-          row: reservedNonRawErrorIdAuditRow(rule)
-        });
-        const errorIdContent = await readFile(errorIdAuditPath, "utf8");
-        expect(errorIdContent).toContain('"rule":"workspace-quota"');
-        expect(errorIdContent).toContain(`"error_id":"${rule}:failed:test"`);
-        expect(errorIdContent).toContain('"guard_class":"authority"');
+        await expect(
+          appendPolicyGateAuditRow({
+            workspaceRoot: fixture.root,
+            protectedRawPaths: [fixture.rawRoot],
+            fileName: `reserved-error-authority-${rule}.ndjson`,
+            row: reservedNonRawErrorIdAuditRow(rule)
+          })
+        ).rejects.toThrow(
+          "Reserved authority policy audit rows require trusted producer evidence"
+        );
       }
     } finally {
       await fixture.cleanup();
@@ -764,7 +765,7 @@ describe("raw data seatbelt sandbox", () => {
     }
   });
 
-  test("public audit append accepts exact reserved rules and legal reserved error_id prefixes", async () => {
+  test("public audit append rejects exact reserved rules and reserved error_id prefixes", async () => {
     const fixture = await createFixture();
     try {
       for (const rule of [
@@ -772,34 +773,39 @@ describe("raw data seatbelt sandbox", () => {
         SPAWN_PROFILE_SUBSET_RULE_ID,
         TOOL_PARAMETER_SCHEMA_RULE_ID
       ]) {
-        const exactRulePath = await appendPolicyGateAuditRow({
-          workspaceRoot: fixture.root,
-          protectedRawPaths: [fixture.rawRoot],
-          fileName: `reserved-exact-rule-${rule}.ndjson`,
-          row: {
-            ...minimalAuditRow(),
-            rule,
-            decision: "failed",
-            guard_class: "authority"
-          }
-        });
-        expect(await readFile(exactRulePath, "utf8")).toContain(`"rule":"${rule}"`);
+        const expected =
+          rule === RAW_DATA_WRITE_RULE_ID
+            ? "Raw-data authority audit rows require trusted producer evidence"
+            : "Reserved authority policy audit rows require trusted producer evidence";
 
-        const errorIdPath = await appendPolicyGateAuditRow({
-          workspaceRoot: fixture.root,
-          protectedRawPaths: [fixture.rawRoot],
-          fileName: `reserved-error-prefix-${rule}.ndjson`,
-          row: {
-            ...minimalAuditRow(),
-            rule: "workspace-quota",
-            decision: "failed",
-            guard_class: "authority",
-            error_id: `${rule}:failed:legal-prefix`
-          }
-        });
-        expect(await readFile(errorIdPath, "utf8")).toContain(
-          `"error_id":"${rule}:failed:legal-prefix"`
-        );
+        await expect(
+          appendPolicyGateAuditRow({
+            workspaceRoot: fixture.root,
+            protectedRawPaths: [fixture.rawRoot],
+            fileName: `reserved-exact-rule-${rule}.ndjson`,
+            row: {
+              ...minimalAuditRow(),
+              rule,
+              decision: "failed",
+              guard_class: "authority"
+            }
+          })
+        ).rejects.toThrow(expected);
+
+        await expect(
+          appendPolicyGateAuditRow({
+            workspaceRoot: fixture.root,
+            protectedRawPaths: [fixture.rawRoot],
+            fileName: `reserved-error-prefix-${rule}.ndjson`,
+            row: {
+              ...minimalAuditRow(),
+              rule: "workspace-quota",
+              decision: "failed",
+              guard_class: "authority",
+              error_id: `${rule}:failed:legal-prefix`
+            }
+          })
+        ).rejects.toThrow(expected);
       }
     } finally {
       await fixture.cleanup();
@@ -850,7 +856,7 @@ describe("raw data seatbelt sandbox", () => {
         fileName: "lifecycle.ndjson",
         row: {
           ...minimalAuditRow(),
-          error_id: `${RAW_DATA_WRITE_RULE_ID}:failed:lifecycle`
+          error_id: "workspace-quota:failed:lifecycle"
         }
       });
       const lifecycleWithoutRulePath = await appendPolicyGateAuditRow({
@@ -859,7 +865,7 @@ describe("raw data seatbelt sandbox", () => {
         fileName: "lifecycle-without-rule.ndjson",
         row: auditRowWithoutRule({
           ...minimalAuditRow(),
-          error_id: `${RAW_DATA_WRITE_RULE_ID}:failed:lifecycle-without-rule`
+          error_id: "workspace-quota:failed:lifecycle-without-rule"
         })
       });
       const nonRawPath = await appendPolicyGateAuditRow({
@@ -875,10 +881,10 @@ describe("raw data seatbelt sandbox", () => {
 
       expect(await readFile(lifecyclePath, "utf8")).toContain('"decision":"failed"');
       expect(await readFile(lifecyclePath, "utf8")).toContain(
-        `"error_id":"${RAW_DATA_WRITE_RULE_ID}:failed:lifecycle"`
+        '"error_id":"workspace-quota:failed:lifecycle"'
       );
       expect(await readFile(lifecycleWithoutRulePath, "utf8")).toContain(
-        `"error_id":"${RAW_DATA_WRITE_RULE_ID}:failed:lifecycle-without-rule"`
+        '"error_id":"workspace-quota:failed:lifecycle-without-rule"'
       );
       expect(await readFile(lifecycleWithoutRulePath, "utf8")).toContain(
         '"guard_class":"authority"'
@@ -946,6 +952,222 @@ describe("raw data seatbelt sandbox", () => {
           "to-json-forgery.ndjson"
         )
       );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("public audit append validates cheap options before reading hostile rows", async () => {
+    const fixture = await createFixture();
+    try {
+      let rowReads = 0;
+      let traps = 0;
+      const hostileRow = new Proxy(nonReservedAuditRow(), {
+        get() {
+          traps += 1;
+          throw new Error("audit row trap secret get");
+        },
+        ownKeys() {
+          traps += 1;
+          throw new Error("audit row trap secret ownKeys");
+        }
+      });
+      const makeOptions = (
+        overrides: Partial<Parameters<typeof appendPolicyGateAuditRow>[0]>
+      ) =>
+        ({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          get row() {
+            rowReads += 1;
+            return hostileRow;
+          },
+          ...overrides
+        }) as Parameters<typeof appendPolicyGateAuditRow>[0];
+
+      await expect(
+        appendPolicyGateAuditRow(makeOptions({ protectedRawPaths: undefined as never }))
+      ).rejects.toThrow("protectedRawPaths is required");
+      await expect(
+        appendPolicyGateAuditRow(makeOptions({ workspaceRoot: "workspace" }))
+      ).rejects.toThrow("workspaceRoot must be absolute");
+      await expect(
+        appendPolicyGateAuditRow(makeOptions({ protectedRawPaths: ["data/raw"] }))
+      ).rejects.toThrow("protectedRawPaths must be absolute");
+      await expect(
+        appendPolicyGateAuditRow(makeOptions({ taskId: ".." }))
+      ).rejects.toThrow("Invalid audit task id");
+      await expect(
+        appendPolicyGateAuditRow(makeOptions({ fileName: "../policy-gate.ndjson" }))
+      ).rejects.toThrow("Invalid audit file name");
+
+      expect(rowReads).toBe(0);
+      expect(traps).toBe(0);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("public audit append normalizes row option getter traps", async () => {
+    const fixture = await createFixture();
+    try {
+      const secret = "audit row option getter secret";
+      let reads = 0;
+      const options = {
+        workspaceRoot: fixture.root,
+        protectedRawPaths: [fixture.rawRoot],
+        fileName: "row-option-getter.ndjson",
+        get row() {
+          reads += 1;
+          throw new Error(secret);
+        }
+      } as Parameters<typeof appendPolicyGateAuditRow>[0];
+
+      let message = "";
+      try {
+        await appendPolicyGateAuditRow(options);
+      } catch (error) {
+        message = error instanceof Error ? error.message : String(error);
+      }
+
+      expect(reads).toBe(1);
+      expect(message).toContain(
+        "Policy gate audit rows must be stable ordinary structured data"
+      );
+      expect(message).not.toContain(secret);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("public audit append rejects proxy rows without leaking trap text", async () => {
+    const fixture = await createFixture();
+    try {
+      const secret = "audit row trap secret";
+      let traps = 0;
+      const row = new Proxy(nonReservedAuditRow(), {
+        get() {
+          traps += 1;
+          throw new Error(`${secret}: get`);
+        },
+        ownKeys() {
+          traps += 1;
+          throw new Error(`${secret}: ownKeys`);
+        },
+        getOwnPropertyDescriptor() {
+          traps += 1;
+          throw new Error(`${secret}: descriptor`);
+        }
+      });
+
+      let message = "";
+      try {
+        await appendPolicyGateAuditRow({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          fileName: "proxy-row.ndjson",
+          row
+        });
+      } catch (error) {
+        message = error instanceof Error ? error.message : String(error);
+      }
+
+      expect(message).toContain(
+        "Policy gate audit rows must be stable ordinary structured data"
+      );
+      expect(message).not.toContain(secret);
+      expect(traps).toBe(0);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("public audit append rejects accessor audit row data", async () => {
+    const fixture = await createFixture();
+    try {
+      const row = nonReservedAuditRow();
+      let reads = 0;
+      Object.defineProperty(row, "reason", {
+        enumerable: true,
+        get() {
+          reads += 1;
+          return "accessor secret";
+        }
+      });
+
+      await expect(
+        appendPolicyGateAuditRow({
+          workspaceRoot: fixture.root,
+          protectedRawPaths: [fixture.rawRoot],
+          fileName: "accessor-row.ndjson",
+          row
+        })
+      ).rejects.toThrow("Policy gate audit rows must contain only data fields");
+      expect(reads).toBe(0);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("public audit append rejects audit rows that exceed snapshot budgets", async () => {
+    const fixture = await createFixture();
+    try {
+      const deepRow = nonReservedAuditRow();
+      let cursor = deepRow as Record<string, unknown>;
+      for (let index = 0; index < 40; index += 1) {
+        const next: Record<string, unknown> = {};
+        cursor[`level${index}`] = next;
+        cursor = next;
+      }
+
+      const wideRow = {
+        ...nonReservedAuditRow(),
+        details: Object.fromEntries(
+          Array.from({ length: 300 }, (_, index) => [`key${index}`, "value"])
+        )
+      };
+      const bigArrayRow = {
+        ...nonReservedAuditRow(),
+        values: Array.from({ length: 1_100 }, () => "value")
+      };
+      const longStringRow = {
+        ...nonReservedAuditRow(),
+        reason: "x".repeat(140_000)
+      };
+
+      const cases = [
+        {
+          fileName: "over-depth.ndjson",
+          row: deepRow,
+          expected: "Policy gate audit row exceeds depth budget"
+        },
+        {
+          fileName: "over-wide.ndjson",
+          row: wideRow,
+          expected: "Policy gate audit row exceeds object key budget"
+        },
+        {
+          fileName: "big-array.ndjson",
+          row: bigArrayRow,
+          expected: "Policy gate audit row exceeds array length budget"
+        },
+        {
+          fileName: "long-string.ndjson",
+          row: longStringRow,
+          expected: "Policy gate audit row exceeds string budget"
+        }
+      ] as const;
+
+      for (const testCase of cases) {
+        await expect(
+          appendPolicyGateAuditRow({
+            workspaceRoot: fixture.root,
+            protectedRawPaths: [fixture.rawRoot],
+            fileName: testCase.fileName,
+            row: testCase.row
+          })
+        ).rejects.toThrow(testCase.expected);
+      }
     } finally {
       await fixture.cleanup();
     }
@@ -5655,10 +5877,18 @@ function minimalAuditRow(): PolicyGateAuditRow {
   return {
     event: "tool.failed",
     tool_id: "bash",
-    rule: RAW_DATA_WRITE_RULE_ID,
+    rule: "workspace-quota",
     decision: "failed",
     guard_class: "authority",
     ts: "2026-07-04T00:00:00.000Z"
+  };
+}
+
+function rawDataAuditRow(): PolicyGateAuditRow {
+  return {
+    ...minimalAuditRow(),
+    rule: RAW_DATA_WRITE_RULE_ID,
+    guard_class: "authority"
   };
 }
 
@@ -5705,7 +5935,7 @@ function auditRowWithGuardClass(
 }
 
 function rawDataAuditRowWithoutGuard(): PolicyGateAuditRow {
-  const copy = { ...minimalAuditRow() } as Partial<PolicyGateAuditRow>;
+  const copy = { ...rawDataAuditRow() } as Partial<PolicyGateAuditRow>;
   delete copy.guard_class;
   return copy as PolicyGateAuditRow;
 }

--- a/packages/core/src/tools/raw-data-sandbox.test.ts
+++ b/packages/core/src/tools/raw-data-sandbox.test.ts
@@ -1134,6 +1134,15 @@ describe("raw data seatbelt sandbox", () => {
         ...nonReservedAuditRow(),
         reason: "x".repeat(140_000)
       };
+      const nodeBudgetRow = {
+        ...nonReservedAuditRow(),
+        details: Object.fromEntries(
+          Array.from({ length: 101 }, (_, index) => [
+            `group${index}`,
+            Array.from({ length: 100 }, () => 0)
+          ])
+        )
+      };
 
       const cases = [
         {
@@ -1155,6 +1164,11 @@ describe("raw data seatbelt sandbox", () => {
           fileName: "long-string.ndjson",
           row: longStringRow,
           expected: "Policy gate audit row exceeds string budget"
+        },
+        {
+          fileName: "node-budget.ndjson",
+          row: nodeBudgetRow,
+          expected: "Policy gate audit row exceeds node budget"
         }
       ] as const;
 

--- a/packages/core/src/tools/raw-data-sandbox.test.ts
+++ b/packages/core/src/tools/raw-data-sandbox.test.ts
@@ -38,6 +38,7 @@ import {
   type PolicyGateAuditRow,
   type RawDataDenialPayload
 } from "./raw-data-sandbox";
+import { evaluatePolicyGate } from "./policy-gate-core";
 import {
   completeRawDataSandboxInvocationProcessesForTest,
   createRawDataSandboxInvocationDescendantTrackerForTest,
@@ -147,6 +148,44 @@ describe("raw data seatbelt sandbox", () => {
 
   test("raw data advisory rule carries authority guard classification", () => {
     expect(createRawDataWriteAdvisoryRule(["/tmp/raw"]).guardClass).toBe("authority");
+  });
+
+  test("raw data advisory rule guard classification is immutable", () => {
+    const rule = createRawDataWriteAdvisoryRule(["/tmp/raw"]);
+    let mutationThrew = false;
+
+    try {
+      rule.guardClass = "capability";
+    } catch {
+      mutationThrew = true;
+    }
+
+    expect(Object.isFrozen(rule)).toBe(true);
+    expect(mutationThrew || rule.guardClass === "authority").toBe(true);
+    expect(rule.guardClass).toBe("authority");
+  });
+
+  test("raw data write rule id cannot be reclassified as capability", () => {
+    expect(() =>
+      evaluatePolicyGate(
+        {
+          toolId: "bash",
+          role: "worker",
+          input: { command: "printf ok" },
+          workDir: "/tmp/shud-harness-test"
+        },
+        {
+          rules: [
+            {
+              ruleId: RAW_DATA_WRITE_RULE_ID,
+              description: "Misclassified raw data authority rule.",
+              guardClass: "capability",
+              evaluate: () => ({ decision: "allow" })
+            }
+          ]
+        }
+      )
+    ).toThrow(/known authority rule cannot be classified as capability/);
   });
 
   test("normal completion cleanup does not sample or signal a reused root PID", async () => {

--- a/packages/core/src/tools/raw-data-sandbox.ts
+++ b/packages/core/src/tools/raw-data-sandbox.ts
@@ -953,7 +953,8 @@ interface PolicyGateAuditReservationFailure {
 export function createRawDataWriteAdvisoryRule(
   protectedRawPaths: readonly string[]
 ): PolicyRule {
-  return {
+  const protectedRawPathSnapshot = Object.freeze([...protectedRawPaths]);
+  return Object.freeze({
     ruleId: RAW_DATA_WRITE_RULE_ID,
     description:
       "Advisory-only detection for obvious static writes to protected raw data paths.",
@@ -968,9 +969,9 @@ export function createRawDataWriteAdvisoryRule(
         return { decision: "allow" };
       }
 
-      return evaluateRawDataWriteAdvisory(command, protectedRawPaths);
+      return evaluateRawDataWriteAdvisory(command, protectedRawPathSnapshot);
     }
-  };
+  });
 }
 
 export function evaluateRawDataWriteAdvisory(

--- a/packages/core/src/tools/raw-data-sandbox.ts
+++ b/packages/core/src/tools/raw-data-sandbox.ts
@@ -72,6 +72,8 @@ const POLICY_GATE_AUDIT_ROW_MAX_NODES = 10_000;
 const POLICY_GATE_AUDIT_ROW_MAX_ARRAY_LENGTH = 1_024;
 const POLICY_GATE_AUDIT_ROW_MAX_OBJECT_KEYS = 256;
 const POLICY_GATE_AUDIT_ROW_MAX_STRING_CHARS = 131_072;
+const POLICY_GATE_AUDIT_OPTIONS_MAX_PROTECTED_ROOTS = 1_024;
+const POLICY_GATE_AUDIT_OPTIONS_MAX_STRING_CHARS = 131_072;
 const DEFAULT_ABORT_MESSAGE = "Command aborted by user from Session Detail.";
 const RAW_DATA_SANDBOXED_BASH_DESCRIPTION = [
   "何时该用: 在 SHUD runtime 中执行需要 shell 的本机命令，并让 raw/evidence 写保护与 fuse 规则生效。",
@@ -1070,23 +1072,47 @@ function evaluateCommandAnalysisBudget(
 export async function appendPolicyGateAuditRow(
   options: AppendPolicyGateAuditRowOptions
 ): Promise<string> {
-  assertProtectedRawPathsProvided(options.protectedRawPaths);
-  assertAbsoluteRoot(options.workspaceRoot, "workspaceRoot");
-  assertAbsoluteRoots(options.protectedRawPaths, "protectedRawPaths");
-  const taskId = options.taskId ?? DEFAULT_POLICY_GATE_AUDIT_TASK_ID;
+  const optionRecord = readPolicyGateAuditOptionsRecord(options);
+  const optionState = { stringChars: 0 };
+  const protectedRawPaths = readPolicyGateAuditProtectedRawPathsOption(
+    optionRecord,
+    optionState
+  );
+  const workspaceRoot = readRequiredPolicyGateAuditOptionString(
+    optionRecord,
+    "workspaceRoot",
+    "workspaceRoot",
+    optionState
+  );
+  assertProtectedRawPathsProvided(protectedRawPaths);
+  assertAbsoluteRoot(workspaceRoot, "workspaceRoot");
+  assertAbsoluteRoots(protectedRawPaths, "protectedRawPaths");
+  const taskId =
+    readOptionalPolicyGateAuditOptionString(
+      optionRecord,
+      "taskId",
+      "audit task id",
+      optionState
+    ) ?? DEFAULT_POLICY_GATE_AUDIT_TASK_ID;
   assertSafePathSegment(taskId, "audit task id");
 
-  const fileName = options.fileName ?? DEFAULT_AUDIT_FILE_NAME;
+  const fileName =
+    readOptionalPolicyGateAuditOptionString(
+      optionRecord,
+      "fileName",
+      "audit file name",
+      optionState
+    ) ?? DEFAULT_AUDIT_FILE_NAME;
   assertSafePathSegment(fileName, "audit file name");
 
-  const row = snapshotPolicyGateAuditRow(readPolicyGateAuditRowOption(options));
+  const row = snapshotPolicyGateAuditRow(readPolicyGateAuditRowOption(optionRecord));
   assertPublicPolicyGateAuditRow(row);
 
   const reservation = await ensurePolicyGateAuditReservation(
-    resolve(options.workspaceRoot),
+    resolve(workspaceRoot),
     taskId,
     fileName,
-    options.protectedRawPaths
+    protectedRawPaths
   );
   try {
     await appendReservedPolicyGateAuditRow(reservation, row);
@@ -1127,16 +1153,165 @@ function policyGateAuditRowSnapshotError(message: string): PolicyGateAuditRowSna
   return new PolicyGateAuditRowSnapshotError(message);
 }
 
-function readPolicyGateAuditRowOption(
+function policyGateAuditOptionSnapshotError(message: string): Error {
+  return new Error(message);
+}
+
+function readPolicyGateAuditOptionsRecord(
   options: AppendPolicyGateAuditRowOptions
-): PolicyGateAuditRow {
-  try {
-    return options.row;
-  } catch {
-    throw policyGateAuditRowSnapshotError(
-      "Policy gate audit rows must be stable ordinary structured data."
+): object {
+  if (typeof options !== "object" || options === null || Array.isArray(options)) {
+    throw policyGateAuditOptionSnapshotError(
+      "Policy gate audit options must be stable ordinary structured data."
     );
   }
+  if (nodeUtilTypes.isProxy(options)) {
+    throw policyGateAuditOptionSnapshotError(
+      "Policy gate audit options must be stable ordinary structured data."
+    );
+  }
+  const prototype = Object.getPrototypeOf(options);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw policyGateAuditOptionSnapshotError(
+      "Policy gate audit options must be plain structured data."
+    );
+  }
+  return options;
+}
+
+function readPolicyGateAuditProtectedRawPathsOption(
+  options: object,
+  state: { stringChars: number }
+): readonly string[] | undefined {
+  const value = readPolicyGateAuditOptionDataField(
+    options,
+    "protectedRawPaths",
+    "protectedRawPaths"
+  );
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    throw new Error("protectedRawPaths is required for policy gate audit writes.");
+  }
+  if (nodeUtilTypes.isProxy(value) || Object.getPrototypeOf(value) !== Array.prototype) {
+    throw policyGateAuditOptionSnapshotError(
+      "protectedRawPaths must be an ordinary string array."
+    );
+  }
+  if (value.length > POLICY_GATE_AUDIT_OPTIONS_MAX_PROTECTED_ROOTS) {
+    throw policyGateAuditOptionSnapshotError(
+      "protectedRawPaths exceeds array length budget."
+    );
+  }
+
+  const copy: string[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const descriptor = readPolicyGateAuditOptionDataDescriptor(
+      value,
+      String(index),
+      "protectedRawPaths"
+    );
+    if (!descriptor || typeof descriptor.value !== "string") {
+      throw policyGateAuditOptionSnapshotError(
+        "protectedRawPaths must contain only strings."
+      );
+    }
+    addPolicyGateAuditOptionStringBudget(descriptor.value.length, state);
+    copy.push(descriptor.value);
+  }
+  return copy;
+}
+
+function readRequiredPolicyGateAuditOptionString(
+  options: object,
+  key: string,
+  label: string,
+  state: { stringChars: number }
+): string {
+  const value = readPolicyGateAuditOptionDataField(options, key, label);
+  if (typeof value !== "string") {
+    throw policyGateAuditOptionSnapshotError(`${label} must be a string.`);
+  }
+  addPolicyGateAuditOptionStringBudget(value.length, state);
+  return value;
+}
+
+function readOptionalPolicyGateAuditOptionString(
+  options: object,
+  key: string,
+  label: string,
+  state: { stringChars: number }
+): string | undefined {
+  const value = readPolicyGateAuditOptionDataField(options, key, label);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw policyGateAuditOptionSnapshotError(`${label} must be a string.`);
+  }
+  addPolicyGateAuditOptionStringBudget(value.length, state);
+  return value;
+}
+
+function readPolicyGateAuditOptionDataField(
+  options: object,
+  key: string,
+  label: string
+): unknown {
+  return readPolicyGateAuditOptionDataDescriptor(options, key, label)?.value;
+}
+
+function readPolicyGateAuditOptionDataDescriptor(
+  options: object,
+  key: string,
+  label: string
+): JsonAuditDataDescriptor | undefined {
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = Object.getOwnPropertyDescriptor(options, key);
+  } catch {
+    throw policyGateAuditOptionSnapshotError(
+      "Policy gate audit options must be stable ordinary structured data."
+    );
+  }
+  if (!descriptor) {
+    return undefined;
+  }
+  if (!("value" in descriptor) || descriptor.get !== undefined || descriptor.set !== undefined) {
+    throw policyGateAuditOptionSnapshotError(
+      "Policy gate audit options must contain only data fields."
+    );
+  }
+  return descriptor as JsonAuditDataDescriptor;
+}
+
+function addPolicyGateAuditOptionStringBudget(
+  length: number,
+  state: { stringChars: number }
+): void {
+  state.stringChars += length;
+  if (state.stringChars > POLICY_GATE_AUDIT_OPTIONS_MAX_STRING_CHARS) {
+    throw policyGateAuditOptionSnapshotError(
+      "Policy gate audit options exceed string budget."
+    );
+  }
+}
+
+function readPolicyGateAuditRowOption(
+  options: object
+): PolicyGateAuditRow {
+  const descriptor = readPolicyGateAuditOptionDataDescriptor(
+    options,
+    "row",
+    "Policy gate audit row"
+  );
+  if (!descriptor) {
+    throw policyGateAuditRowSnapshotError(
+      "Policy gate audit row is required."
+    );
+  }
+  return descriptor.value as PolicyGateAuditRow;
 }
 
 function snapshotPolicyGateAuditRow(row: PolicyGateAuditRow): PolicyGateAuditRow {

--- a/packages/core/src/tools/raw-data-sandbox.ts
+++ b/packages/core/src/tools/raw-data-sandbox.ts
@@ -28,6 +28,10 @@ import type {
   PolicyRule,
   PolicyRuleDecision
 } from "./policy-gate-core";
+import {
+  isReservedAuthorityPolicyEvidenceId,
+  PolicyGuardClassSchema
+} from "./policy-gate-core";
 
 export const RAW_DATA_WRITE_RULE_ID = "raw-data-write";
 export const RAW_DATA_SANDBOX_PROFILE_VERSION = "raw-data-seatbelt-v1";
@@ -1122,11 +1126,7 @@ function snapshotAuditValue(
 }
 
 function assertPublicPolicyGateAuditRow(row: PolicyGateAuditRow): void {
-  if (isRawDataAuthorityAuditRowWithoutAuthorityGuard(row)) {
-    throw new Error(
-      "Raw-data authority audit rows require guard_class authority."
-    );
-  }
+  const guardClass = readPolicyGateAuditGuardClass(row.guard_class);
   if (isRawDataDenialDecision(row.decision)) {
     throw new Error(
       "Raw-data denial audit rows require RawDataSandboxedBashTool trusted evidence."
@@ -1137,19 +1137,37 @@ function assertPublicPolicyGateAuditRow(row: PolicyGateAuditRow): void {
       "Reserved raw-data denial error_id values require RawDataSandboxedBashTool trusted evidence."
     );
   }
-}
-
-function isRawDataAuthorityAuditRowWithoutAuthorityGuard(
-  row: PolicyGateAuditRow
-): boolean {
-  return (
-    isRawDataAuthorityAuditRow(row) &&
-    row.guard_class !== rawDataGuardClassForRawData()
-  );
+  if (!isReservedAuthorityPolicyAuditRow(row) || guardClass === rawDataGuardClassForRawData()) {
+    return;
+  }
+  if (isRawDataAuthorityAuditRow(row)) {
+    throw new Error("Raw-data authority audit rows require guard_class authority.");
+  }
+  throw new Error("Reserved authority policy audit rows require guard_class authority.");
 }
 
 function isRawDataAuthorityAuditRow(row: PolicyGateAuditRow): boolean {
   return row.rule === RAW_DATA_WRITE_RULE_ID || isRawDataAuthorityErrorId(row.error_id);
+}
+
+function isReservedAuthorityPolicyAuditRow(row: PolicyGateAuditRow): boolean {
+  return (
+    isReservedAuthorityPolicyEvidenceId(row.rule) ||
+    isReservedAuthorityPolicyEvidenceId(row.error_id)
+  );
+}
+
+function readPolicyGateAuditGuardClass(
+  guardClass: PolicyGateAuditRow["guard_class"]
+): RawDataGuardClass | undefined {
+  if (guardClass === undefined) {
+    return undefined;
+  }
+  const parsed = PolicyGuardClassSchema.safeParse(guardClass);
+  if (!parsed.success) {
+    throw new Error("Policy gate audit rows guard_class must be authority or capability.");
+  }
+  return parsed.data;
 }
 
 function isRawDataAuthorityErrorId(errorId: string | undefined): boolean {

--- a/packages/core/src/tools/raw-data-sandbox.ts
+++ b/packages/core/src/tools/raw-data-sandbox.ts
@@ -957,6 +957,7 @@ export function createRawDataWriteAdvisoryRule(
     ruleId: RAW_DATA_WRITE_RULE_ID,
     description:
       "Advisory-only detection for obvious static writes to protected raw data paths.",
+    guardClass: "authority",
     evaluate(call: PolicyGateToolCall): PolicyRuleDecision {
       if (call.toolId !== "bash" && call.toolId !== "sandbox.exec") {
         return { decision: "allow" };

--- a/packages/core/src/tools/raw-data-sandbox.ts
+++ b/packages/core/src/tools/raw-data-sandbox.ts
@@ -14,6 +14,7 @@ import {
 import type { FileHandle } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, normalize, parse, resolve } from "node:path";
+import { types as nodeUtilTypes } from "node:util";
 import { BaseTool, BashTool, FuseListChecker } from "@zero-os/core";
 import type {
   FuseRule,
@@ -66,6 +67,11 @@ const COMMAND_ANALYSIS_MAX_SEGMENTS = 512;
 const COMMAND_ANALYSIS_MAX_CALLS = 512;
 const PROCESS_PREFLIGHT_ANALYSIS_MAX_LENGTH = 32_000;
 const STREAM_CAPTURE_MAX_CHARS = 64_000;
+const POLICY_GATE_AUDIT_ROW_MAX_DEPTH = 32;
+const POLICY_GATE_AUDIT_ROW_MAX_NODES = 10_000;
+const POLICY_GATE_AUDIT_ROW_MAX_ARRAY_LENGTH = 1_024;
+const POLICY_GATE_AUDIT_ROW_MAX_OBJECT_KEYS = 256;
+const POLICY_GATE_AUDIT_ROW_MAX_STRING_CHARS = 131_072;
 const DEFAULT_ABORT_MESSAGE = "Command aborted by user from Session Detail.";
 const RAW_DATA_SANDBOXED_BASH_DESCRIPTION = [
   "何时该用: 在 SHUD runtime 中执行需要 shell 的本机命令，并让 raw/evidence 写保护与 fuse 规则生效。",
@@ -1064,16 +1070,17 @@ function evaluateCommandAnalysisBudget(
 export async function appendPolicyGateAuditRow(
   options: AppendPolicyGateAuditRowOptions
 ): Promise<string> {
-  const row = snapshotPolicyGateAuditRow(options.row);
   assertProtectedRawPathsProvided(options.protectedRawPaths);
   assertAbsoluteRoot(options.workspaceRoot, "workspaceRoot");
   assertAbsoluteRoots(options.protectedRawPaths, "protectedRawPaths");
-  assertPublicPolicyGateAuditRow(row);
   const taskId = options.taskId ?? DEFAULT_POLICY_GATE_AUDIT_TASK_ID;
   assertSafePathSegment(taskId, "audit task id");
 
   const fileName = options.fileName ?? DEFAULT_AUDIT_FILE_NAME;
   assertSafePathSegment(fileName, "audit file name");
+
+  const row = snapshotPolicyGateAuditRow(readPolicyGateAuditRowOption(options));
+  assertPublicPolicyGateAuditRow(row);
 
   const reservation = await ensurePolicyGateAuditReservation(
     resolve(options.workspaceRoot),
@@ -1099,77 +1106,257 @@ type JsonAuditValue =
 
 const OMIT_JSON_AUDIT_PROPERTY = Symbol("omit-json-audit-property");
 
+type PolicyGateAuditSnapshotState = {
+  seen: WeakSet<object>;
+  nodes: number;
+  stringChars: number;
+};
+
+type JsonAuditDataDescriptor = PropertyDescriptor & {
+  value: unknown;
+};
+
+class PolicyGateAuditRowSnapshotError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PolicyGateAuditRowSnapshotError";
+  }
+}
+
+function policyGateAuditRowSnapshotError(message: string): PolicyGateAuditRowSnapshotError {
+  return new PolicyGateAuditRowSnapshotError(message);
+}
+
+function readPolicyGateAuditRowOption(
+  options: AppendPolicyGateAuditRowOptions
+): PolicyGateAuditRow {
+  try {
+    return options.row;
+  } catch {
+    throw policyGateAuditRowSnapshotError(
+      "Policy gate audit rows must be stable ordinary structured data."
+    );
+  }
+}
+
 function snapshotPolicyGateAuditRow(row: PolicyGateAuditRow): PolicyGateAuditRow {
-  return snapshotAuditValue(row) as PolicyGateAuditRow;
+  try {
+    return snapshotAuditValue(row, {
+      seen: new WeakSet<object>(),
+      nodes: 0,
+      stringChars: 0
+    }) as PolicyGateAuditRow;
+  } catch (error) {
+    if (error instanceof PolicyGateAuditRowSnapshotError) {
+      throw error;
+    }
+    throw policyGateAuditRowSnapshotError(
+      "Policy gate audit rows must be stable ordinary structured data."
+    );
+  }
 }
 
 function snapshotAuditValue(
   value: unknown,
-  seen = new WeakSet<object>()
+  state: PolicyGateAuditSnapshotState,
+  depth = 0
 ): JsonAuditValue | typeof OMIT_JSON_AUDIT_PROPERTY {
+  if (depth > POLICY_GATE_AUDIT_ROW_MAX_DEPTH) {
+    throw policyGateAuditRowSnapshotError("Policy gate audit row exceeds depth budget.");
+  }
+
+  state.nodes += 1;
+  if (state.nodes > POLICY_GATE_AUDIT_ROW_MAX_NODES) {
+    throw policyGateAuditRowSnapshotError("Policy gate audit row exceeds node budget.");
+  }
+
   if (value === undefined) {
     return OMIT_JSON_AUDIT_PROPERTY;
   }
-  if (value === null || typeof value === "string" || typeof value === "boolean") {
+  if (value === null || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    addPolicyGateAuditStringBudget(value.length, state);
     return value;
   }
   if (typeof value === "number") {
     if (!Number.isFinite(value)) {
-      throw new Error("Policy gate audit rows must contain only finite JSON numbers.");
+      throw policyGateAuditRowSnapshotError(
+        "Policy gate audit rows must contain only finite JSON numbers."
+      );
     }
     return value;
   }
   if (typeof value === "function" || typeof value === "symbol" || typeof value === "bigint") {
-    throw new Error("Policy gate audit rows must contain only JSON-compatible data.");
+    throw policyGateAuditRowSnapshotError(
+      "Policy gate audit rows must contain only JSON-compatible data."
+    );
   }
   if (typeof value !== "object") {
-    throw new Error("Policy gate audit rows must contain only JSON-compatible data.");
+    throw policyGateAuditRowSnapshotError(
+      "Policy gate audit rows must contain only JSON-compatible data."
+    );
+  }
+
+  if (nodeUtilTypes.isProxy(value)) {
+    throw policyGateAuditRowSnapshotError(
+      "Policy gate audit rows must be stable ordinary structured data."
+    );
   }
 
   if (value instanceof Date) {
-    return value.toISOString();
-  }
-
-  if (seen.has(value)) {
-    throw new Error("Policy gate audit rows must not contain cyclic data.");
-  }
-  seen.add(value);
-
-  if (Array.isArray(value)) {
-    const copy: JsonAuditValue[] = [];
-    for (const item of value) {
-      const snapshot = snapshotAuditValue(item, seen);
-      if (snapshot === OMIT_JSON_AUDIT_PROPERTY) {
-        throw new Error("Policy gate audit row arrays must not contain undefined values.");
-      }
-      copy.push(snapshot);
+    let timestamp: string;
+    try {
+      timestamp = Date.prototype.toISOString.call(value);
+    } catch {
+      throw policyGateAuditRowSnapshotError(
+        "Policy gate audit rows must contain only valid Date values."
+      );
     }
-    seen.delete(value);
-    return copy;
+    addPolicyGateAuditStringBudget(timestamp.length, state);
+    return timestamp;
+  }
+
+  if (state.seen.has(value)) {
+    throw policyGateAuditRowSnapshotError("Policy gate audit rows must not contain cyclic data.");
+  }
+  state.seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      assertOrdinaryPolicyGateAuditArray(value);
+      return snapshotAuditArray(value, state, depth);
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw policyGateAuditRowSnapshotError(
+        "Policy gate audit rows must be plain structured data."
+      );
+    }
+
+    return snapshotAuditPlainObject(value, state, depth);
+  } finally {
+    state.seen.delete(value);
+  }
+}
+
+function assertOrdinaryPolicyGateAuditArray(value: readonly unknown[]): void {
+  if (Object.getPrototypeOf(value) !== Array.prototype) {
+    throw policyGateAuditRowSnapshotError(
+      "Policy gate audit row arrays must be ordinary structured data."
+    );
+  }
+}
+
+function snapshotAuditArray(
+  value: readonly unknown[],
+  state: PolicyGateAuditSnapshotState,
+  depth: number
+): JsonAuditValue[] {
+  const length = readPolicyGateAuditArrayLength(value);
+  if (length > POLICY_GATE_AUDIT_ROW_MAX_ARRAY_LENGTH) {
+    throw policyGateAuditRowSnapshotError("Policy gate audit row exceeds array length budget.");
+  }
+
+  const copy = new Array<JsonAuditValue>(length);
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = readPolicyGateAuditArrayIndexDataDescriptor(value, index);
+    if (!descriptor) {
+      throw policyGateAuditRowSnapshotError(
+        "Policy gate audit row arrays must not contain undefined values."
+      );
+    }
+    const snapshot = snapshotAuditValue(descriptor.value, state, depth + 1);
+    if (snapshot === OMIT_JSON_AUDIT_PROPERTY) {
+      throw policyGateAuditRowSnapshotError(
+        "Policy gate audit row arrays must not contain undefined values."
+      );
+    }
+    copy[index] = snapshot;
+  }
+  return copy;
+}
+
+function snapshotAuditPlainObject(
+  value: object,
+  state: PolicyGateAuditSnapshotState,
+  depth: number
+): { [key: string]: JsonAuditValue } {
+  const keys = Reflect.ownKeys(value);
+  if (keys.length > POLICY_GATE_AUDIT_ROW_MAX_OBJECT_KEYS) {
+    throw policyGateAuditRowSnapshotError("Policy gate audit row exceeds object key budget.");
   }
 
   const copy = Object.create(null) as { [key: string]: JsonAuditValue };
-  for (const key of Reflect.ownKeys(value)) {
+  for (const key of keys) {
     const descriptor = Object.getOwnPropertyDescriptor(value, key);
     if (!descriptor?.enumerable) {
       continue;
     }
     if (typeof key === "symbol") {
-      throw new Error("Policy gate audit rows must not contain enumerable symbol keys.");
+      throw policyGateAuditRowSnapshotError(
+        "Policy gate audit rows must not contain enumerable symbol keys."
+      );
     }
+    addPolicyGateAuditStringBudget(key.length, state);
     if (key === "toJSON") {
-      throw new Error("Policy gate audit rows must not define enumerable toJSON.");
+      throw policyGateAuditRowSnapshotError(
+        "Policy gate audit rows must not define enumerable toJSON."
+      );
     }
-    if (!("value" in descriptor)) {
-      throw new Error("Policy gate audit rows must contain only data fields.");
+    if (!("value" in descriptor) || descriptor.get !== undefined || descriptor.set !== undefined) {
+      throw policyGateAuditRowSnapshotError(
+        "Policy gate audit rows must contain only data fields."
+      );
     }
-    const snapshot = snapshotAuditValue(descriptor.value, seen);
+    const snapshot = snapshotAuditValue(descriptor.value, state, depth + 1);
     if (snapshot !== OMIT_JSON_AUDIT_PROPERTY) {
       copy[key] = snapshot;
     }
   }
-  seen.delete(value);
   return copy;
+}
+
+function readPolicyGateAuditArrayLength(value: readonly unknown[]): number {
+  const length = Reflect.get(value, "length");
+  if (
+    typeof length !== "number" ||
+    !Number.isSafeInteger(length) ||
+    length < 0 ||
+    length > 4_294_967_295
+  ) {
+    throw policyGateAuditRowSnapshotError(
+      "Policy gate audit rows contain an unsafe array length."
+    );
+  }
+  return length;
+}
+
+function readPolicyGateAuditArrayIndexDataDescriptor(
+  value: readonly unknown[],
+  index: number
+): JsonAuditDataDescriptor | undefined {
+  const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+  if (!descriptor) {
+    return undefined;
+  }
+  if (!("value" in descriptor) || descriptor.get !== undefined || descriptor.set !== undefined) {
+    throw policyGateAuditRowSnapshotError(
+      "Policy gate audit rows must contain only data fields."
+    );
+  }
+  return descriptor as JsonAuditDataDescriptor;
+}
+
+function addPolicyGateAuditStringBudget(
+  length: number,
+  state: Pick<PolicyGateAuditSnapshotState, "stringChars">
+): void {
+  state.stringChars += length;
+  if (state.stringChars > POLICY_GATE_AUDIT_ROW_MAX_STRING_CHARS) {
+    throw policyGateAuditRowSnapshotError("Policy gate audit row exceeds string budget.");
+  }
 }
 
 function assertPublicPolicyGateAuditRow(row: PolicyGateAuditRow): void {
@@ -1187,13 +1374,19 @@ function assertPublicPolicyGateAuditRow(row: PolicyGateAuditRow): void {
   if (isReservedAuthorityPolicyRuleIdPrefixImpersonation(row.rule)) {
     throw new Error("Reserved authority policy rule prefixes are reserved for error_id.");
   }
-  if (!isReservedAuthorityPolicyAuditRow(row) || guardClass === rawDataGuardClassForRawData()) {
+  if (!isReservedAuthorityPolicyAuditRow(row)) {
     return;
   }
-  if (isRawDataAuthorityAuditRow(row)) {
-    throw new Error("Raw-data authority audit rows require guard_class authority.");
+  if (guardClass !== rawDataGuardClassForRawData()) {
+    if (isRawDataAuthorityAuditRow(row)) {
+      throw new Error("Raw-data authority audit rows require guard_class authority.");
+    }
+    throw new Error("Reserved authority policy audit rows require guard_class authority.");
   }
-  throw new Error("Reserved authority policy audit rows require guard_class authority.");
+  if (isRawDataAuthorityAuditRow(row)) {
+    throw new Error("Raw-data authority audit rows require trusted producer evidence.");
+  }
+  throw new Error("Reserved authority policy audit rows require trusted producer evidence.");
 }
 
 function isRawDataAuthorityAuditRow(row: PolicyGateAuditRow): boolean {

--- a/packages/core/src/tools/raw-data-sandbox.ts
+++ b/packages/core/src/tools/raw-data-sandbox.ts
@@ -29,7 +29,9 @@ import type {
   PolicyRuleDecision
 } from "./policy-gate-core";
 import {
-  isReservedAuthorityPolicyEvidenceId,
+  isReservedAuthorityPolicyErrorId,
+  isReservedAuthorityPolicyRuleId,
+  isReservedAuthorityPolicyRuleIdPrefixImpersonation,
   PolicyGuardClassSchema
 } from "./policy-gate-core";
 
@@ -1087,41 +1089,86 @@ export async function appendPolicyGateAuditRow(
   }
 }
 
+type JsonAuditValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonAuditValue[]
+  | { [key: string]: JsonAuditValue };
+
+const OMIT_JSON_AUDIT_PROPERTY = Symbol("omit-json-audit-property");
+
 function snapshotPolicyGateAuditRow(row: PolicyGateAuditRow): PolicyGateAuditRow {
   return snapshotAuditValue(row) as PolicyGateAuditRow;
 }
 
 function snapshotAuditValue(
   value: unknown,
-  seen = new WeakMap<object, unknown>()
-): unknown {
-  if (value === null || typeof value !== "object") {
+  seen = new WeakSet<object>()
+): JsonAuditValue | typeof OMIT_JSON_AUDIT_PROPERTY {
+  if (value === undefined) {
+    return OMIT_JSON_AUDIT_PROPERTY;
+  }
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
     return value;
   }
-
-  const existing = seen.get(value);
-  if (existing !== undefined) {
-    return existing;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error("Policy gate audit rows must contain only finite JSON numbers.");
+    }
+    return value;
+  }
+  if (typeof value === "function" || typeof value === "symbol" || typeof value === "bigint") {
+    throw new Error("Policy gate audit rows must contain only JSON-compatible data.");
+  }
+  if (typeof value !== "object") {
+    throw new Error("Policy gate audit rows must contain only JSON-compatible data.");
   }
 
   if (value instanceof Date) {
-    return new Date(value.getTime());
+    return value.toISOString();
   }
 
+  if (seen.has(value)) {
+    throw new Error("Policy gate audit rows must not contain cyclic data.");
+  }
+  seen.add(value);
+
   if (Array.isArray(value)) {
-    const copy: unknown[] = [];
-    seen.set(value, copy);
+    const copy: JsonAuditValue[] = [];
     for (const item of value) {
-      copy.push(snapshotAuditValue(item, seen));
+      const snapshot = snapshotAuditValue(item, seen);
+      if (snapshot === OMIT_JSON_AUDIT_PROPERTY) {
+        throw new Error("Policy gate audit row arrays must not contain undefined values.");
+      }
+      copy.push(snapshot);
     }
+    seen.delete(value);
     return copy;
   }
 
-  const copy: Record<string, unknown> = {};
-  seen.set(value, copy);
-  for (const [key, item] of Object.entries(value)) {
-    copy[key] = snapshotAuditValue(item, seen);
+  const copy = Object.create(null) as { [key: string]: JsonAuditValue };
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor?.enumerable) {
+      continue;
+    }
+    if (typeof key === "symbol") {
+      throw new Error("Policy gate audit rows must not contain enumerable symbol keys.");
+    }
+    if (key === "toJSON") {
+      throw new Error("Policy gate audit rows must not define enumerable toJSON.");
+    }
+    if (!("value" in descriptor)) {
+      throw new Error("Policy gate audit rows must contain only data fields.");
+    }
+    const snapshot = snapshotAuditValue(descriptor.value, seen);
+    if (snapshot !== OMIT_JSON_AUDIT_PROPERTY) {
+      copy[key] = snapshot;
+    }
   }
+  seen.delete(value);
   return copy;
 }
 
@@ -1136,6 +1183,9 @@ function assertPublicPolicyGateAuditRow(row: PolicyGateAuditRow): void {
     throw new Error(
       "Reserved raw-data denial error_id values require RawDataSandboxedBashTool trusted evidence."
     );
+  }
+  if (isReservedAuthorityPolicyRuleIdPrefixImpersonation(row.rule)) {
+    throw new Error("Reserved authority policy rule prefixes are reserved for error_id.");
   }
   if (!isReservedAuthorityPolicyAuditRow(row) || guardClass === rawDataGuardClassForRawData()) {
     return;
@@ -1152,8 +1202,8 @@ function isRawDataAuthorityAuditRow(row: PolicyGateAuditRow): boolean {
 
 function isReservedAuthorityPolicyAuditRow(row: PolicyGateAuditRow): boolean {
   return (
-    isReservedAuthorityPolicyEvidenceId(row.rule) ||
-    isReservedAuthorityPolicyEvidenceId(row.error_id)
+    isReservedAuthorityPolicyRuleId(row.rule ?? "") ||
+    isReservedAuthorityPolicyErrorId(row.error_id)
   );
 }
 
@@ -5115,7 +5165,27 @@ async function appendReservedPolicyGateAuditRow(
   row: PolicyGateAuditRow
 ): Promise<void> {
   await assertAuditPathIdentity(reservation);
-  await appendAuditHandle(reservation.handle, reservation.auditPath, `${JSON.stringify(row)}\n`);
+  await appendAuditHandle(
+    reservation.handle,
+    reservation.auditPath,
+    `${stringifyJsonAuditValue(row as JsonAuditValue)}\n`
+  );
+}
+
+function stringifyJsonAuditValue(value: JsonAuditValue): string {
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stringifyJsonAuditValue(item)).join(",")}]`;
+  }
+
+  return `{${Object.keys(value)
+    .map((key) => `${JSON.stringify(key)}:${stringifyJsonAuditValue(value[key])}`)
+    .join(",")}}`;
 }
 
 async function appendAuditHandle(handle: FileHandle, path: string, line: string): Promise<void> {

--- a/packages/core/src/tools/raw-data-sandbox.ts
+++ b/packages/core/src/tools/raw-data-sandbox.ts
@@ -767,6 +767,7 @@ export class RawDataSandboxedBashTool extends BaseTool {
           tool_id: this.name,
           rule: RAW_DATA_WRITE_RULE_ID,
           decision: input.decision,
+          guard_class: rawDataGuardClassForRawData(),
           ts: new Date().toISOString(),
           profile_id: input.profile.profileId,
           profile_path: input.profilePath
@@ -1121,6 +1122,11 @@ function snapshotAuditValue(
 }
 
 function assertPublicPolicyGateAuditRow(row: PolicyGateAuditRow): void {
+  if (isRawDataAuthorityAuditRowWithoutAuthorityGuard(row)) {
+    throw new Error(
+      "Raw-data authority audit rows require guard_class authority."
+    );
+  }
   if (isRawDataDenialDecision(row.decision)) {
     throw new Error(
       "Raw-data denial audit rows require RawDataSandboxedBashTool trusted evidence."
@@ -1131,6 +1137,23 @@ function assertPublicPolicyGateAuditRow(row: PolicyGateAuditRow): void {
       "Reserved raw-data denial error_id values require RawDataSandboxedBashTool trusted evidence."
     );
   }
+}
+
+function isRawDataAuthorityAuditRowWithoutAuthorityGuard(
+  row: PolicyGateAuditRow
+): boolean {
+  return (
+    isRawDataAuthorityAuditRow(row) &&
+    row.guard_class !== rawDataGuardClassForRawData()
+  );
+}
+
+function isRawDataAuthorityAuditRow(row: PolicyGateAuditRow): boolean {
+  return row.rule === RAW_DATA_WRITE_RULE_ID || isRawDataAuthorityErrorId(row.error_id);
+}
+
+function isRawDataAuthorityErrorId(errorId: string | undefined): boolean {
+  return errorId === RAW_DATA_WRITE_RULE_ID || errorId?.startsWith(`${RAW_DATA_WRITE_RULE_ID}:`) === true;
 }
 
 export function buildRawDataDeniedPayload(input: {
@@ -1144,7 +1167,6 @@ export function buildRawDataDeniedPayload(input: {
 }): RawDataAdvisoryDenialPayload {
   const ts = input.ts ?? new Date().toISOString();
   const remediation = rawDataWriteRemediation();
-  const guardClass = rawDataGuardClassForRawData();
   const errorId = [
     RAW_DATA_WRITE_RULE_ID,
     "denied_by_advisory",
@@ -1156,9 +1178,8 @@ export function buildRawDataDeniedPayload(input: {
   return {
     error: "raw_data_write_denied",
     tool_id: input.toolId,
-    rule: RAW_DATA_WRITE_RULE_ID,
+    ...rawDataAuthorityEvidenceFields(),
     decision: "denied_by_advisory",
-    guard_class: guardClass,
     reason: input.reason,
     remediation,
     profile_id: input.profile.profileId,
@@ -1504,7 +1525,7 @@ function buildAuditReservationFailureResult(input: {
   const payload = {
     error: "policy_gate_audit_unavailable",
     tool_id: input.toolId,
-    rule: RAW_DATA_WRITE_RULE_ID,
+    ...rawDataAuthorityEvidenceFields(),
     reason: input.reason,
     remediation: {
       next_action: "fix_and_retry",
@@ -1527,7 +1548,7 @@ function buildPathResolutionFailureResult(input: {
   const payload = {
     error: "raw_data_sandbox_path_resolution_failed",
     tool_id: input.toolId,
-    rule: RAW_DATA_WRITE_RULE_ID,
+    ...rawDataAuthorityEvidenceFields(),
     reason: input.reason,
     remediation: {
       next_action: "fix_and_retry",
@@ -1550,7 +1571,7 @@ function buildInvalidTimeoutFailureResult(input: {
   const payload = {
     error: "raw_data_sandbox_invalid_timeout",
     tool_id: input.toolId,
-    rule: RAW_DATA_WRITE_RULE_ID,
+    ...rawDataAuthorityEvidenceFields(),
     reason: input.reason,
     remediation: {
       next_action: "fix_and_retry",
@@ -1573,7 +1594,7 @@ function buildProfileSetupFailureResult(input: {
   const payload = {
     error: "raw_data_sandbox_profile_unavailable",
     tool_id: input.toolId,
-    rule: RAW_DATA_WRITE_RULE_ID,
+    ...rawDataAuthorityEvidenceFields(),
     reason: input.reason,
     remediation: {
       next_action: "fix_and_retry",
@@ -1596,7 +1617,7 @@ function buildProcessContainmentFailureResult(input: {
   const payload = {
     error: "policy_gate_process_containment_unavailable",
     tool_id: input.toolId,
-    rule: RAW_DATA_WRITE_RULE_ID,
+    ...rawDataAuthorityEvidenceFields(),
     reason: input.reason,
     remediation: {
       next_action: "fix_and_retry",
@@ -4605,6 +4626,16 @@ function isParentShellWaitSegment(
 
 function rawDataGuardClassForRawData(): RawDataGuardClass {
   return "authority";
+}
+
+function rawDataAuthorityEvidenceFields(): {
+  rule: typeof RAW_DATA_WRITE_RULE_ID;
+  guard_class: RawDataGuardClass;
+} {
+  return {
+    rule: RAW_DATA_WRITE_RULE_ID,
+    guard_class: rawDataGuardClassForRawData()
+  };
 }
 
 function hasKnownRawDataWriteTarget(


### PR DESCRIPTION
## Summary

- Enforces `guardClass` metadata on policy-gate hard guard rules at type level and runtime assembly/evaluation.
- Adds lint-style failures that point at the unclassified guard rule id.
- Tags current M1 policy guards as `authority`, including spawn profile subset and raw-data write advisory.
- Hardens public evidence boundaries for WebSocket `tool.failed` payloads and audit append inputs so proxy/accessor/`toJSON` side effects cannot forge or leak reserved evidence fields.

## Acceptance Mapping

- Unclassified hard guard assembly fails: covered by `policy gate evaluator assembly rejects unclassified hard guard rules`.
- Missing/invalid guard metadata fails with rule identity: covered by `guard_class lint rejects unclassified hard guard rules` and `guard_class lint rejects invalid hard guard classifications`.
- M1 landed guards carry legal metadata: covered by spawn profile subset assertion and raw-data advisory guard-class assertion.
- Repeated public-boundary regressions are covered by WebSocket trusted/generic failure tests and raw-data audit append snapshot tests.

## Verification

- `npx --yes bun@1.2.19 test ./packages/core/src/tools/raw-data-sandbox.test.ts`
- `npx --yes bun@1.2.19 run typecheck`
- `git diff --check`
- `npx --yes bun@1.2.19 run check`
- `openspec validate m1-foundation --strict --no-interactive`
- `git -C zero diff --quiet`
- GitHub CI: docs-links, linux-base, macos-seatbelt, check

## Agent Review

- Reviewer agents used: correctness, invariant/state, security/performance, integration, spec-compliance, test/evidence
- Reviewed head SHA: `b04d9741762d436b83029cf552186aad8a334646`
- Review evidence: consolidated final evidence comment posted on PR #58; local evidence bundle under `.workplans/issue-26/review/round14/`
- OpenSpec change: `m1-foundation`; fixture level: high; selected risk packs: API/schema contract, state/idempotency, integration boundary, security/capability, test/oracle integrity
- Key findings addressed: guard-class enforcement gaps, raw-data advisory/evidence bypasses, WebSocket `tool.failed` reserved-field leakage, audit append proxy/accessor leakage, and repeated public-boundary snapshot regressions were fixed and verified.
- Routed follow-up: `cand-r14-security-perf-1` policy-gate decision validation proxy/accessor hardening is tracked separately before merge because it is a sibling P2 outside #26's `guard_class` acceptance surface. Issue: #59 https://github.com/DankerMu/SHUD-Harness/issues/59

Closes #26
