### PR TITLE
feat(tools): enforce spawn depth and concurrency limits

### DIFF
--- a/packages/core/src/tools/policy-gate-core.test.ts
+++ b/packages/core/src/tools/policy-gate-core.test.ts
@@ -5,9 +5,16 @@ import {
   isReservedAuthorityPolicyErrorId,
   isReservedAuthorityPolicyRuleIdPrefixImpersonation,
   isReservedAuthorityPolicyRuleId,
+  MAX_CONCURRENT_SUBAGENTS,
+  MAX_SPAWN_DEPTH,
   normalizeSpawnAgentInput,
   PolicyGateRemediationSchema,
   RESERVED_AUTHORITY_POLICY_RULE_IDS,
+  SPAWN_CONCURRENCY_LIMIT_RULE,
+  SPAWN_CONCURRENCY_LIMIT_RULE_ID,
+  SPAWN_DEPTH_LIMIT_RULE,
+  SPAWN_DEPTH_LIMIT_RULE_ID,
+  SPAWN_LIMITS_POLICY_REF,
   SPAWN_PROFILE_ALLOWLIST_MAX_ITEMS,
   SPAWN_PROFILE_ALLOWLIST_MAX_TOTAL_CHARS,
   SPAWN_PROFILE_MAX_EXCESS_TOOL_SAMPLES,
@@ -19,6 +26,7 @@ import {
   type PolicyGateToolCall,
   type PolicyRule
 } from "./policy-gate-core";
+import { DEFAULT_SHUD_POLICY_GATE_CONTEXT } from "./policy-gate-registry";
 import { RAW_DATA_WRITE_RULE_ID } from "./raw-data-sandbox";
 import { getRoleToolIds } from "./role-tool-map";
 
@@ -1253,6 +1261,149 @@ describe("spawn profile subset policy rule", () => {
     });
 
     expectSpawnBudgetDeny(decision, "total tool-id characters", tailSentinel);
+  });
+});
+
+describe("spawn limit policy rules", () => {
+  test("default SHUD context includes reserved authority spawn limit rules", () => {
+    const defaultRuleIds = DEFAULT_SHUD_POLICY_GATE_CONTEXT.rules.map((rule) => rule.ruleId);
+
+    expect(defaultRuleIds).toContain(SPAWN_PROFILE_SUBSET_RULE_ID);
+    expect(defaultRuleIds).toContain(SPAWN_DEPTH_LIMIT_RULE_ID);
+    expect(defaultRuleIds).toContain(SPAWN_CONCURRENCY_LIMIT_RULE_ID);
+    expect(RESERVED_AUTHORITY_POLICY_RULE_IDS).toContain(SPAWN_DEPTH_LIMIT_RULE_ID);
+    expect(RESERVED_AUTHORITY_POLICY_RULE_IDS).toContain(SPAWN_CONCURRENCY_LIMIT_RULE_ID);
+    expect(isReservedAuthorityPolicyRuleId(SPAWN_DEPTH_LIMIT_RULE_ID)).toBe(true);
+    expect(isReservedAuthorityPolicyRuleId(SPAWN_CONCURRENCY_LIMIT_RULE_ID)).toBe(true);
+
+    for (const rule of [SPAWN_DEPTH_LIMIT_RULE, SPAWN_CONCURRENCY_LIMIT_RULE]) {
+      expect(rule.guardClass).toBe("authority");
+      expect(rule.guard_class).toBeUndefined();
+    }
+  });
+
+  test("denies spawn_agent when trusted context is already at max spawn depth", () => {
+    const decision = evaluatePolicyGate(
+      {
+        ...spawnToolCall({ role: "worker", tools: ["read"] }),
+        spawnDepth: MAX_SPAWN_DEPTH
+      },
+      DEFAULT_SHUD_POLICY_GATE_CONTEXT
+    );
+
+    expect(decision).toMatchObject({
+      decision: "deny",
+      ruleId: SPAWN_DEPTH_LIMIT_RULE_ID,
+      guardClass: "authority",
+      remediation: {
+        next_action: "adjust_scope",
+        ref: SPAWN_LIMITS_POLICY_REF
+      }
+    });
+    if (decision.decision === "deny") {
+      expect(decision.reason).toContain(`max_spawn_depth=${MAX_SPAWN_DEPTH}`);
+      expect(decision.reason).toContain("spawn depth 2");
+      expect(decision.remediation.hint).toContain("coordinator");
+      expect(PolicyGateRemediationSchema.safeParse(decision.remediation).success).toBe(true);
+    }
+  });
+
+  test("denies spawn_agent when trusted context reaches max concurrent subagents", () => {
+    const decision = evaluatePolicyGate(
+      {
+        ...spawnToolCall({ role: "worker", tools: ["read"] }),
+        activeSubagentCount: MAX_CONCURRENT_SUBAGENTS
+      },
+      DEFAULT_SHUD_POLICY_GATE_CONTEXT
+    );
+
+    expect(decision).toMatchObject({
+      decision: "deny",
+      ruleId: SPAWN_CONCURRENCY_LIMIT_RULE_ID,
+      guardClass: "authority",
+      remediation: {
+        next_action: "adjust_scope",
+        ref: SPAWN_LIMITS_POLICY_REF
+      }
+    });
+    if (decision.decision === "deny") {
+      expect(decision.reason).toContain(
+        `max_concurrent_subagents=${MAX_CONCURRENT_SUBAGENTS}`
+      );
+      expect(decision.remediation.hint).toContain("M1 denies");
+      expect(PolicyGateRemediationSchema.safeParse(decision.remediation).success).toBe(true);
+    }
+  });
+
+  test("allows spawn_agent below trusted depth and concurrency limits", () => {
+    const decision = evaluatePolicyGate(
+      {
+        ...spawnToolCall({ role: "worker", tools: ["read", "sandbox.exec"] }),
+        spawnDepth: MAX_SPAWN_DEPTH - 1,
+        activeSubagentCount: MAX_CONCURRENT_SUBAGENTS - 1
+      },
+      DEFAULT_SHUD_POLICY_GATE_CONTEXT
+    );
+
+    expect(decision).toEqual({ decision: "allow" });
+  });
+
+  test("denies present-invalid trusted spawn depth metadata", () => {
+    for (const spawnDepth of [-1, Number.NaN, 1.5]) {
+      const decision = evaluatePolicyGate(
+        {
+          ...spawnToolCall({ role: "worker", tools: ["read"] }),
+          spawnDepth
+        },
+        DEFAULT_SHUD_POLICY_GATE_CONTEXT
+      );
+
+      expect(decision).toMatchObject({
+        decision: "deny",
+        ruleId: SPAWN_DEPTH_LIMIT_RULE_ID,
+        guardClass: "authority",
+        remediation: {
+          next_action: "adjust_scope",
+          ref: SPAWN_LIMITS_POLICY_REF
+        }
+      });
+    }
+  });
+
+  test("denies present-invalid trusted active subagent count metadata", () => {
+    for (const activeSubagentCount of [-1, Number.NaN, 1.5]) {
+      const decision = evaluatePolicyGate(
+        {
+          ...spawnToolCall({ role: "worker", tools: ["read"] }),
+          activeSubagentCount
+        },
+        DEFAULT_SHUD_POLICY_GATE_CONTEXT
+      );
+
+      expect(decision).toMatchObject({
+        decision: "deny",
+        ruleId: SPAWN_CONCURRENCY_LIMIT_RULE_ID,
+        guardClass: "authority",
+        remediation: {
+          next_action: "adjust_scope",
+          ref: SPAWN_LIMITS_POLICY_REF
+        }
+      });
+    }
+  });
+
+  test("does not treat model-controlled spawn limit input fields as trusted context", () => {
+    const decision = evaluatePolicyGate(
+      spawnToolCall({
+        role: "worker",
+        tools: ["read"],
+        spawnDepth: MAX_SPAWN_DEPTH,
+        activeSubagentCount: MAX_CONCURRENT_SUBAGENTS
+      }),
+      DEFAULT_SHUD_POLICY_GATE_CONTEXT
+    );
+
+    expect(decision).toEqual({ decision: "allow" });
   });
 });
 

