### PR TITLE
fix(tools): harden policy decision snapshots

### DIFF
--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -471,3 +471,84 @@ Review focus:
 - The description-section check is exact enough to fail missing required sections while preserving existing valid tools.
 - Zod validation failures are returned as structured policy-gate-style denials and do not execute inner tools.
 - Existing registry and sandbox behavior remains compatible.
+
+## Subagent Workflow Fixture - Issue #59
+
+Fixture level: expanded; repair intensity: high
+Project profile: SHUD-Harness
+Change surface:
+- `packages/core/src/tools/policy-gate-registry.ts`
+- `packages/core/src/tools/policy-gate-registry.test.ts`
+
+Must preserve:
+- Existing evaluator and execution-validator allow/deny semantics.
+- Reserved authority `ruleId` and `guard_class` fail-closed behavior from #26/#27.
+- Inner tools are not executed when decision validation fails.
+- `zero/` remains source-clean and pinned; no Zero source edits.
+
+Must add/change:
+- Policy-gate decision candidates from custom evaluators and execution validators are snapshotted as plain data before validation reads identity fields.
+- Proxy-backed, accessor-backed, or enumerable-`toJSON` decision objects fail closed with a stable policy-gate validation error.
+- Trap text or accessor-thrown sentinel text is not echoed through `ToolResult.output` or `outputSummary`.
+
+Risk packs considered:
+- Public API / CLI / script entry: selected - custom evaluators and execution validators are public extension seams for wrapped tools.
+- Config / project setup: not selected - no package manager, provider, or environment setup changes.
+- File IO / path safety / overwrite: not selected - no file mutation behavior beyond tests.
+- Schema / columns / units / field names: selected - policy decision payload shape is a structured contract.
+- Auth / permissions / secrets: selected - reserved authority decisions must not be spoofed or downgraded through malformed payloads.
+- Concurrency / shared state / ordering: not selected - no shared runtime state or scheduling changes.
+- Resource limits / large input / discovery: selected - snapshotting must bound traversal and reject hostile objects without executing traps.
+- Legacy compatibility / examples: selected - existing policy-gate, spawn subset, and raw sandbox tests must remain green.
+- Error handling / rollback / partial outputs: selected - invalid decisions must fail closed before side effects and with stable error text.
+- Release / packaging / dependency compatibility: selected - no new dependency; Bun/TypeScript checks must remain compatible.
+- Documentation / migration notes: selected - PR evidence must explain this is a #26 review follow-up and not a policy semantic change.
+Domain packs:
+- Scientific governance / PI gate / evidence lineage: not selected - no scientific decision or evidence claim changes.
+- Hydrology runtime / SHUD-rSHUD-AutoSHUD compatibility: not selected - no solver/runtime behavior changes.
+- Zero adapter / tool registry / agent role governance: selected - policy-gate wrapper authority is the shared governance boundary.
+
+Invariant Matrix:
+- Governing invariant: Policy-gate decisions from extension seams must be validated only from bounded, plain-data snapshots, so hostile objects cannot execute code during validation or control stable error text.
+- Source-of-truth identity/contract: `PolicyGateDecision` / `PolicyGateDecisionInput`, `PolicyGateRemediationSchema`, reserved authority rule id helpers, and `PolicyGateDecisionValidationError`.
+- Producers: custom policy evaluators and execution validators.
+- Validators/preflight: `validatePolicyGateDecision`, `validatePolicyGateDenyDecision`, and the decision-candidate snapshot helper.
+- Storage/cache/query: none - decisions are per-call in-memory payloads.
+- Public routes/entrypoints: `wrapToolWithPolicyGate(...).run(...)`, `createShudPolicyGateEvaluator(...)`, and execution-validator paths.
+- Frontend/downstream consumers: `ToolResult.output`, `ToolResult.outputSummary`, `policy_gate_denied` payload consumers, and running-tool terminal metadata.
+- Failure paths/rollback/stale state: malformed/proxy/accessor/toJSON decision candidates fail closed before inner execution and without untrusted trap text.
+- Evidence/audit/readiness: PR evidence and review-loop log record #59 as a #26 follow-up hardening, not a policy semantic change.
+- Regression rows:
+  - Plain valid allow/deny decision -> existing allow/deny semantics and structured `policy_gate_denied` payloads are preserved.
+  - Evaluator proxy/accessor decision -> `success=false`, stable `Invalid policy gate decision...` in `output` and `outputSummary`, sentinel/trap text absent from both, no `policy_gate_denied`, inner tool call count `0`.
+  - Execution-validator proxy/accessor deny decision -> same stable failure contract and inner tool call count `0`.
+  - Enumerable `toJSON` decision candidate -> rejected or ignored without invoking `toJSON`, without sentinel text leak, and without changing validation semantics.
+  - Over-depth or over-wide decision object -> bounded fail-closed validation result or explicit non-goal rationale; no unbounded traversal.
+
+Boundary-surface checklist:
+- Shared helper roots: `policy-gate-registry.ts` decision validation helpers and policy wrapper error-result builders.
+- Public entrypoints: custom evaluator path, execution-validator path, and direct `createShudPolicyGateEvaluator` custom path.
+- Read surfaces: decision candidate own descriptors only; no accessor/proxy trap execution.
+- Write/delete/overwrite surfaces: none.
+- Producer/consumer evidence boundaries: candidate decision object -> validation snapshot -> `PolicyGateDecision` or stable failed `ToolResult`.
+- Stale-state/idempotency boundaries: none - per-call validation only.
+- Unchanged downstream consumers: ordinary plain-object allow/deny decisions, reserved authority validation tests, raw-data sandbox policy-gate composition tests, and running tool handle finalization.
+
+Required evidence:
+- Evaluator returns proxy/accessor decision -> `success=false`, stable `Invalid policy gate decision...` in `output`/`outputSummary`, sentinel trap text absent from both, no `policy_gate_denied`, inner tool call count `0`.
+- Execution validator returns proxy/accessor deny decision -> `success=false`, stable `Invalid policy gate decision...` in `output`/`outputSummary`, sentinel trap text absent from both, no `policy_gate_denied`, inner tool call count `0`.
+- Enumerable `toJSON` on a decision candidate -> rejected or ignored without invoking `toJSON`, without sentinel text leak, and without affecting valid plain-object decision behavior.
+- Resource-boundary evidence: snapshotting rejects or bounds over-depth/over-wide decision candidates, or records a precise non-goal if the snapshot only reads the first-level decision contract by descriptor.
+- Existing reserved authority decision validation tests remain green.
+- PR evidence states #59 is a #26 review follow-up and not a policy semantic change.
+- `bun run test:policy-gate`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`.
+
+Non-goals:
+- WebSocket and audit public-input snapshots already covered by #26.
+- Changing policy rule semantics, reserved rule ids, `guard_class` taxonomy, or raw-data sandbox behavior.
+
+Review focus:
+- Decision validation reads only a stable, plain-data snapshot and never invokes user-supplied getters, proxies, or `toJSON`.
+- Stable validation errors do not contain untrusted trap text.
+- The evaluator and execution-validator paths are both covered.
+- Existing policy-gate denial payloads remain compatible for ordinary plain objects.

--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -477,6 +477,8 @@ Review focus:
 Fixture level: expanded; repair intensity: high
 Project profile: SHUD-Harness
 Change surface:
+- `packages/core/src/tools/policy-gate-core.ts`
+- `packages/core/src/tools/policy-gate-core.test.ts`
 - `packages/core/src/tools/policy-gate-registry.ts`
 - `packages/core/src/tools/policy-gate-registry.test.ts`
 
@@ -488,6 +490,7 @@ Must preserve:
 
 Must add/change:
 - Policy-gate decision candidates from custom evaluators and execution validators are snapshotted as plain data before validation reads identity fields.
+- Rule decisions returned by `PolicyRule.evaluate()` through `createPolicyGateEvaluator(...)` are snapshotted as plain data before `evaluatePolicyGate(...)` reads identity fields.
 - Proxy-backed, accessor-backed, or enumerable-`toJSON` decision objects fail closed with a stable policy-gate validation error.
 - Trap text or accessor-thrown sentinel text is not echoed through `ToolResult.output` or `outputSummary`.
 
@@ -511,8 +514,8 @@ Domain packs:
 Invariant Matrix:
 - Governing invariant: Policy-gate decisions from extension seams must be validated only from bounded, plain-data snapshots, so hostile objects cannot execute code during validation or control stable error text.
 - Source-of-truth identity/contract: `PolicyGateDecision` / `PolicyGateDecisionInput`, `PolicyGateRemediationSchema`, reserved authority rule id helpers, and `PolicyGateDecisionValidationError`.
-- Producers: custom policy evaluators and execution validators.
-- Validators/preflight: `validatePolicyGateDecision`, `validatePolicyGateDenyDecision`, and the decision-candidate snapshot helper.
+- Producers: custom policy evaluators, execution validators, and custom `PolicyRule.evaluate()` functions.
+- Validators/preflight: `evaluatePolicyGate`, `validatePolicyGateDecision`, `validatePolicyGateDenyDecision`, and the decision-candidate snapshot helpers.
 - Storage/cache/query: none - decisions are per-call in-memory payloads.
 - Public routes/entrypoints: `wrapToolWithPolicyGate(...).run(...)`, `createShudPolicyGateEvaluator(...)`, and execution-validator paths.
 - Frontend/downstream consumers: `ToolResult.output`, `ToolResult.outputSummary`, `policy_gate_denied` payload consumers, and running-tool terminal metadata.
@@ -522,12 +525,13 @@ Invariant Matrix:
   - Plain valid allow/deny decision -> existing allow/deny semantics and structured `policy_gate_denied` payloads are preserved.
   - Evaluator proxy/accessor decision -> `success=false`, stable `Invalid policy gate decision...` in `output` and `outputSummary`, sentinel/trap text absent from both, no `policy_gate_denied`, inner tool call count `0`.
   - Execution-validator proxy/accessor deny decision -> same stable failure contract and inner tool call count `0`.
+  - Rule-based evaluator proxy/accessor decision via `createPolicyGateEvaluator(...)` -> same stable failure contract and inner tool call count `0` when wrapped.
   - Enumerable `toJSON` decision candidate -> rejected or ignored without invoking `toJSON`, without sentinel text leak, and without changing validation semantics.
   - Over-depth or over-wide decision object -> bounded fail-closed validation result or explicit non-goal rationale; no unbounded traversal.
 
 Boundary-surface checklist:
-- Shared helper roots: `policy-gate-registry.ts` decision validation helpers and policy wrapper error-result builders.
-- Public entrypoints: custom evaluator path, execution-validator path, and direct `createShudPolicyGateEvaluator` custom path.
+- Shared helper roots: `policy-gate-core.ts` rule evaluation helpers, `policy-gate-registry.ts` decision validation helpers, and policy wrapper error-result builders.
+- Public entrypoints: custom evaluator path, execution-validator path, direct `createShudPolicyGateEvaluator` custom path, and `createPolicyGateEvaluator(...)` rule-based custom context path.
 - Read surfaces: decision candidate own descriptors only; no accessor/proxy trap execution.
 - Write/delete/overwrite surfaces: none.
 - Producer/consumer evidence boundaries: candidate decision object -> validation snapshot -> `PolicyGateDecision` or stable failed `ToolResult`.
@@ -537,6 +541,8 @@ Boundary-surface checklist:
 Required evidence:
 - Evaluator returns proxy/accessor decision -> `success=false`, stable `Invalid policy gate decision...` in `output`/`outputSummary`, sentinel trap text absent from both, no `policy_gate_denied`, inner tool call count `0`.
 - Execution validator returns proxy/accessor deny decision -> `success=false`, stable `Invalid policy gate decision...` in `output`/`outputSummary`, sentinel trap text absent from both, no `policy_gate_denied`, inner tool call count `0`.
+- Custom `PolicyRule.evaluate()` returns proxy/accessor decision through `createPolicyGateEvaluator(...)` -> stable `PolicyGateDecisionValidationError`; when wrapped, sentinel trap text absent from `output`/`outputSummary`, no `policy_gate_denied`, and inner tool call count `0`.
+- Consumed nested `remediation` proxy/accessor fields in evaluator and execution-validator decisions -> stable invalid-decision failure without sentinel leak and without inner execution.
 - Enumerable `toJSON` on a decision candidate -> rejected or ignored without invoking `toJSON`, without sentinel text leak, and without affecting valid plain-object decision behavior.
 - Resource-boundary evidence: snapshotting rejects or bounds over-depth/over-wide decision candidates, or records a precise non-goal if the snapshot only reads the first-level decision contract by descriptor.
 - Existing reserved authority decision validation tests remain green.
@@ -550,5 +556,5 @@ Non-goals:
 Review focus:
 - Decision validation reads only a stable, plain-data snapshot and never invokes user-supplied getters, proxies, or `toJSON`.
 - Stable validation errors do not contain untrusted trap text.
-- The evaluator and execution-validator paths are both covered.
+- The custom evaluator, execution-validator, and rule-based evaluator paths are covered.
 - Existing policy-gate denial payloads remain compatible for ordinary plain objects.

--- a/packages/core/src/tools/policy-gate-core.test.ts
+++ b/packages/core/src/tools/policy-gate-core.test.ts
@@ -8,6 +8,7 @@ import {
   MAX_CONCURRENT_SUBAGENTS,
   MAX_SPAWN_DEPTH,
   normalizeSpawnAgentInput,
+  PolicyGateDecisionValidationError,
   PolicyGateRemediationSchema,
   RESERVED_AUTHORITY_POLICY_RULE_IDS,
   SPAWN_CONCURRENCY_LIMIT_RULE,
@@ -565,6 +566,199 @@ describe("policy gate pure evaluator", () => {
         ]
       })
     ).toThrow("next_action");
+  });
+
+  test("rule decision snapshot rejects proxy results without reading traps", () => {
+    const sentinel = "RULE_DECISION_PROXY_SECRET";
+    let getCalls = 0;
+    let descriptorCalls = 0;
+    const proxyDecision = new Proxy(
+      {
+        decision: "deny" as const,
+        reason: "proxy-backed rule decisions should be rejected",
+        remediation: sampleRemediation()
+      },
+      {
+        get() {
+          getCalls += 1;
+          throw new Error(sentinel);
+        },
+        getOwnPropertyDescriptor() {
+          descriptorCalls += 1;
+          throw new Error(sentinel);
+        }
+      }
+    );
+
+    const error = capturePolicyGateError(() =>
+      evaluatePolicyGate(sampleToolCall(), {
+        rules: [
+          {
+            ruleId: "proxy-rule-decision",
+            description: "Returns a proxy-backed decision.",
+            guardClass: "capability",
+            evaluate: () => proxyDecision as never
+          }
+        ]
+      })
+    );
+
+    expect(error).toBeInstanceOf(PolicyGateDecisionValidationError);
+    expect((error as Error).message).toBe(
+      "Invalid policy gate decision for proxy-rule-decision: decision"
+    );
+    expect((error as Error).message).not.toContain(sentinel);
+    expect(getCalls).toBe(0);
+    expect(descriptorCalls).toBe(0);
+  });
+
+  test("rule decision snapshot rejects accessor result fields without invoking getters", () => {
+    const sentinel = "RULE_DECISION_ACCESSOR_SECRET";
+    let decisionReads = 0;
+    const accessorDecision: Record<string, unknown> = {
+      reason: "accessor-backed decision fields should be rejected",
+      remediation: sampleRemediation()
+    };
+    Object.defineProperty(accessorDecision, "decision", {
+      enumerable: true,
+      get() {
+        decisionReads += 1;
+        throw new Error(sentinel);
+      }
+    });
+
+    const error = capturePolicyGateError(() =>
+      evaluatePolicyGate(sampleToolCall(), {
+        rules: [
+          {
+            ruleId: "accessor-rule-decision",
+            description: "Returns an accessor-backed decision.",
+            guardClass: "capability",
+            evaluate: () => accessorDecision as never
+          }
+        ]
+      })
+    );
+
+    expect(error).toBeInstanceOf(PolicyGateDecisionValidationError);
+    expect((error as Error).message).toBe(
+      "Invalid policy gate decision for accessor-rule-decision: decision"
+    );
+    expect((error as Error).message).not.toContain(sentinel);
+    expect(decisionReads).toBe(0);
+  });
+
+  test("rule decision snapshot rejects enumerable toJSON without invoking it", () => {
+    const sentinel = "RULE_DECISION_TO_JSON_SECRET";
+    let toJsonCalls = 0;
+    const decision = {
+      decision: "deny" as const,
+      reason: "enumerable toJSON should be rejected",
+      remediation: sampleRemediation(),
+      toJSON() {
+        toJsonCalls += 1;
+        throw new Error(sentinel);
+      }
+    };
+
+    const error = capturePolicyGateError(() =>
+      evaluatePolicyGate(sampleToolCall(), {
+        rules: [
+          {
+            ruleId: "tojson-rule-decision",
+            description: "Returns a decision with enumerable toJSON.",
+            guardClass: "capability",
+            evaluate: () => decision
+          }
+        ]
+      })
+    );
+
+    expect(error).toBeInstanceOf(PolicyGateDecisionValidationError);
+    expect((error as Error).message).toBe(
+      "Invalid policy gate decision for tojson-rule-decision: toJSON"
+    );
+    expect((error as Error).message).not.toContain(sentinel);
+    expect(toJsonCalls).toBe(0);
+  });
+
+  test("rule decision snapshot rejects hostile remediation fields before schema parsing", () => {
+    const proxySentinel = "RULE_REMEDIATION_PROXY_SECRET";
+    let proxyGetCalls = 0;
+    let proxyDescriptorCalls = 0;
+    const proxyRemediation = new Proxy(sampleRemediation(), {
+      get() {
+        proxyGetCalls += 1;
+        throw new Error(proxySentinel);
+      },
+      getOwnPropertyDescriptor() {
+        proxyDescriptorCalls += 1;
+        throw new Error(proxySentinel);
+      }
+    });
+
+    const proxyError = capturePolicyGateError(() =>
+      evaluatePolicyGate(sampleToolCall(), {
+        rules: [
+          {
+            ruleId: "proxy-remediation-rule-decision",
+            description: "Returns proxy-backed remediation.",
+            guardClass: "capability",
+            evaluate: () => ({
+              decision: "deny",
+              reason: "proxy remediation should be rejected",
+              remediation: proxyRemediation
+            })
+          }
+        ]
+      })
+    );
+
+    expect(proxyError).toBeInstanceOf(PolicyGateDecisionValidationError);
+    expect((proxyError as Error).message).toBe(
+      "Invalid policy gate decision for proxy-remediation-rule-decision: remediation"
+    );
+    expect((proxyError as Error).message).not.toContain(proxySentinel);
+    expect(proxyGetCalls).toBe(0);
+    expect(proxyDescriptorCalls).toBe(0);
+
+    const accessorSentinel = "RULE_REMEDIATION_ACCESSOR_SECRET";
+    let nextActionReads = 0;
+    const accessorRemediation: Record<string, unknown> = {
+      hint: "Use data descriptors for remediation fields.",
+      ref: "openspec/changes/m1-foundation/specs/tool-registry-governance/spec.md"
+    };
+    Object.defineProperty(accessorRemediation, "next_action", {
+      enumerable: true,
+      get() {
+        nextActionReads += 1;
+        throw new Error(accessorSentinel);
+      }
+    });
+
+    const accessorError = capturePolicyGateError(() =>
+      evaluatePolicyGate(sampleToolCall(), {
+        rules: [
+          {
+            ruleId: "accessor-remediation-rule-decision",
+            description: "Returns accessor-backed remediation.",
+            guardClass: "capability",
+            evaluate: () => ({
+              decision: "deny",
+              reason: "accessor remediation should be rejected",
+              remediation: accessorRemediation
+            })
+          }
+        ]
+      })
+    );
+
+    expect(accessorError).toBeInstanceOf(PolicyGateDecisionValidationError);
+    expect((accessorError as Error).message).toBe(
+      "Invalid policy gate decision for accessor-remediation-rule-decision: remediation.next_action"
+    );
+    expect((accessorError as Error).message).not.toContain(accessorSentinel);
+    expect(nextActionReads).toBe(0);
   });
 });
 
@@ -1427,6 +1621,15 @@ function expectSpawnBudgetDeny(
     expect(combined).not.toContain(tailSentinel);
     expect(combined.length).toBeLessThan(500);
   }
+}
+
+function capturePolicyGateError(action: () => void): unknown {
+  try {
+    action();
+  } catch (error) {
+    return error;
+  }
+  throw new Error("Expected policy gate evaluation to throw.");
 }
 
 function sampleToolCall(): PolicyGateToolCall {

--- a/packages/core/src/tools/policy-gate-core.ts
+++ b/packages/core/src/tools/policy-gate-core.ts
@@ -1,3 +1,4 @@
+import { types as nodeUtilTypes } from "node:util";
 import { z } from "zod";
 import { RemediationNextActionSchema } from "../domain/schemas";
 import {
@@ -138,6 +139,18 @@ type ValidatedPolicyRuleMetadata = {
   guardClass: PolicyGuardClass;
 };
 
+type PolicyRuleDecisionDataDescriptor = PropertyDescriptor & {
+  value: unknown;
+};
+
+type PolicyRuleDecisionSnapshot = Record<string, unknown> & {
+  decision?: unknown;
+  reason?: unknown;
+  remediation?: unknown;
+  guardClass?: unknown;
+  guard_class?: unknown;
+};
+
 export interface PolicyGateContext {
   rules: readonly PolicyRule[];
 }
@@ -208,12 +221,16 @@ export function evaluatePolicyGate(
   const metadata = validatePolicyGateContextMetadata(context);
 
   for (const { rule, ruleId, guardClass } of metadata) {
-    const result = rule.evaluate(call, context);
+    const result = snapshotPolicyRuleDecisionResult(ruleId, rule.evaluate(call, context));
     if (result.decision === "allow") {
       continue;
     }
+    if (result.decision !== "deny") {
+      throw invalidPolicyRuleDecisionSnapshot(ruleId, "decision");
+    }
 
-    validatePolicyGateRemediation(ruleId, result.remediation);
+    const reason = validatePolicyRuleDenyReason(ruleId, result.reason);
+    const remediation = validatePolicyGateRemediation(ruleId, result.remediation);
     const normalizedGuardClass = normalizePolicyRuleDenyGuardClass(
       ruleId,
       guardClass,
@@ -222,8 +239,8 @@ export function evaluatePolicyGate(
     return {
       decision: "deny",
       ruleId,
-      reason: result.reason,
-      remediation: result.remediation,
+      reason,
+      remediation,
       guardClass: normalizedGuardClass
     };
   }
@@ -231,10 +248,145 @@ export function evaluatePolicyGate(
   return { decision: "allow" };
 }
 
+const POLICY_RULE_DENY_DECISION_SNAPSHOT_KEYS = Object.freeze([
+  "reason",
+  "remediation",
+  "guardClass",
+  "guard_class"
+] as const);
+const POLICY_RULE_REMEDIATION_SNAPSHOT_KEYS = Object.freeze([
+  "next_action",
+  "hint",
+  "ref"
+] as const);
+
+function snapshotPolicyRuleDecisionResult(
+  ruleId: string,
+  result: unknown
+): PolicyRuleDecisionSnapshot {
+  if (result === null || typeof result !== "object") {
+    throw invalidPolicyRuleDecisionSnapshot(ruleId, "decision");
+  }
+
+  const objectResult = result as object;
+  if (nodeUtilTypes.isProxy(objectResult)) {
+    throw invalidPolicyRuleDecisionSnapshot(ruleId, "decision");
+  }
+
+  assertNoEnumerablePolicyRuleDecisionToJson(ruleId, objectResult);
+
+  const snapshot = Object.create(null) as PolicyRuleDecisionSnapshot;
+  snapshotPolicyRuleDecisionField(ruleId, objectResult, snapshot, "decision", "decision");
+  if (snapshot.decision !== "deny") {
+    return snapshot;
+  }
+
+  for (const key of POLICY_RULE_DENY_DECISION_SNAPSHOT_KEYS) {
+    snapshotPolicyRuleDecisionField(ruleId, objectResult, snapshot, key, key);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(snapshot, "remediation")) {
+    snapshot.remediation = snapshotPolicyRuleRemediationCandidate(
+      ruleId,
+      snapshot.remediation
+    );
+  }
+
+  return snapshot;
+}
+
+function assertNoEnumerablePolicyRuleDecisionToJson(ruleId: string, result: object): void {
+  const descriptor = readPolicyRuleDecisionOwnDescriptor(ruleId, result, "toJSON", "toJSON");
+  if (descriptor?.enumerable) {
+    throw invalidPolicyRuleDecisionSnapshot(ruleId, "toJSON");
+  }
+}
+
+function snapshotPolicyRuleDecisionField(
+  ruleId: string,
+  source: object,
+  snapshot: PolicyRuleDecisionSnapshot | Record<string, unknown>,
+  key: string,
+  fieldPath: string
+): void {
+  const descriptor = readPolicyRuleDecisionOwnDescriptor(ruleId, source, key, fieldPath);
+  if (!descriptor) {
+    return;
+  }
+  assertPolicyRuleDecisionDataDescriptor(ruleId, descriptor, fieldPath);
+  snapshot[key] = descriptor.value;
+}
+
+function snapshotPolicyRuleRemediationCandidate(ruleId: string, remediation: unknown): unknown {
+  if (remediation === null || typeof remediation !== "object") {
+    return remediation;
+  }
+
+  const objectRemediation = remediation as object;
+  if (nodeUtilTypes.isProxy(objectRemediation)) {
+    throw invalidPolicyRuleDecisionSnapshot(ruleId, "remediation");
+  }
+
+  const snapshot = Object.create(null) as Record<string, unknown>;
+  for (const key of POLICY_RULE_REMEDIATION_SNAPSHOT_KEYS) {
+    snapshotPolicyRuleDecisionField(
+      ruleId,
+      objectRemediation,
+      snapshot,
+      key,
+      `remediation.${key}`
+    );
+  }
+  return snapshot;
+}
+
+function readPolicyRuleDecisionOwnDescriptor(
+  ruleId: string,
+  source: object,
+  key: string,
+  fieldPath: string
+): PropertyDescriptor | undefined {
+  try {
+    return Object.getOwnPropertyDescriptor(source, key);
+  } catch {
+    throw invalidPolicyRuleDecisionSnapshot(ruleId, fieldPath);
+  }
+}
+
+function assertPolicyRuleDecisionDataDescriptor(
+  ruleId: string,
+  descriptor: PropertyDescriptor,
+  fieldPath: string
+): asserts descriptor is PolicyRuleDecisionDataDescriptor {
+  if (
+    !("value" in descriptor) ||
+    descriptor.get !== undefined ||
+    descriptor.set !== undefined
+  ) {
+    throw invalidPolicyRuleDecisionSnapshot(ruleId, fieldPath);
+  }
+}
+
+function validatePolicyRuleDenyReason(ruleId: string, reason: unknown): string {
+  if (typeof reason !== "string") {
+    throw invalidPolicyRuleDecisionSnapshot(ruleId, "reason");
+  }
+  return reason;
+}
+
+function invalidPolicyRuleDecisionSnapshot(
+  ruleId: string,
+  fieldPath: string
+): PolicyGateDecisionValidationError {
+  return policyGateDecisionValidationError(
+    `Invalid policy gate decision for ${ruleId}: ${fieldPath}`
+  );
+}
+
 function normalizePolicyRuleDenyGuardClass(
   ruleId: string,
   ruleGuardClass: PolicyGuardClass,
-  result: Extract<PolicyRuleDecision, { decision: "deny" }>
+  result: Pick<PolicyRuleDecisionSnapshot, "guardClass" | "guard_class">
 ): PolicyGuardClass {
   const resultGuardClass = readPolicyGuardClassAliases(result);
   if (resultGuardClass.state === "missing") {
@@ -1305,10 +1457,13 @@ function formatToolIdSample(toolId: string): string {
   return `${toolId.slice(0, SPAWN_PROFILE_TOOL_ID_SAMPLE_MAX_CHARS - 3)}...`;
 }
 
-function validatePolicyGateRemediation(ruleId: string, remediation: PolicyGateRemediation): void {
+function validatePolicyGateRemediation(
+  ruleId: string,
+  remediation: unknown
+): PolicyGateRemediation {
   const parsed = PolicyGateRemediationSchema.safeParse(remediation);
   if (parsed.success) {
-    return;
+    return parsed.data;
   }
 
   const fieldPaths = parsed.error.issues

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -2247,6 +2247,210 @@ describe("policy-gated zero tool registry", () => {
     expect(accessorTool.calls).toBe(0);
   });
 
+  test("custom evaluator decision snapshot rejects hostile remediation without leaking trap text", async () => {
+    const proxySentinel = "EVALUATOR_REMEDIATION_PROXY_SECRET";
+    let proxyGetCalls = 0;
+    let proxyDescriptorCalls = 0;
+    const proxyTool = new RecordingTool("decision.proxy-remediation.evaluator");
+    const proxyRemediation = new Proxy(
+      {
+        next_action: "fix_and_retry" as const,
+        hint: "Return plain remediation before retrying.",
+        ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+      },
+      {
+        get() {
+          proxyGetCalls += 1;
+          throw new Error(proxySentinel);
+        },
+        getOwnPropertyDescriptor() {
+          proxyDescriptorCalls += 1;
+          throw new Error(proxySentinel);
+        }
+      }
+    );
+    const proxyWrapped = wrapToolWithPolicyGate(proxyTool, {
+      evaluate: () => ({
+        decision: "deny",
+        ruleId: "proxy-remediation-evaluator",
+        reason: "proxy remediation should fail closed",
+        remediation: proxyRemediation,
+        guardClass: "capability"
+      })
+    });
+
+    const proxyResult = await proxyWrapped.run(createToolContext("worker"), {
+      blocked: true
+    });
+
+    expectInvalidPolicyGateDecisionFailure(proxyResult, proxySentinel);
+    expect(proxyResult.output).toContain("remediation");
+    expect(proxyGetCalls).toBe(0);
+    expect(proxyDescriptorCalls).toBe(0);
+    expect(proxyTool.calls).toBe(0);
+
+    const accessorSentinel = "EVALUATOR_REMEDIATION_ACCESSOR_SECRET";
+    let nextActionReads = 0;
+    const accessorTool = new RecordingTool("decision.accessor-remediation.evaluator");
+    const accessorRemediation: Record<string, unknown> = {
+      hint: "Use data-property remediation fields before retrying.",
+      ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+    };
+    Object.defineProperty(accessorRemediation, "next_action", {
+      enumerable: true,
+      get() {
+        nextActionReads += 1;
+        throw new Error(accessorSentinel);
+      }
+    });
+    const accessorWrapped = wrapToolWithPolicyGate(accessorTool, {
+      evaluate: () => ({
+        decision: "deny",
+        ruleId: "accessor-remediation-evaluator",
+        reason: "accessor remediation should fail closed",
+        remediation: accessorRemediation,
+        guardClass: "capability"
+      })
+    });
+
+    const accessorResult = await accessorWrapped.run(createToolContext("worker"), {
+      blocked: true
+    });
+
+    expectInvalidPolicyGateDecisionFailure(accessorResult, accessorSentinel);
+    expect(accessorResult.output).toContain("remediation.next_action");
+    expect(nextActionReads).toBe(0);
+    expect(accessorTool.calls).toBe(0);
+  });
+
+  test("execution validator decision snapshot rejects hostile remediation without leaking trap text", async () => {
+    const proxySentinel = "VALIDATOR_REMEDIATION_PROXY_SECRET";
+    let proxyGetCalls = 0;
+    let proxyDescriptorCalls = 0;
+    const proxyTool = new RecordingTool("decision.proxy-remediation.validator");
+    const proxyRemediation = new Proxy(
+      {
+        next_action: "fix_and_retry" as const,
+        hint: "Return plain validator remediation before retrying.",
+        ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+      },
+      {
+        get() {
+          proxyGetCalls += 1;
+          throw new Error(proxySentinel);
+        },
+        getOwnPropertyDescriptor() {
+          proxyDescriptorCalls += 1;
+          throw new Error(proxySentinel);
+        }
+      }
+    );
+    const proxyWrapped = wrapToolWithPolicyGate(proxyTool, {
+      evaluate: async () => ({ decision: "allow" }),
+      validateExecutionInput: () => ({
+        decision: "deny",
+        ruleId: "proxy-remediation-validator",
+        reason: "proxy remediation should fail closed",
+        remediation: proxyRemediation,
+        guardClass: "capability"
+      })
+    });
+
+    const proxyResult = await proxyWrapped.run(createToolContext("worker"), {
+      blocked: true
+    });
+
+    expectInvalidPolicyGateDecisionFailure(proxyResult, proxySentinel);
+    expect(proxyResult.output).toContain("remediation");
+    expect(proxyGetCalls).toBe(0);
+    expect(proxyDescriptorCalls).toBe(0);
+    expect(proxyTool.calls).toBe(0);
+
+    const accessorSentinel = "VALIDATOR_REMEDIATION_ACCESSOR_SECRET";
+    let nextActionReads = 0;
+    const accessorTool = new RecordingTool("decision.accessor-remediation.validator");
+    const accessorRemediation: Record<string, unknown> = {
+      hint: "Use data-property validator remediation fields before retrying.",
+      ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+    };
+    Object.defineProperty(accessorRemediation, "next_action", {
+      enumerable: true,
+      get() {
+        nextActionReads += 1;
+        throw new Error(accessorSentinel);
+      }
+    });
+    const accessorWrapped = wrapToolWithPolicyGate(accessorTool, {
+      evaluate: async () => ({ decision: "allow" }),
+      validateExecutionInput: () => ({
+        decision: "deny",
+        ruleId: "accessor-remediation-validator",
+        reason: "accessor remediation should fail closed",
+        remediation: accessorRemediation,
+        guardClass: "capability"
+      })
+    });
+
+    const accessorResult = await accessorWrapped.run(createToolContext("worker"), {
+      blocked: true
+    });
+
+    expectInvalidPolicyGateDecisionFailure(accessorResult, accessorSentinel);
+    expect(accessorResult.output).toContain("remediation.next_action");
+    expect(nextActionReads).toBe(0);
+    expect(accessorTool.calls).toBe(0);
+  });
+
+  test("rule-based evaluator decision snapshot fails closed through policy wrapper", async () => {
+    const sentinel = "WRAPPED_RULE_DECISION_PROXY_SECRET";
+    let proxyGetCalls = 0;
+    let proxyDescriptorCalls = 0;
+    const tool = new RecordingTool("decision.rule-proxy.wrapper");
+    const proxyDecision = new Proxy(
+      {
+        decision: "deny" as const,
+        reason: "proxy rule decision should fail before wrapper denial serialization",
+        remediation: {
+          next_action: "fix_and_retry" as const,
+          hint: "Return a plain rule decision before retrying.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        }
+      },
+      {
+        get() {
+          proxyGetCalls += 1;
+          throw new Error(sentinel);
+        },
+        getOwnPropertyDescriptor() {
+          proxyDescriptorCalls += 1;
+          throw new Error(sentinel);
+        }
+      }
+    );
+    const wrapped = wrapToolWithPolicyGate(tool, {
+      evaluate: createPolicyGateEvaluator({
+        rules: [
+          {
+            ruleId: "wrapped-proxy-rule-decision",
+            description: "Returns a proxy-backed rule decision.",
+            guardClass: "capability",
+            evaluate: () => proxyDecision as never
+          }
+        ]
+      })
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), {
+      blocked: true
+    });
+
+    expectInvalidPolicyGateDecisionFailure(result, sentinel);
+    expect(result.output).toContain("wrapped-proxy-rule-decision");
+    expect(proxyGetCalls).toBe(0);
+    expect(proxyDescriptorCalls).toBe(0);
+    expect(tool.calls).toBe(0);
+  });
+
   test("decision snapshot rejects enumerable toJSON without invoking it and keeps plain deny behavior", async () => {
     const sentinel = "DECISION_TO_JSON_SECRET";
     let toJsonCalls = 0;

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -2097,6 +2097,296 @@ describe("policy-gated zero tool registry", () => {
     });
   });
 
+  test("custom evaluator decision snapshot rejects Proxy and accessor candidates without leaking trap text", async () => {
+    const proxySentinel = "EVALUATOR_PROXY_DECISION_TRAP_SECRET";
+    let proxyGetCalls = 0;
+    let proxyDescriptorCalls = 0;
+    const proxyTool = new RecordingTool("decision.proxy.evaluator");
+    const proxyDecision = new Proxy(
+      {
+        decision: "deny" as const,
+        ruleId: "proxy-evaluator-decision",
+        reason: "proxy evaluator decision should fail before property reads",
+        remediation: {
+          next_action: "fix_and_retry" as const,
+          hint: "Return a plain decision object before retrying.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        },
+        guardClass: "capability" as const
+      },
+      {
+        get() {
+          proxyGetCalls += 1;
+          throw new Error(proxySentinel);
+        },
+        getOwnPropertyDescriptor() {
+          proxyDescriptorCalls += 1;
+          throw new Error(proxySentinel);
+        }
+      }
+    );
+    const proxyWrapped = wrapToolWithPolicyGate(proxyTool, {
+      evaluate: () => proxyDecision
+    });
+
+    const proxyResult = await proxyWrapped.run(createToolContext("worker"), {
+      blocked: true
+    });
+
+    expectInvalidPolicyGateDecisionFailure(proxyResult, proxySentinel);
+    expect(proxyGetCalls).toBe(0);
+    expect(proxyDescriptorCalls).toBe(0);
+    expect(proxyTool.calls).toBe(0);
+
+    const accessorSentinel = "EVALUATOR_ACCESSOR_DECISION_SECRET";
+    let accessorReads = 0;
+    const accessorTool = new RecordingTool("decision.accessor.evaluator");
+    const accessorDecision: Record<string, unknown> = {
+      ruleId: "accessor-evaluator-decision",
+      reason: "accessor evaluator decision should fail before getter reads",
+      remediation: {
+        next_action: "fix_and_retry",
+        hint: "Return a data-property decision before retrying.",
+        ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+      },
+      guardClass: "capability"
+    };
+    Object.defineProperty(accessorDecision, "decision", {
+      enumerable: true,
+      get() {
+        accessorReads += 1;
+        throw new Error(accessorSentinel);
+      }
+    });
+    const accessorWrapped = wrapToolWithPolicyGate(accessorTool, {
+      evaluate: () => accessorDecision as never
+    });
+
+    const accessorResult = await accessorWrapped.run(createToolContext("worker"), {
+      blocked: true
+    });
+
+    expectInvalidPolicyGateDecisionFailure(accessorResult, accessorSentinel);
+    expect(accessorReads).toBe(0);
+    expect(accessorTool.calls).toBe(0);
+  });
+
+  test("execution validator decision snapshot rejects Proxy and accessor denies without leaking trap text", async () => {
+    const proxySentinel = "VALIDATOR_PROXY_DECISION_TRAP_SECRET";
+    let proxyGetCalls = 0;
+    let proxyDescriptorCalls = 0;
+    const proxyTool = new RecordingTool("decision.proxy.validator");
+    const proxyDecision = new Proxy(
+      {
+        decision: "deny" as const,
+        ruleId: "proxy-validator-decision",
+        reason: "proxy validator decision should fail before property reads",
+        remediation: {
+          next_action: "fix_and_retry" as const,
+          hint: "Return a plain deny decision before retrying.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        },
+        guardClass: "capability" as const
+      },
+      {
+        get() {
+          proxyGetCalls += 1;
+          throw new Error(proxySentinel);
+        },
+        getOwnPropertyDescriptor() {
+          proxyDescriptorCalls += 1;
+          throw new Error(proxySentinel);
+        }
+      }
+    );
+    const proxyWrapped = wrapToolWithPolicyGate(proxyTool, {
+      evaluate: async () => ({ decision: "allow" }),
+      validateExecutionInput: () => proxyDecision
+    });
+
+    const proxyResult = await proxyWrapped.run(createToolContext("worker"), {
+      blocked: true
+    });
+
+    expectInvalidPolicyGateDecisionFailure(proxyResult, proxySentinel);
+    expect(proxyGetCalls).toBe(0);
+    expect(proxyDescriptorCalls).toBe(0);
+    expect(proxyTool.calls).toBe(0);
+
+    const accessorSentinel = "VALIDATOR_ACCESSOR_DECISION_SECRET";
+    let accessorReads = 0;
+    const accessorTool = new RecordingTool("decision.accessor.validator");
+    const accessorDecision: Record<string, unknown> = {
+      decision: "deny",
+      reason: "accessor validator decision should fail before getter reads",
+      remediation: {
+        next_action: "fix_and_retry",
+        hint: "Return data properties for validator denies before retrying.",
+        ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+      },
+      guardClass: "capability"
+    };
+    Object.defineProperty(accessorDecision, "ruleId", {
+      enumerable: true,
+      get() {
+        accessorReads += 1;
+        throw new Error(accessorSentinel);
+      }
+    });
+    const accessorWrapped = wrapToolWithPolicyGate(accessorTool, {
+      evaluate: async () => ({ decision: "allow" }),
+      validateExecutionInput: () => accessorDecision as never
+    });
+
+    const accessorResult = await accessorWrapped.run(createToolContext("worker"), {
+      blocked: true
+    });
+
+    expectInvalidPolicyGateDecisionFailure(accessorResult, accessorSentinel);
+    expect(accessorReads).toBe(0);
+    expect(accessorTool.calls).toBe(0);
+  });
+
+  test("decision snapshot rejects enumerable toJSON without invoking it and keeps plain deny behavior", async () => {
+    const sentinel = "DECISION_TO_JSON_SECRET";
+    let toJsonCalls = 0;
+    const toJsonTool = new RecordingTool("decision.enumerable.tojson");
+    const toJsonWrapped = wrapToolWithPolicyGate(toJsonTool, {
+      evaluate: async () => ({
+        decision: "deny" as const,
+        ruleId: "enumerable-tojson-decision",
+        reason: "enumerable toJSON should be rejected before serialization",
+        remediation: {
+          next_action: "fix_and_retry" as const,
+          hint: "Return a decision object without enumerable toJSON.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        },
+        guardClass: "capability" as const,
+        toJSON() {
+          toJsonCalls += 1;
+          throw new Error(sentinel);
+        }
+      })
+    });
+
+    const toJsonResult = await toJsonWrapped.run(createToolContext("worker"), {
+      blocked: true
+    });
+
+    expectInvalidPolicyGateDecisionFailure(toJsonResult, sentinel);
+    expect(toJsonResult.output).toContain("toJSON");
+    expect(toJsonCalls).toBe(0);
+    expect(toJsonTool.calls).toBe(0);
+
+    const plainTool = new RecordingTool("decision.plain.valid");
+    const plainWrapped = wrapToolWithPolicyGate(plainTool, {
+      evaluate: async () => ({
+        decision: "deny",
+        ruleId: "plain-valid-decision",
+        reason: "plain valid decision remains a policy denial",
+        remediation: {
+          next_action: "fix_and_retry",
+          hint: "Fix the plain-object policy denial input.",
+          ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+        },
+        guardClass: "capability"
+      })
+    });
+
+    const plainResult = await plainWrapped.run(createToolContext("worker"), {
+      blocked: true
+    });
+
+    expect(plainResult.success).toBe(false);
+    expect(plainResult.output).toContain("policy_gate_denied");
+    const payload = JSON.parse(plainResult.output) as {
+      error?: string;
+      ruleId?: string;
+      guard_class?: string;
+    };
+    expect(payload.error).toBe("policy_gate_denied");
+    expect(payload.ruleId).toBe("plain-valid-decision");
+    expect(payload.guard_class).toBe("capability");
+    expect(plainTool.calls).toBe(0);
+  });
+
+  test("decision snapshot ignores non-consumed nested accessor and proxy payloads", async () => {
+    const sentinel = "DECISION_EXTRA_PAYLOAD_SECRET";
+    let extraAccessorReads = 0;
+    let proxyGetCalls = 0;
+    let proxyOwnKeysCalls = 0;
+    let proxyDescriptorCalls = 0;
+    const nestedExtra: Record<string, unknown> = {};
+    Object.defineProperty(nestedExtra, "secret", {
+      enumerable: true,
+      get() {
+        extraAccessorReads += 1;
+        throw new Error(sentinel);
+      }
+    });
+    const proxyExtra = new Proxy(
+      { secret: sentinel },
+      {
+        get() {
+          proxyGetCalls += 1;
+          throw new Error(sentinel);
+        },
+        ownKeys() {
+          proxyOwnKeysCalls += 1;
+          throw new Error(sentinel);
+        },
+        getOwnPropertyDescriptor() {
+          proxyDescriptorCalls += 1;
+          throw new Error(sentinel);
+        }
+      }
+    );
+    const decision: Record<string, unknown> = {
+      decision: "deny",
+      ruleId: "bounded-decision-snapshot",
+      reason: "non-consumed fields should not be traversed",
+      remediation: {
+        next_action: "fix_and_retry",
+        hint: "Only consume the decision contract fields.",
+        ref: "docs/02_ARCHITECTURE/Control_Kernel.md#5-stop-conditions-与策略门校验约定"
+      },
+      guardClass: "capability",
+      nestedExtra,
+      proxyExtra
+    };
+    Object.defineProperty(decision, "extraAccessor", {
+      enumerable: true,
+      get() {
+        extraAccessorReads += 1;
+        throw new Error(sentinel);
+      }
+    });
+    const tool = new RecordingTool("decision.bounded.extra");
+    const wrapped = wrapToolWithPolicyGate(tool, {
+      evaluate: async () => decision as never
+    });
+
+    const result = await wrapped.run(createToolContext("worker"), {
+      blocked: true
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("policy_gate_denied");
+    expect(result.output).not.toContain(sentinel);
+    expect(result.outputSummary).not.toContain(sentinel);
+    const payload = JSON.parse(result.output) as {
+      error?: string;
+      ruleId?: string;
+    };
+    expect(payload.error).toBe("policy_gate_denied");
+    expect(payload.ruleId).toBe("bounded-decision-snapshot");
+    expect(extraAccessorReads).toBe(0);
+    expect(proxyGetCalls).toBe(0);
+    expect(proxyOwnKeysCalls).toBe(0);
+    expect(proxyDescriptorCalls).toBe(0);
+    expect(tool.calls).toBe(0);
+  });
+
   test("spawn-profile authority impersonation from custom evaluator fails closed", async () => {
     const bashTool = new RecordingTool("bash");
     const wrapped = wrapToolWithPolicyGate(bashTool, {
@@ -8152,6 +8442,15 @@ function expectReservedRawRuleProducerRejected(result: ToolResult | undefined): 
   expect(result?.output).toContain("ruleId");
   expect(result?.output).not.toContain("policy_gate_raw_data_rule_misconfigured");
   expect(result?.output).not.toContain("raw_data_write_denied");
+}
+
+function expectInvalidPolicyGateDecisionFailure(result: ToolResult, sentinel: string): void {
+  expect(result.success).toBe(false);
+  expect(result.output).toContain("Invalid policy gate decision");
+  expect(result.output).not.toContain(sentinel);
+  expect(result.output).not.toContain("policy_gate_denied");
+  expect(result.outputSummary).toContain("Error: Invalid policy gate decision");
+  expect(result.outputSummary).not.toContain(sentinel);
 }
 
 function expectToolParameterSchemaValidationDenial(result: ToolResult | undefined): void {

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -238,12 +238,18 @@ export function createShudPolicyGateEvaluator(
   }
 
   return trustReservedAuthorityPolicyGateEvaluator(async (call, context) => {
-    const authorityDecision = await authorityEvaluate(call, context);
+    const authorityResult = authorityEvaluate(call, context);
+    const authorityDecision = isPolicyGateDecisionInputPromise(authorityResult)
+      ? await authorityResult
+      : authorityResult;
     if (authorityDecision.decision === "deny") {
       return authorityDecision;
     }
 
-    const customDecision = await customEvaluate(call, context);
+    const customResult = customEvaluate(call, context);
+    const customDecision = isPolicyGateDecisionInputPromise(customResult)
+      ? await customResult
+      : customResult;
     try {
       return validatePolicyGateDecision(call.toolId, customDecision);
     } catch (error) {
@@ -253,6 +259,12 @@ export function createShudPolicyGateEvaluator(
       throw new PolicyGateDecisionValidationError(error);
     }
   });
+}
+
+function isPolicyGateDecisionInputPromise(
+  result: PolicyGateDecisionInput | Promise<PolicyGateDecisionInput>
+): result is Promise<PolicyGateDecisionInput> {
+  return nodeUtilTypes.isPromise(result);
 }
 
 export function wrapToolWithPolicyGate(
@@ -1069,13 +1081,16 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
   > {
     let candidate: PolicyGateDecisionInput;
     try {
-      candidate = await this.#evaluate(
+      const candidateResult = this.#evaluate(
         buildPolicyGateToolCall(this.#policyGateToolId, role, evaluatorInput, toolContext),
         {
           tool: this,
           toolContext
         }
       );
+      candidate = isPolicyGateDecisionInputPromise(candidateResult)
+        ? await candidateResult
+        : candidateResult;
     } catch (error) {
       return {
         status: "error",
@@ -1662,18 +1677,29 @@ interface PolicyGateDecisionValidationOptions {
   allowReservedAuthorityRuleIds?: boolean;
 }
 
+type PolicyGateDecisionDataDescriptor = PropertyDescriptor & {
+  value: unknown;
+};
+
+const POLICY_GATE_DENY_DECISION_SNAPSHOT_KEYS = Object.freeze([
+  "ruleId",
+  "reason",
+  "remediation",
+  "guardClass",
+  "guard_class"
+] as const);
+const POLICY_GATE_REMEDIATION_SNAPSHOT_KEYS = Object.freeze([
+  "next_action",
+  "hint",
+  "ref"
+] as const);
+
 function validatePolicyGateDecision(
   toolId: string,
   candidate: unknown,
   options: PolicyGateDecisionValidationOptions = {}
 ): PolicyGateDecision {
-  if (candidate === null || typeof candidate !== "object") {
-    throw new PolicyGateDecisionValidationError(
-      `Invalid policy gate decision for ${toolId}: decision`
-    );
-  }
-
-  const rawDecision = candidate as Record<string, unknown>;
+  const rawDecision = snapshotPolicyGateDecisionCandidate(toolId, candidate);
   if (rawDecision.decision === "allow") {
     return { decision: "allow" };
   }
@@ -1737,6 +1763,128 @@ function validatePolicyGateDecision(
     remediation,
     guardClass
   };
+}
+
+function snapshotPolicyGateDecisionCandidate(
+  toolId: string,
+  candidate: unknown
+): Record<string, unknown> {
+  if (candidate === null || typeof candidate !== "object") {
+    throw invalidPolicyGateDecisionSnapshot(toolId, "decision");
+  }
+
+  const objectCandidate = candidate as object;
+  if (nodeUtilTypes.isProxy(objectCandidate)) {
+    throw invalidPolicyGateDecisionSnapshot(toolId, "decision");
+  }
+
+  assertNoEnumerablePolicyGateDecisionToJson(toolId, objectCandidate);
+
+  const snapshot = Object.create(null) as Record<string, unknown>;
+  snapshotPolicyGateDecisionField(toolId, objectCandidate, snapshot, "decision", "decision");
+  if (snapshot.decision !== "deny") {
+    return snapshot;
+  }
+
+  for (const key of POLICY_GATE_DENY_DECISION_SNAPSHOT_KEYS) {
+    snapshotPolicyGateDecisionField(toolId, objectCandidate, snapshot, key, key);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(snapshot, "remediation")) {
+    snapshot.remediation = snapshotPolicyGateRemediationCandidate(
+      toolId,
+      snapshot.remediation
+    );
+  }
+
+  return snapshot;
+}
+
+function assertNoEnumerablePolicyGateDecisionToJson(
+  toolId: string,
+  candidate: object
+): void {
+  const descriptor = readPolicyGateDecisionOwnDescriptor(toolId, candidate, "toJSON", "toJSON");
+  if (descriptor?.enumerable) {
+    throw invalidPolicyGateDecisionSnapshot(toolId, "toJSON");
+  }
+}
+
+function snapshotPolicyGateDecisionField(
+  toolId: string,
+  candidate: object,
+  snapshot: Record<string, unknown>,
+  key: string,
+  fieldPath: string
+): void {
+  const descriptor = readPolicyGateDecisionOwnDescriptor(toolId, candidate, key, fieldPath);
+  if (!descriptor) {
+    return;
+  }
+  assertPolicyGateDecisionDataDescriptor(toolId, descriptor, fieldPath);
+  snapshot[key] = descriptor.value;
+}
+
+function snapshotPolicyGateRemediationCandidate(
+  toolId: string,
+  remediation: unknown
+): unknown {
+  if (remediation === null || typeof remediation !== "object") {
+    return remediation;
+  }
+
+  const objectRemediation = remediation as object;
+  if (nodeUtilTypes.isProxy(objectRemediation)) {
+    throw invalidPolicyGateDecisionSnapshot(toolId, "remediation");
+  }
+
+  const snapshot = Object.create(null) as Record<string, unknown>;
+  for (const key of POLICY_GATE_REMEDIATION_SNAPSHOT_KEYS) {
+    snapshotPolicyGateDecisionField(
+      toolId,
+      objectRemediation,
+      snapshot,
+      key,
+      `remediation.${key}`
+    );
+  }
+  return snapshot;
+}
+
+function readPolicyGateDecisionOwnDescriptor(
+  toolId: string,
+  candidate: object,
+  key: string,
+  fieldPath: string
+): PropertyDescriptor | undefined {
+  try {
+    return Object.getOwnPropertyDescriptor(candidate, key);
+  } catch {
+    throw invalidPolicyGateDecisionSnapshot(toolId, fieldPath);
+  }
+}
+
+function assertPolicyGateDecisionDataDescriptor(
+  toolId: string,
+  descriptor: PropertyDescriptor,
+  fieldPath: string
+): asserts descriptor is PolicyGateDecisionDataDescriptor {
+  if (
+    !("value" in descriptor) ||
+    descriptor.get !== undefined ||
+    descriptor.set !== undefined
+  ) {
+    throw invalidPolicyGateDecisionSnapshot(toolId, fieldPath);
+  }
+}
+
+function invalidPolicyGateDecisionSnapshot(
+  toolId: string,
+  fieldPath: string
+): PolicyGateDecisionValidationError {
+  return new PolicyGateDecisionValidationError(
+    `Invalid policy gate decision for ${toolId}: ${fieldPath}`
+  );
 }
 
 function normalizePolicyGateDecisionRuleId(ruleId: unknown): string | undefined {


### PR DESCRIPTION
Part of #11
Closes #59

## Summary

- #59 is a #26 review follow-up hardening and does not change policy semantics.
- Add bounded plain-data snapshot steps before policy-gate validation reads evaluator, execution-validator, or rule-based `PolicyRule.evaluate()` decision fields.
- Reject Proxy-backed, accessor-backed, and enumerable `toJSON` decision candidates with stable `Invalid policy gate decision...` failures.
- Preserve ordinary plain-object allow/deny behavior, reserved authority validation, and the invariant that inner tools are not executed on invalid decision payloads.

## Acceptance Mapping

- Proxy/accessor evaluator decision fails closed without sentinel trap text: covered by `custom evaluator decision snapshot rejects Proxy and accessor candidates without leaking trap text`.
- Proxy/accessor execution validator deny fails closed without sentinel trap text: covered by `execution validator decision snapshot rejects Proxy and accessor denies without leaking trap text`.
- Rule-based evaluator decisions fail closed through the wrapper path: covered by `rule-based evaluator decision snapshot fails closed through policy wrapper`.
- Nested `remediation` Proxy/accessor payloads fail closed before policy denial serialization: covered by the evaluator, execution-validator, and core hostile remediation tests.
- Enumerable `toJSON` cannot affect validation output: covered by `decision snapshot rejects enumerable toJSON without invoking it and keeps plain deny behavior`.
- Inner tool not called on invalid decision payloads: asserted in evaluator, validator, remediation, `toJSON`, and rule-wrapper tests.
- Existing policy-gate behavior remains compatible: focused policy-gate suite and full local check pass.

## Verification

- `npx --yes bun@1.2.19 test ./packages/core/src/tools/policy-gate-core.test.ts ./packages/core/src/tools/policy-gate-registry.test.ts` (227 pass)
- `npx --yes bun@1.2.19 run typecheck`
- `openspec validate m1-foundation --strict --no-interactive`
- `npx --yes bun@1.2.19 run check`
- `git diff --check -- openspec/changes/m1-foundation/design.md packages/core/src/tools/policy-gate-core.ts packages/core/src/tools/policy-gate-core.test.ts packages/core/src/tools/policy-gate-registry.test.ts`
- `git -C zero diff --quiet`
- GitHub CI: `check`, `docs-links`, `linux-base`, `macos-seatbelt`

## Agent Review

- Reviewer agents used: `review-correctness`, `review-integration`, `review-security-perf`, `review-test-evidence`, `review-spec-compliance`, `review-invariant-state`, `final-gap-sweep`
- Reviewed head SHA: `4526300449bae8ab2b045abfae2a538b1d3d9263`
- Review evidence: [Agent Review Evidence](https://github.com/DankerMu/SHUD-Harness/pull/62#issuecomment-4905583998) | [工作情况说明](https://github.com/DankerMu/SHUD-Harness/pull/62#issuecomment-4905584505)
- OpenSpec change: `m1-foundation`; fixture level: expanded; repair intensity: high; selected risk packs: Public API / CLI / script entry, Schema / columns / units / field names, Auth / permissions / secrets, Resource limits / large input / discovery, Legacy compatibility / examples, Error handling / rollback / partial outputs, Release / packaging / dependency compatibility, Documentation / migration notes, Zero adapter / tool registry / agent role governance
- Key findings addressed: rule-based `PolicyRule.evaluate()` result snapshot gap, consumed nested `remediation` regression gap, and PR evidence traceability gap. Round 2 and final gap sweep were clean.