--- a/packages/core/src/tools/policy-gate-core.ts
+++ b/packages/core/src/tools/policy-gate-core.ts
@@ -20,9 +20,15 @@ export const PolicyGuardClassSchema = z.enum(["authority", "capability"]);
 export type PolicyGuardClass = z.infer<typeof PolicyGuardClassSchema>;
 
 export const SPAWN_PROFILE_SUBSET_RULE_ID = "spawn-profile-subset";
+export const SPAWN_DEPTH_LIMIT_RULE_ID = "spawn-depth-limit";
+export const SPAWN_CONCURRENCY_LIMIT_RULE_ID = "spawn-concurrency-limit";
 export const TOOL_PARAMETER_SCHEMA_RULE_ID = "tool-parameter-schema-validation";
 export const SPAWN_PROFILE_SUBSET_POLICY_REF =
   "docs/02_ARCHITECTURE/Roles_and_Boundaries.md#0-canonical-agent-role-registry";
+export const SPAWN_LIMITS_POLICY_REF =
+  "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定";
+export const MAX_SPAWN_DEPTH = 1;
+export const MAX_CONCURRENT_SUBAGENTS = 3;
 export const SPAWN_PROFILE_ALLOWLIST_MAX_ITEMS = 64;
 export const SPAWN_PROFILE_TOOL_ID_MAX_CHARS = 128;
 export const SPAWN_PROFILE_ALLOWLIST_MAX_TOTAL_CHARS = 4096;
@@ -32,6 +38,8 @@ export const SPAWN_PROFILE_TEXT_FIELD_MAX_CHARS = 65536;
 export const RESERVED_AUTHORITY_POLICY_RULE_IDS = Object.freeze([
   "raw-data-write",
   SPAWN_PROFILE_SUBSET_RULE_ID,
+  SPAWN_DEPTH_LIMIT_RULE_ID,
+  SPAWN_CONCURRENCY_LIMIT_RULE_ID,
   TOOL_PARAMETER_SCHEMA_RULE_ID
 ] as const);
 
@@ -40,6 +48,8 @@ export interface PolicyGateToolCall {
   role: HarnessRole | "unknown";
   input: unknown;
   workDir?: string;
+  spawnDepth?: number;
+  activeSubagentCount?: number;
 }
 
 export type PolicyRuleDecision =
@@ -421,6 +431,25 @@ export const SPAWN_PROFILE_SUBSET_RULE: PolicyRule = Object.freeze({
   }
 });
 
+export const SPAWN_DEPTH_LIMIT_RULE: PolicyRule = Object.freeze({
+  ruleId: SPAWN_DEPTH_LIMIT_RULE_ID,
+  description: "Reject spawn_agent calls that would exceed Control_Kernel max_spawn_depth.",
+  guardClass: "authority",
+  evaluate(call: PolicyGateToolCall): PolicyRuleDecision {
+    return evaluateSpawnDepthLimit(call);
+  }
+});
+
+export const SPAWN_CONCURRENCY_LIMIT_RULE: PolicyRule = Object.freeze({
+  ruleId: SPAWN_CONCURRENCY_LIMIT_RULE_ID,
+  description:
+    "Reject spawn_agent calls when active subagents already meet max_concurrent_subagents.",
+  guardClass: "authority",
+  evaluate(call: PolicyGateToolCall): PolicyRuleDecision {
+    return evaluateSpawnConcurrencyLimit(call);
+  }
+});
+
 export function evaluateSpawnProfileSubset(call: PolicyGateToolCall): PolicyRuleDecision {
   if (call.toolId !== "spawn_agent") {
     return { decision: "allow" };
@@ -432,6 +461,44 @@ export function evaluateSpawnProfileSubset(call: PolicyGateToolCall): PolicyRule
   }
 
   return evaluateSpawnProfileSubsetSnapshot(parsed.snapshot);
+}
+
+export function evaluateSpawnDepthLimit(call: PolicyGateToolCall): PolicyRuleDecision {
+  if (call.toolId !== "spawn_agent") {
+    return { decision: "allow" };
+  }
+
+  const spawnDepth = readTrustedSpawnLimitCount(call.spawnDepth);
+  if (spawnDepth.kind === "missing") {
+    return { decision: "allow" };
+  }
+  if (spawnDepth.kind === "invalid") {
+    return buildSpawnDepthLimitDeny(MAX_SPAWN_DEPTH);
+  }
+  if (spawnDepth.value < MAX_SPAWN_DEPTH) {
+    return { decision: "allow" };
+  }
+
+  return buildSpawnDepthLimitDeny(spawnDepth.value);
+}
+
+export function evaluateSpawnConcurrencyLimit(call: PolicyGateToolCall): PolicyRuleDecision {
+  if (call.toolId !== "spawn_agent") {
+    return { decision: "allow" };
+  }
+
+  const activeSubagentCount = readTrustedSpawnLimitCount(call.activeSubagentCount);
+  if (activeSubagentCount.kind === "missing") {
+    return { decision: "allow" };
+  }
+  if (activeSubagentCount.kind === "invalid") {
+    return buildSpawnConcurrencyLimitDeny(MAX_CONCURRENT_SUBAGENTS);
+  }
+  if (activeSubagentCount.value < MAX_CONCURRENT_SUBAGENTS) {
+    return { decision: "allow" };
+  }
+
+  return buildSpawnConcurrencyLimitDeny(activeSubagentCount.value);
 }
 
 export function normalizeSpawnAgentInput(
@@ -966,8 +1033,51 @@ function toSpawnProfileGateDeny(
   };
 }
 
+function readTrustedSpawnLimitCount(
+  value: number | undefined
+): { kind: "missing" } | { kind: "invalid" } | { kind: "valid"; value: number } {
+  if (value === undefined) {
+    return { kind: "missing" };
+  }
+  if (!Number.isSafeInteger(value) || value < 0) {
+    return { kind: "invalid" };
+  }
+  return { kind: "valid", value };
+}
+
 function uniqueStrings(values: readonly string[]): string[] {
   return [...new Set(values)];
+}
+
+function buildSpawnDepthLimitDeny(
+  currentDepth: number
+): Extract<PolicyRuleDecision, { decision: "deny" }> {
+  const requestedDepth = currentDepth + 1;
+  return {
+    decision: "deny",
+    reason: `spawn_agent would create spawn depth ${requestedDepth}, exceeding max_spawn_depth=${MAX_SPAWN_DEPTH}.`,
+    remediation: {
+      next_action: "adjust_scope",
+      hint: "Do not chain spawn_agent from an existing subagent; return the work to the coordinator or handle it within the current delegated scope.",
+      ref: SPAWN_LIMITS_POLICY_REF
+    },
+    guardClass: "authority"
+  };
+}
+
+function buildSpawnConcurrencyLimitDeny(
+  activeSubagentCount: number
+): Extract<PolicyRuleDecision, { decision: "deny" }> {
+  return {
+    decision: "deny",
+    reason: `spawn_agent requested while ${activeSubagentCount} subagent(s) are already active, meeting max_concurrent_subagents=${MAX_CONCURRENT_SUBAGENTS}.`,
+    remediation: {
+      next_action: "adjust_scope",
+      hint: "Wait for an active subagent to finish before spawning another one; M1 denies instead of scheduling a queue.",
+      ref: SPAWN_LIMITS_POLICY_REF
+    },
+    guardClass: "authority"
+  };
 }
 
 function buildSpawnProfileMalformedDeny(

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -26,12 +26,17 @@ import type {
 } from "@zero-os/shared";
 import { z } from "zod";
 import {
+  MAX_CONCURRENT_SUBAGENTS,
+  MAX_SPAWN_DEPTH,
   PolicyGateRemediationSchema,
   RESERVED_AUTHORITY_POLICY_RULE_IDS,
+  SPAWN_CONCURRENCY_LIMIT_RULE_ID,
+  SPAWN_DEPTH_LIMIT_RULE_ID,
   SPAWN_PROFILE_ALLOWLIST_MAX_ITEMS,
   SPAWN_PROFILE_MAX_EXCESS_TOOL_SAMPLES,
   SPAWN_PROFILE_SUBSET_POLICY_REF,
   SPAWN_PROFILE_SUBSET_RULE_ID,
+  SPAWN_LIMITS_POLICY_REF,
   TOOL_PARAMETER_SCHEMA_RULE_ID
 } from "./policy-gate-core";
 import {
@@ -299,6 +304,56 @@ describe("policy-gated zero tool registry", () => {
       success: false,
       outputSummary: result.outputSummary
     });
+  });
+
+  test("non-spawn policy calls do not read trusted spawn metadata getters", async () => {
+    const editTool = new RecordingTool("edit");
+    const agentControl = createAgentControlSpy();
+    let activeCountReads = 0;
+    let spawnedByRequestIdReads = 0;
+    let capturedCall: unknown;
+    Object.defineProperty(agentControl.control, "activeAgentCount", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        activeCountReads += 1;
+        throw new Error("activeAgentCount should not be read for edit");
+      }
+    });
+    const toolContext = {
+      ...createToolContext("worker"),
+      agentControl: agentControl.control
+    };
+    Object.defineProperty(toolContext, "spawnedByRequestId", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        spawnedByRequestIdReads += 1;
+        throw new Error("spawnedByRequestId should not be read for edit");
+      }
+    });
+    const wrapped = wrapToolWithPolicyGate(editTool, {
+      evaluate: async (call) => {
+        capturedCall = call;
+        return { decision: "allow" };
+      }
+    });
+
+    const result = await wrapped.run(toolContext, {});
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("edit executed");
+    expect(editTool.calls).toBe(1);
+    expect(activeCountReads).toBe(0);
+    expect(spawnedByRequestIdReads).toBe(0);
+    const call = capturedCall as {
+      toolId?: string;
+      spawnDepth?: unknown;
+      activeSubagentCount?: unknown;
+    };
+    expect(call.toolId).toBe("edit");
+    expect(call).not.toHaveProperty("spawnDepth");
+    expect(call).not.toHaveProperty("activeSubagentCount");
   });
 
   test("non-spawn input preparation failures finalize without executing the inner tool", async () => {
@@ -3994,6 +4049,16 @@ describe("policy-gated zero tool registry", () => {
         ref: SPAWN_PROFILE_SUBSET_POLICY_REF
       },
       {
+        name: "spawn-depth",
+        ruleId: SPAWN_DEPTH_LIMIT_RULE_ID,
+        ref: SPAWN_LIMITS_POLICY_REF
+      },
+      {
+        name: "spawn-concurrency",
+        ruleId: SPAWN_CONCURRENCY_LIMIT_RULE_ID,
+        ref: SPAWN_LIMITS_POLICY_REF
+      },
+      {
         name: "schema",
         ruleId: TOOL_PARAMETER_SCHEMA_RULE_ID,
         ref: "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定"
@@ -4042,6 +4107,16 @@ describe("policy-gated zero tool registry", () => {
         name: "spawn",
         ruleId: SPAWN_PROFILE_SUBSET_RULE_ID,
         ref: SPAWN_PROFILE_SUBSET_POLICY_REF
+      },
+      {
+        name: "spawn-depth",
+        ruleId: SPAWN_DEPTH_LIMIT_RULE_ID,
+        ref: SPAWN_LIMITS_POLICY_REF
+      },
+      {
+        name: "spawn-concurrency",
+        ruleId: SPAWN_CONCURRENCY_LIMIT_RULE_ID,
+        ref: SPAWN_LIMITS_POLICY_REF
       },
       {
         name: "schema",
@@ -4957,6 +5032,222 @@ describe("policy-gated zero tool registry", () => {
         "docs/02_ARCHITECTURE/Roles_and_Boundaries.md#0-canonical-agent-role-registry"
       );
       expect(agentControl.getSpawnCalls()).toBe(0);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("SHUD runtime denies spawn_agent from Zero subagent context before execution", async () => {
+    const fixture = await createRawFixture();
+    try {
+      await writeWorkerRoleFixture(fixture.root);
+      const modelRouter = createSpawnModelRouterStub();
+      const zeroLikeRegistry = new ToolRegistry();
+      zeroLikeRegistry.register(new RecordingTool("spawn_agent"));
+      zeroLikeRegistry.register(new RecordingTool("read"));
+      const agentControl = createAgentControlSpy();
+
+      const registry = createShudRuntimeToolRegistry({
+        tools: zeroLikeRegistry.list(),
+        protectedRawPaths: [fixture.rawRoot],
+        allowedWriteRoots: [fixture.root],
+        tempRoot: fixture.tempRoot,
+        profileRoot: fixture.profileRoot,
+        fuseRules: [],
+        modelRouter
+      });
+
+      const result = await registry.get("spawn_agent")?.run(
+        {
+          ...fixture.context,
+          spawnedByRequestId: "REQ-PARENT-1",
+          agentControl: agentControl.control,
+          projectRoot: fixture.root
+        },
+        {
+          instruction: "Run a worker task.",
+          role: "worker",
+          tools: ["read"]
+        }
+      );
+
+      expect(result?.success).toBe(false);
+      expect(result?.output).toContain("policy_gate_denied");
+      const payload = JSON.parse(result?.output ?? "{}") as {
+        error?: string;
+        ruleId?: string;
+        guard_class?: string;
+        remediation?: {
+          next_action?: string;
+          ref?: string;
+        };
+      };
+      expect(payload.error).toBe("policy_gate_denied");
+      expect(payload.ruleId).toBe(SPAWN_DEPTH_LIMIT_RULE_ID);
+      expect(payload.guard_class).toBe("authority");
+      expect(payload.remediation?.next_action).toBe("adjust_scope");
+      expect(payload.remediation?.ref).toBe(SPAWN_LIMITS_POLICY_REF);
+      expect(PolicyGateRemediationSchema.safeParse(payload.remediation).success).toBe(true);
+      expect(agentControl.getSpawnCalls()).toBe(0);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("SHUD runtime denies spawn_agent at trusted max active subagents before execution", async () => {
+    const fixture = await createRawFixture();
+    try {
+      await writeWorkerRoleFixture(fixture.root);
+      const modelRouter = createSpawnModelRouterStub();
+      const zeroLikeRegistry = new ToolRegistry();
+      zeroLikeRegistry.register(new RecordingTool("spawn_agent"));
+      zeroLikeRegistry.register(new RecordingTool("read"));
+      const agentControl = createAgentControlSpy();
+      let activeCountReads = 0;
+      Object.defineProperty(agentControl.control, "activeAgentCount", {
+        configurable: true,
+        enumerable: true,
+        get() {
+          activeCountReads += 1;
+          return MAX_CONCURRENT_SUBAGENTS;
+        }
+      });
+
+      const registry = createShudRuntimeToolRegistry({
+        tools: zeroLikeRegistry.list(),
+        protectedRawPaths: [fixture.rawRoot],
+        allowedWriteRoots: [fixture.root],
+        tempRoot: fixture.tempRoot,
+        profileRoot: fixture.profileRoot,
+        fuseRules: [],
+        modelRouter
+      });
+
+      const result = await registry.get("spawn_agent")?.run(
+        {
+          ...fixture.context,
+          agentControl: agentControl.control,
+          projectRoot: fixture.root
+        },
+        {
+          instruction: "Run a worker task.",
+          role: "worker",
+          tools: ["read"]
+        }
+      );
+
+      expect(result?.success).toBe(false);
+      expect(result?.output).toContain("policy_gate_denied");
+      const payload = JSON.parse(result?.output ?? "{}") as {
+        error?: string;
+        ruleId?: string;
+        guard_class?: string;
+        remediation?: {
+          next_action?: string;
+          ref?: string;
+        };
+      };
+      expect(payload.error).toBe("policy_gate_denied");
+      expect(payload.ruleId).toBe(SPAWN_CONCURRENCY_LIMIT_RULE_ID);
+      expect(payload.guard_class).toBe("authority");
+      expect(payload.remediation?.next_action).toBe("adjust_scope");
+      expect(payload.remediation?.ref).toBe(SPAWN_LIMITS_POLICY_REF);
+      expect(PolicyGateRemediationSchema.safeParse(payload.remediation).success).toBe(true);
+      expect(activeCountReads).toBe(1);
+      expect(agentControl.getSpawnCalls()).toBe(0);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("SHUD runtime denies malformed trusted active subagent count before execution", async () => {
+    const fixture = await createRawFixture();
+    try {
+      await writeWorkerRoleFixture(fixture.root);
+      const modelRouter = createSpawnModelRouterStub();
+      const zeroLikeRegistry = new ToolRegistry();
+      zeroLikeRegistry.register(new RecordingTool("spawn_agent"));
+      zeroLikeRegistry.register(new RecordingTool("read"));
+      const agentControl = createAgentControlSpy();
+      agentControl.control.activeAgentCount = "3" as unknown as number;
+
+      const registry = createShudRuntimeToolRegistry({
+        tools: zeroLikeRegistry.list(),
+        protectedRawPaths: [fixture.rawRoot],
+        allowedWriteRoots: [fixture.root],
+        tempRoot: fixture.tempRoot,
+        profileRoot: fixture.profileRoot,
+        fuseRules: [],
+        modelRouter
+      });
+
+      const result = await registry.get("spawn_agent")?.run(
+        {
+          ...fixture.context,
+          agentControl: agentControl.control,
+          projectRoot: fixture.root
+        },
+        {
+          instruction: "Run a worker task.",
+          role: "worker",
+          tools: ["read"]
+        }
+      );
+
+      expect(result?.success).toBe(false);
+      const payload = JSON.parse(result?.output ?? "{}") as {
+        error?: string;
+        ruleId?: string;
+        guard_class?: string;
+      };
+      expect(payload.error).toBe("policy_gate_denied");
+      expect(payload.ruleId).toBe(SPAWN_CONCURRENCY_LIMIT_RULE_ID);
+      expect(payload.guard_class).toBe("authority");
+      expect(agentControl.getSpawnCalls()).toBe(0);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("SHUD runtime ignores model-controlled spawn limit fields below trusted limits", async () => {
+    const fixture = await createRawFixture();
+    try {
+      await writeWorkerRoleFixture(fixture.root);
+      const modelRouter = createSpawnModelRouterStub();
+      const zeroLikeRegistry = new ToolRegistry();
+      zeroLikeRegistry.register(new RecordingTool("spawn_agent"));
+      zeroLikeRegistry.register(new RecordingTool("read"));
+      const agentControl = createAgentControlSpy();
+
+      const registry = createShudRuntimeToolRegistry({
+        tools: zeroLikeRegistry.list(),
+        protectedRawPaths: [fixture.rawRoot],
+        allowedWriteRoots: [fixture.root],
+        tempRoot: fixture.tempRoot,
+        profileRoot: fixture.profileRoot,
+        fuseRules: [],
+        modelRouter
+      });
+
+      const result = await registry.get("spawn_agent")?.run(
+        {
+          ...fixture.context,
+          agentControl: agentControl.control,
+          projectRoot: fixture.root
+        },
+        {
+          instruction: "Run a worker task.",
+          role: "worker",
+          tools: ["read"],
+          spawnDepth: MAX_SPAWN_DEPTH,
+          activeSubagentCount: MAX_CONCURRENT_SUBAGENTS
+        }
+      );
+
+      expect(result?.success).toBe(true);
+      expect(result?.output).not.toContain("policy_gate_denied");
+      expect(agentControl.getSpawnCalls()).toBe(1);
+      expect(getCapturedToolNames(agentControl.getLastAgentContext())).toEqual(["read"]);
     } finally {
       await fixture.cleanup();
     }

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -22,6 +22,8 @@ import {
   PolicyGuardClassSchema,
   PolicyGateRemediationSchema,
   SPAWN_PROFILE_MAX_EXCESS_TOOL_SAMPLES,
+  SPAWN_CONCURRENCY_LIMIT_RULE,
+  SPAWN_DEPTH_LIMIT_RULE,
   SPAWN_PROFILE_SUBSET_POLICY_REF,
   SPAWN_PROFILE_SUBSET_RULE,
   SPAWN_PROFILE_SUBSET_RULE_ID,
@@ -201,7 +203,11 @@ function canExecutionValidatorReturnReservedAuthorityDecision(
 }
 
 export const DEFAULT_SHUD_POLICY_GATE_CONTEXT: PolicyGateContext = Object.freeze({
-  rules: Object.freeze([SPAWN_PROFILE_SUBSET_RULE])
+  rules: Object.freeze([
+    SPAWN_PROFILE_SUBSET_RULE,
+    SPAWN_DEPTH_LIMIT_RULE,
+    SPAWN_CONCURRENCY_LIMIT_RULE
+  ])
 });
 
 // Mirrors Zero's sub-agent hard filter at the pinned zero submodule boundary.
@@ -1064,12 +1070,7 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
     let candidate: PolicyGateDecisionInput;
     try {
       candidate = await this.#evaluate(
-        {
-          toolId: this.#policyGateToolId,
-          role,
-          input: evaluatorInput,
-          workDir: toolContext.workDir
-        },
+        buildPolicyGateToolCall(this.#policyGateToolId, role, evaluatorInput, toolContext),
         {
           tool: this,
           toolContext
@@ -1102,6 +1103,48 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       };
     }
   }
+}
+
+function buildPolicyGateToolCall(
+  toolId: string,
+  role: HarnessRole | "unknown",
+  input: unknown,
+  toolContext: ToolContext
+): PolicyGateToolCall {
+  const baseCall: PolicyGateToolCall = {
+    toolId,
+    role,
+    input,
+    workDir: toolContext.workDir
+  };
+
+  if (toolId !== "spawn_agent") {
+    return baseCall;
+  }
+
+  return {
+    ...baseCall,
+    spawnDepth: resolveTrustedSpawnDepth(toolContext),
+    activeSubagentCount: resolveTrustedActiveSubagentCount(toolContext)
+  };
+}
+
+function resolveTrustedSpawnDepth(toolContext: ToolContext): number | undefined {
+  return toolContext.spawnedByRequestId !== undefined ? 1 : undefined;
+}
+
+function resolveTrustedActiveSubagentCount(toolContext: ToolContext): number | undefined {
+  if (!toolContext.agentControl) {
+    return undefined;
+  }
+  const count = toolContext.agentControl.activeAgentCount;
+  return readTrustedNonNegativeInteger(count) ?? Number.MAX_SAFE_INTEGER;
+}
+
+function readTrustedNonNegativeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : undefined;
 }
 
 function policyGateErrorToolResult(error: unknown): ToolResult {

--- a/packages/core/src/tools/raw-data-sandbox.test.ts
+++ b/packages/core/src/tools/raw-data-sandbox.test.ts
@@ -40,8 +40,7 @@ import {
 } from "./raw-data-sandbox";
 import {
   evaluatePolicyGate,
-  SPAWN_PROFILE_SUBSET_RULE_ID,
-  TOOL_PARAMETER_SCHEMA_RULE_ID
+  RESERVED_AUTHORITY_POLICY_RULE_IDS
 } from "./policy-gate-core";
 import {
   completeRawDataSandboxInvocationProcessesForTest,
@@ -55,6 +54,9 @@ import {
 const requireSeatbeltTests = process.env.SHUD_REQUIRE_SEATBELT_TESTS === "1";
 const hasSeatbelt = process.platform === "darwin" && existsSync("/usr/bin/sandbox-exec");
 const hasPython3 = commandExistsSync("python3");
+const RESERVED_NON_RAW_AUTHORITY_POLICY_RULE_IDS = RESERVED_AUTHORITY_POLICY_RULE_IDS.filter(
+  (ruleId) => ruleId !== RAW_DATA_WRITE_RULE_ID
+);
 if (requireSeatbeltTests) {
   if (process.platform !== "darwin") {
     throw new Error("SHUD_REQUIRE_SEATBELT_TESTS requires macOS.");
@@ -566,62 +568,23 @@ describe("raw data seatbelt sandbox", () => {
   test("public audit append rejects reserved non-raw rules without authority guard_class", async () => {
     const fixture = await createFixture();
     try {
-      const cases = [
+      const cases = RESERVED_NON_RAW_AUTHORITY_POLICY_RULE_IDS.flatMap((rule) => [
         {
-          name: "spawn-missing",
-          rule: SPAWN_PROFILE_SUBSET_RULE_ID,
-          row: auditRowWithGuardClass(
-            reservedNonRawAuditRow(SPAWN_PROFILE_SUBSET_RULE_ID),
-            undefined
-          ),
+          name: `${rule}-missing`,
+          row: auditRowWithGuardClass(reservedNonRawAuditRow(rule), undefined),
           expected: "Reserved authority policy audit rows require guard_class authority"
         },
         {
-          name: "spawn-capability",
-          rule: SPAWN_PROFILE_SUBSET_RULE_ID,
-          row: auditRowWithGuardClass(
-            reservedNonRawAuditRow(SPAWN_PROFILE_SUBSET_RULE_ID),
-            "capability"
-          ),
+          name: `${rule}-capability`,
+          row: auditRowWithGuardClass(reservedNonRawAuditRow(rule), "capability"),
           expected: "Reserved authority policy audit rows require guard_class authority"
         },
         {
-          name: "spawn-invalid",
-          rule: SPAWN_PROFILE_SUBSET_RULE_ID,
-          row: auditRowWithGuardClass(
-            reservedNonRawAuditRow(SPAWN_PROFILE_SUBSET_RULE_ID),
-            "temporary" as never
-          ),
-          expected: "Policy gate audit rows guard_class must be authority or capability"
-        },
-        {
-          name: "schema-missing",
-          rule: TOOL_PARAMETER_SCHEMA_RULE_ID,
-          row: auditRowWithGuardClass(
-            reservedNonRawAuditRow(TOOL_PARAMETER_SCHEMA_RULE_ID),
-            undefined
-          ),
-          expected: "Reserved authority policy audit rows require guard_class authority"
-        },
-        {
-          name: "schema-capability",
-          rule: TOOL_PARAMETER_SCHEMA_RULE_ID,
-          row: auditRowWithGuardClass(
-            reservedNonRawAuditRow(TOOL_PARAMETER_SCHEMA_RULE_ID),
-            "capability"
-          ),
-          expected: "Reserved authority policy audit rows require guard_class authority"
-        },
-        {
-          name: "schema-invalid",
-          rule: TOOL_PARAMETER_SCHEMA_RULE_ID,
-          row: auditRowWithGuardClass(
-            reservedNonRawAuditRow(TOOL_PARAMETER_SCHEMA_RULE_ID),
-            "temporary" as never
-          ),
+          name: `${rule}-invalid`,
+          row: auditRowWithGuardClass(reservedNonRawAuditRow(rule), "temporary" as never),
           expected: "Policy gate audit rows guard_class must be authority or capability"
         }
-      ] as const;
+      ]);
 
       for (const testCase of cases) {
         await expect(
@@ -641,56 +604,23 @@ describe("raw data seatbelt sandbox", () => {
   test("public audit append rejects reserved non-raw error_id prefixes without authority guard_class", async () => {
     const fixture = await createFixture();
     try {
-      const cases = [
+      const cases = RESERVED_NON_RAW_AUTHORITY_POLICY_RULE_IDS.flatMap((rule) => [
         {
-          name: "spawn-missing",
-          row: auditRowWithGuardClass(
-            reservedNonRawErrorIdAuditRow(SPAWN_PROFILE_SUBSET_RULE_ID),
-            undefined
-          ),
+          name: `${rule}-missing`,
+          row: auditRowWithGuardClass(reservedNonRawErrorIdAuditRow(rule), undefined),
           expected: "Reserved authority policy audit rows require guard_class authority"
         },
         {
-          name: "spawn-capability",
-          row: auditRowWithGuardClass(
-            reservedNonRawErrorIdAuditRow(SPAWN_PROFILE_SUBSET_RULE_ID),
-            "capability"
-          ),
+          name: `${rule}-capability`,
+          row: auditRowWithGuardClass(reservedNonRawErrorIdAuditRow(rule), "capability"),
           expected: "Reserved authority policy audit rows require guard_class authority"
         },
         {
-          name: "spawn-invalid",
-          row: auditRowWithGuardClass(
-            reservedNonRawErrorIdAuditRow(SPAWN_PROFILE_SUBSET_RULE_ID),
-            "temporary" as never
-          ),
-          expected: "Policy gate audit rows guard_class must be authority or capability"
-        },
-        {
-          name: "schema-missing",
-          row: auditRowWithGuardClass(
-            reservedNonRawErrorIdAuditRow(TOOL_PARAMETER_SCHEMA_RULE_ID),
-            undefined
-          ),
-          expected: "Reserved authority policy audit rows require guard_class authority"
-        },
-        {
-          name: "schema-capability",
-          row: auditRowWithGuardClass(
-            reservedNonRawErrorIdAuditRow(TOOL_PARAMETER_SCHEMA_RULE_ID),
-            "capability"
-          ),
-          expected: "Reserved authority policy audit rows require guard_class authority"
-        },
-        {
-          name: "schema-invalid",
-          row: auditRowWithGuardClass(
-            reservedNonRawErrorIdAuditRow(TOOL_PARAMETER_SCHEMA_RULE_ID),
-            "temporary" as never
-          ),
+          name: `${rule}-invalid`,
+          row: auditRowWithGuardClass(reservedNonRawErrorIdAuditRow(rule), "temporary" as never),
           expected: "Policy gate audit rows guard_class must be authority or capability"
         }
-      ] as const;
+      ]);
 
       for (const testCase of cases) {
         await expect(
@@ -710,7 +640,7 @@ describe("raw data seatbelt sandbox", () => {
   test("public audit append rejects reserved non-raw authority guard_class", async () => {
     const fixture = await createFixture();
     try {
-      for (const rule of [SPAWN_PROFILE_SUBSET_RULE_ID, TOOL_PARAMETER_SCHEMA_RULE_ID]) {
+      for (const rule of RESERVED_NON_RAW_AUTHORITY_POLICY_RULE_IDS) {
         await expect(
           appendPolicyGateAuditRow({
             workspaceRoot: fixture.root,
@@ -741,11 +671,7 @@ describe("raw data seatbelt sandbox", () => {
   test("public audit append rejects reserved rule prefix impersonation", async () => {
     const fixture = await createFixture();
     try {
-      for (const rule of [
-        RAW_DATA_WRITE_RULE_ID,
-        SPAWN_PROFILE_SUBSET_RULE_ID,
-        TOOL_PARAMETER_SCHEMA_RULE_ID
-      ]) {
+      for (const rule of RESERVED_AUTHORITY_POLICY_RULE_IDS) {
         await expect(
           appendPolicyGateAuditRow({
             workspaceRoot: fixture.root,
@@ -768,11 +694,7 @@ describe("raw data seatbelt sandbox", () => {
   test("public audit append rejects exact reserved rules and reserved error_id prefixes", async () => {
     const fixture = await createFixture();
     try {
-      for (const rule of [
-        RAW_DATA_WRITE_RULE_ID,
-        SPAWN_PROFILE_SUBSET_RULE_ID,
-        TOOL_PARAMETER_SCHEMA_RULE_ID
-      ]) {
+      for (const rule of RESERVED_AUTHORITY_POLICY_RULE_IDS) {
         const expected =
           rule === RAW_DATA_WRITE_RULE_ID
             ? "Raw-data authority audit rows require trusted producer evidence"


### PR DESCRIPTION
## Summary

- Adds `spawn-depth-limit` and `spawn-concurrency-limit` authority hard guards to the default SHUD policy-gate context.
- Carries trusted spawn metadata through the policy-gated tool wrapper so `spawn_agent` can deny depth and active-subagent limit violations before inner execution.
- Scopes trusted spawn metadata reads to `spawn_agent` so ordinary policy-gated tools do not inherit `activeAgentCount` history-scan overhead.
- Adds pure policy tests, registry injection-point tests, and dynamic raw audit reserved-id coverage for the expanded authority rule set.

## Acceptance Mapping

- Depth=1 subagent spawn chain denies the would-be depth 2 call with `remediation{next_action,hint,ref}` pointing to Control_Kernel §5.
- Active subagents at 3 denies a new `spawn_agent` call and does not invoke `agentControl.spawn`.
- Both new guards are `authority`, reserved, and included in `DEFAULT_SHUD_POLICY_GATE_CONTEXT`.
- Model-controlled `spawnDepth` / `activeSubagentCount` input fields are ignored; only trusted policy-call metadata is used.
- Non-`spawn_agent` tools do not read spawn-only trusted metadata getters.

## Verification

- `npx --yes bun@1.2.19 test ./packages/core/src/tools/policy-gate-core.test.ts ./packages/core/src/tools/policy-gate-registry.test.ts`
- `npx --yes bun@1.2.19 test ./packages/core/src/tools/raw-data-sandbox.test.ts`
- `npx --yes bun@1.2.19 run typecheck`
- `git diff --check`
- `git -C zero diff --quiet`
- `openspec validate m1-foundation --strict --no-interactive`
- `npx --yes bun@1.2.19 run check`

## Agent Review

- Reviewer agents used: review-correctness, review-integration, review-security-perf, review-test-evidence, final-gap-sweep.
- Reviewed head SHA: `1d3d5feb952241a71c3ecd74cbdb0728e307af7e`
- Review evidence: https://github.com/DankerMu/SHUD-Harness/pull/60#issuecomment-4904933094
- Chinese work summary: https://github.com/DankerMu/SHUD-Harness/pull/60#issuecomment-4904933116
- OpenSpec change: `m1-foundation`; fixture level: expanded; selected risk packs: Public API/tool registry entry, Concurrency/shared state/ordering, Resource limits, Error handling/remediation, Zero adapter/tool registry/agent role governance.
- Key findings addressed: depth source now derives from Zero `ToolContext.spawnedByRequestId`; invalid trusted metadata fails closed; non-spawn tools no longer read spawn-only trusted metadata. Direct concurrent spawn reservation is routed to follow-up #61 as M3 scheduling work.

Closes #27
