### PR TITLE
fix(tools): reserve concurrent spawn admission

### DIFF
--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -558,3 +558,87 @@ Review focus:
 - Stable validation errors do not contain untrusted trap text.
 - The custom evaluator, execution-validator, and rule-based evaluator paths are covered.
 - Existing policy-gate denial payloads remain compatible for ordinary plain objects.
+
+## Subagent Workflow Fixture - Issue #61
+
+Fixture level: expanded; repair intensity: high
+Project profile: SHUD-Harness
+
+Expanded-trigger rationale:
+- Core triggers: concurrency, shared runtime state, public tool entrypoint, and error/remediation contract.
+- Profile triggers: `Zero`, tool registry governance, `remediation`, and `guard_class`.
+
+Change surface:
+- `packages/core/src/tools/policy-gate-registry.ts`
+- `packages/core/src/tools/policy-gate-registry.test.ts`
+
+Must preserve:
+- #27 pure policy-gate contract: `activeSubagentCount >= 3` denies before `spawn_agent` execution with rule id `spawn-concurrency-limit`.
+- Standard Zero session serialized execution remains compatible; no M3 queue scheduler is introduced.
+- `zero/` remains source-clean and pinned; no Zero source edits.
+- Existing spawn profile subset, spawn depth, zod parameter validation, and tool-availability denials keep their policy identity and remediation.
+
+Must add/change:
+- Direct concurrent `spawn_agent.run()` calls sharing the same trusted `agentControl` must not both pass admission when `activeAgentCount=2` and max concurrent subagents is 3.
+- Admission ownership sits in the SHUD policy-gated adapter layer as a per-`agentControl` reservation/recheck around spawn execution; the pure rule stays unchanged.
+- Reservation is released on success, denial, validation failure, or inner tool failure, so serialized follow-up calls are not permanently blocked.
+
+Risk packs considered:
+- Public API / CLI / script entry: selected - `spawn_agent.run()` is a direct public tool entrypoint.
+- Config / project setup: not selected - no package manager, provider, or environment setup changes.
+- File IO / path safety / overwrite: not selected - no file mutation behavior beyond tests.
+- Schema / columns / units / field names: selected - denial payload identity and remediation are structured contracts.
+- Auth / permissions / secrets: selected - spawn admission is an authority boundary for subagent capability creation.
+- Concurrency / shared state / ordering: selected - this is the defect class.
+- Resource limits / large input / discovery: selected - max concurrent subagents is an explicit runtime resource limit.
+- Legacy compatibility / examples: selected - existing policy-gate, spawn profile, depth, and raw sandbox tests must remain green.
+- Error handling / rollback / partial outputs: selected - denied admission must not invoke the inner spawn tool and reservations must unwind on all early exits.
+- Release / packaging / dependency compatibility: selected - no new dependency; Bun/TypeScript checks must remain compatible.
+- Documentation / migration notes: selected - PR evidence must state this is a #27/#60 follow-up and not M3 scheduling.
+Domain packs:
+- Scientific governance / PI gate / evidence lineage: not selected - no scientific decision or evidence claim changes.
+- Hydrology runtime / SHUD-rSHUD-AutoSHUD compatibility: not selected - no solver/runtime behavior changes.
+- Zero adapter / tool registry / agent role governance: selected - admission sits at the SHUD wrapper boundary over Zero tools.
+
+Invariant Matrix:
+- Governing invariant: Every direct `spawn_agent` admission for the same trusted `agentControl` must reserve capacity before any async gap, so observed active subagents plus reservations never exceeds `MAX_CONCURRENT_SUBAGENTS`.
+- Source-of-truth identity/contract: Control_Kernel §5 max concurrent subagents, `MAX_CONCURRENT_SUBAGENTS`, `SPAWN_CONCURRENCY_LIMIT_RULE_ID`, and `SPAWN_LIMITS_POLICY_REF`.
+- Producers: `agentControl.activeAgentCount` and the adapter-owned in-memory reservation map.
+- Validators/preflight: wrapped `spawn_agent.run()` admission and existing spawn concurrency policy-gate rule.
+- Storage/cache/query: per-process WeakMap keyed by trusted `agentControl`; no persisted runtime state.
+- Public routes/entrypoints: direct wrapped `spawn_agent.run()` calls and standard Zero serialized tool execution.
+- Frontend/downstream consumers: `ToolResult.output` `policy_gate_denied` payloads and spawn caller expectations.
+- Failure paths/rollback/stale state: reservation releases in a `finally` path for denials, validation errors, successful spawn, and inner-tool failures.
+- Evidence/audit/readiness: focused Bun concurrency tests, OpenSpec validation, zero diff check, and PR review evidence.
+- Regression rows:
+  - Two concurrent direct `spawn_agent.run()` calls with shared `agentControl.activeAgentCount=2` -> exactly one inner spawn call, one denial with `spawn-concurrency-limit`, `guard_class=authority`, and `remediation.next_action=adjust_scope`.
+  - A later serialized spawn after the first call completes and active count stays below max -> allowed, proving reservation release.
+  - Existing trusted `activeAgentCount=3` single call -> denied before inner execution with unchanged remediation payload.
+  - Malformed trusted `activeAgentCount` -> fail closed with `spawn-concurrency-limit` and no reservation leak.
+  - Standard Zero serialized call with `activeAgentCount=0` and canonical worker tool subset -> remains compatible and spawns once.
+  - `git -C zero diff --quiet` -> unchanged after implementation.
+
+Boundary-surface checklist:
+- Shared helper roots: `policy-gate-registry.ts` spawn adapter admission helpers.
+- Public entrypoints: wrapped `spawn_agent.run()` only.
+- Producer/consumer evidence boundaries: `agentControl.activeAgentCount` plus reservation count -> policy-gate denial JSON.
+- Stale-state/idempotency boundaries: reservation lifetime is per call and must not leak after early return or thrown inner tool.
+- Unchanged downstream consumers: pure `policy-gate-core` spawn rules, Zero `SpawnAgentTool`, role-map snapshot tests, bash/raw sandbox wrapper, and future M3 queue scheduling.
+
+Required evidence:
+- Barrier-style Bun test for concurrent direct `spawn_agent.run()` calls with `activeAgentCount=2`: one success, one `spawn-concurrency-limit` denial, one inner spawn call total.
+- Follow-up serialized call after the concurrent pair proves reservation release.
+- Existing max-active and malformed-active tests still pass with unchanged rule id and remediation.
+- Existing spawn subset/depth/tool-availability tests remain green.
+- PR evidence states this is a #27/#60 direct-entrypoint hardening, not full M3 queue scheduling.
+- `bun run test:policy-gate`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`.
+
+Non-goals:
+- Implementing a queue, retry scheduler, cancellation semantics, or cross-process/distributed spawn reservations.
+- Changing pure policy-gate rule semantics, max constants, role tool profiles, or Zero source.
+
+Review focus:
+- Reservation happens before any awaited operation and is scoped to trusted `agentControl`, not model-controlled input.
+- Denial uses the existing spawn concurrency policy identity/remediation.
+- Reservation release is covered for success and early-failure paths.
+- Existing serialized Zero behavior and #20/#27 spawn guard behavior remain compatible.

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -66,6 +66,15 @@
     - Existing policy-gated registry, spawn subset, and raw sandbox tests remain compatible; `git -C zero diff --quiet` still passes.
 - [ ] 5.3 硬护栏 guard_class 标注（authority|capability）+ 未标注装配失败负例——依赖: 3.1
 - [ ] 5.4 spawn depth/并发上限 kernel 硬校验（Control_Kernel §5：depth >1 拒绝且含 remediation 三字段；活跃子代理 =3 时新 spawn 非 allow——纯函数负例，真实排队调度随 M3 spawn 接线）+ guard_class 标注——依赖: 3.2
+  - Follow-up evidence floor (#61):
+    - Two concurrent direct `spawn_agent.run()` calls sharing one trusted `agentControl` with `activeAgentCount=2` and canonical worker subset `tools=["read"]` cannot both pass; exactly one inner spawn occurs and the other returns `policy_gate_denied` with `ruleId=spawn-concurrency-limit`, `guard_class=authority`, and schema-valid `remediation{next_action,hint,ref}` where `next_action=adjust_scope` and `ref=SPAWN_LIMITS_POLICY_REF`.
+    - A later serialized `spawn_agent.run()` using the same `agentControl`, active count below max, and canonical worker subset `tools=["read"]` succeeds and records exactly one additional inner spawn, proving the concurrent reservation was released and standard Zero-style serialized execution remains compatible.
+    - Validation-denied path: a reserved `spawn_agent.run()` that fails post-normalization tool-availability validation returns the existing structured denial without inner spawn, then a later serialized canonical worker spawn succeeds, proving no reservation leak on validation denial.
+    - Inner-tool failure path: a reserved `spawn_agent.run()` whose underlying spawn tool rejects or returns failure unwinds the reservation, then a later serialized canonical worker spawn succeeds, proving no reservation leak on inner failure.
+    - Existing max-active (`activeAgentCount=3`) and malformed trusted active-count denial tests remain unchanged.
+    - Existing spawn subset, spawn depth, tool-availability, zod parameter validation, and raw sandbox compatibility tests remain green.
+    - `bun run test:policy-gate`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`.
+    - PR evidence states #61 is #27/#60 direct-entrypoint hardening, not M3 queue scheduling, and does not alter the pure #27 policy-gate rule.
 
 ## 6. 后端骨架（task-api）
 

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -5588,6 +5588,64 @@ describe("policy-gated zero tool registry", () => {
     }
   });
 
+  test("SHUD runtime keeps spawn depth priority when nested spawn is also at active limit", async () => {
+    const fixture = await createRawFixture();
+    try {
+      await writeWorkerRoleFixture(fixture.root);
+      const modelRouter = createSpawnModelRouterStub();
+      const zeroLikeRegistry = new ToolRegistry();
+      zeroLikeRegistry.register(new RecordingTool("spawn_agent"));
+      zeroLikeRegistry.register(new RecordingTool("read"));
+      const agentControl = createAgentControlSpy();
+      agentControl.control.activeAgentCount = MAX_CONCURRENT_SUBAGENTS;
+
+      const registry = createShudRuntimeToolRegistry({
+        tools: zeroLikeRegistry.list(),
+        protectedRawPaths: [fixture.rawRoot],
+        allowedWriteRoots: [fixture.root],
+        tempRoot: fixture.tempRoot,
+        profileRoot: fixture.profileRoot,
+        fuseRules: [],
+        modelRouter
+      });
+
+      const result = await registry.get("spawn_agent")?.run(
+        {
+          ...fixture.context,
+          spawnedByRequestId: "REQ-PARENT-1",
+          agentControl: agentControl.control,
+          projectRoot: fixture.root
+        },
+        {
+          instruction: "Run a worker task.",
+          role: "worker",
+          tools: ["read"]
+        }
+      );
+
+      expect(result?.success).toBe(false);
+      expect(result?.output).toContain("policy_gate_denied");
+      const payload = JSON.parse(result?.output ?? "{}") as {
+        error?: string;
+        ruleId?: string;
+        guard_class?: string;
+        remediation?: {
+          next_action?: string;
+          ref?: string;
+        };
+      };
+      expect(payload.error).toBe("policy_gate_denied");
+      expect(payload.ruleId).toBe(SPAWN_DEPTH_LIMIT_RULE_ID);
+      expect(payload.guard_class).toBe("authority");
+      expect(payload.remediation?.next_action).toBe("adjust_scope");
+      expect(payload.remediation?.ref).toBe(SPAWN_LIMITS_POLICY_REF);
+      expect(PolicyGateRemediationSchema.safeParse(payload.remediation).success).toBe(true);
+      expect(agentControl.getSpawnCalls()).toBe(0);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   test("SHUD runtime denies spawn_agent at trusted max active subagents before execution", async () => {
     const fixture = await createRawFixture();
     try {

--- a/packages/core/src/tools/policy-gate-registry.test.ts
+++ b/packages/core/src/tools/policy-gate-registry.test.ts
@@ -5703,6 +5703,198 @@ describe("policy-gated zero tool registry", () => {
     }
   });
 
+  test("SHUD runtime reserves spawn capacity for concurrent direct spawn calls", async () => {
+    const fixture = await createRawFixture();
+    try {
+      await writeWorkerRoleFixture(fixture.root);
+      const modelRouter = createSpawnModelRouterStub();
+      const zeroLikeRegistry = new ToolRegistry();
+      zeroLikeRegistry.register(new RecordingTool("spawn_agent"));
+      zeroLikeRegistry.register(new RecordingTool("read"));
+      const agentControl = createAgentControlSpy();
+      agentControl.control.activeAgentCount = MAX_CONCURRENT_SUBAGENTS - 1;
+      let releaseEvaluation: () => void = () => {};
+      let evaluatorCalls = 0;
+      const evaluationBarrier = new Promise<void>((resolve) => {
+        releaseEvaluation = resolve;
+      });
+
+      const registry = createShudRuntimeToolRegistry({
+        tools: zeroLikeRegistry.list(),
+        protectedRawPaths: [fixture.rawRoot],
+        allowedWriteRoots: [fixture.root],
+        tempRoot: fixture.tempRoot,
+        profileRoot: fixture.profileRoot,
+        fuseRules: [],
+        modelRouter,
+        evaluate: async () => {
+          evaluatorCalls += 1;
+          await evaluationBarrier;
+          return { decision: "allow" };
+        }
+      });
+      const spawn = registry.get("spawn_agent");
+      if (!spawn) {
+        throw new Error("spawn_agent should be registered");
+      }
+      const context = {
+        ...fixture.context,
+        agentControl: agentControl.control,
+        projectRoot: fixture.root
+      };
+      const input = {
+        instruction: "Run a worker task.",
+        role: "worker",
+        tools: ["read"]
+      };
+
+      const first = spawn.run(context, input);
+      expect(evaluatorCalls).toBe(1);
+      const second = spawn.run(context, input);
+      releaseEvaluation();
+      const results = await Promise.all([first, second]);
+
+      const successes = results.filter((result) => result.success);
+      const denials = results.filter((result) => !result.success);
+      expect(successes).toHaveLength(1);
+      expect(denials).toHaveLength(1);
+      expectSpawnConcurrencyLimitDenial(denials[0]);
+      expect(evaluatorCalls).toBe(1);
+      expect(agentControl.getSpawnCalls()).toBe(1);
+
+      const later = await spawn.run(context, input);
+      expect(later.success).toBe(true);
+      expect(agentControl.getSpawnCalls()).toBe(2);
+      expect(getCapturedToolNames(agentControl.getLastAgentContext())).toEqual(["read"]);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("SHUD runtime releases reserved spawn capacity after tool-availability validation denial", async () => {
+    const fixture = await createRawFixture();
+    try {
+      await writeWorkerRoleFixture(fixture.root);
+      const modelRouter = createSpawnModelRouterStub();
+      const zeroLikeRegistry = new ToolRegistry();
+      zeroLikeRegistry.register(new RecordingTool("spawn_agent"));
+      zeroLikeRegistry.register(new RecordingTool("read"));
+      const agentControl = createAgentControlSpy();
+      agentControl.control.activeAgentCount = MAX_CONCURRENT_SUBAGENTS - 1;
+
+      const registry = createShudRuntimeToolRegistry({
+        tools: zeroLikeRegistry.list(),
+        protectedRawPaths: [fixture.rawRoot],
+        allowedWriteRoots: [fixture.root],
+        tempRoot: fixture.tempRoot,
+        profileRoot: fixture.profileRoot,
+        fuseRules: [],
+        modelRouter
+      });
+      const spawn = registry.get("spawn_agent");
+      if (!spawn) {
+        throw new Error("spawn_agent should be registered");
+      }
+      const context = {
+        ...fixture.context,
+        agentControl: agentControl.control,
+        projectRoot: fixture.root
+      };
+
+      const denied = await spawn.run(context, {
+        instruction: "Coordinate a task.",
+        role: "coordinator",
+        tools: ["spawn_agent"]
+      });
+
+      expect(denied.success).toBe(false);
+      expect(denied.output).toContain("policy_gate_denied");
+      const payload = JSON.parse(denied.output) as {
+        error?: string;
+        ruleId?: string;
+        guard_class?: string;
+        reason?: string;
+        remediation?: {
+          next_action?: string;
+          hint?: string;
+          ref?: string;
+        };
+      };
+      expect(payload.error).toBe("policy_gate_denied");
+      expect(payload.ruleId).toBe(SPAWN_PROFILE_SUBSET_RULE_ID);
+      expect(payload.guard_class).toBe("authority");
+      expect(payload.reason).toContain("spawn_agent");
+      expect(payload.remediation?.next_action).toBe("adjust_scope");
+      expect(payload.remediation?.hint).toContain("spawn_agent");
+      expect(payload.remediation?.ref).toBe(SPAWN_PROFILE_SUBSET_POLICY_REF);
+      expect(PolicyGateRemediationSchema.safeParse(payload.remediation).success).toBe(true);
+      expect(agentControl.getSpawnCalls()).toBe(0);
+
+      const later = await spawn.run(context, {
+        instruction: "Run a worker task.",
+        role: "worker",
+        tools: ["read"]
+      });
+      expect(later.success).toBe(true);
+      expect(agentControl.getSpawnCalls()).toBe(1);
+      expect(getCapturedToolNames(agentControl.getLastAgentContext())).toEqual(["read"]);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test("SHUD runtime releases reserved spawn capacity after inner spawn failure", async () => {
+    const fixture = await createRawFixture();
+    try {
+      await writeWorkerRoleFixture(fixture.root);
+      const modelRouter = createSpawnModelRouterStub();
+      const zeroLikeRegistry = new ToolRegistry();
+      zeroLikeRegistry.register(new RecordingTool("spawn_agent"));
+      zeroLikeRegistry.register(new RecordingTool("read"));
+      const agentControl = createAgentControlSpy({
+        spawn: () => ({ error: "spawn failed for reservation release test" })
+      });
+      agentControl.control.activeAgentCount = MAX_CONCURRENT_SUBAGENTS - 1;
+
+      const registry = createShudRuntimeToolRegistry({
+        tools: zeroLikeRegistry.list(),
+        protectedRawPaths: [fixture.rawRoot],
+        allowedWriteRoots: [fixture.root],
+        tempRoot: fixture.tempRoot,
+        profileRoot: fixture.profileRoot,
+        fuseRules: [],
+        modelRouter
+      });
+      const spawn = registry.get("spawn_agent");
+      if (!spawn) {
+        throw new Error("spawn_agent should be registered");
+      }
+      const context = {
+        ...fixture.context,
+        agentControl: agentControl.control,
+        projectRoot: fixture.root
+      };
+      const input = {
+        instruction: "Run a worker task.",
+        role: "worker",
+        tools: ["read"]
+      };
+
+      const failed = await spawn.run(context, input);
+      expect(failed.success).toBe(false);
+      expect(failed.output).toContain("spawn failed for reservation release test");
+      expect(agentControl.getSpawnCalls()).toBe(1);
+
+      agentControl.setSpawnImplementation(undefined);
+      const later = await spawn.run(context, input);
+      expect(later.success).toBe(true);
+      expect(agentControl.getSpawnCalls()).toBe(2);
+      expect(getCapturedToolNames(agentControl.getLastAgentContext())).toEqual(["read"]);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   test("SHUD runtime ignores model-controlled spawn limit fields below trusted limits", async () => {
     const fixture = await createRawFixture();
     try {
@@ -8684,6 +8876,30 @@ function expectToolParameterSchemaValidationDenial(result: ToolResult | undefine
   expect(PolicyGateRemediationSchema.safeParse(payload.remediation).success).toBe(true);
 }
 
+function expectSpawnConcurrencyLimitDenial(result: ToolResult | undefined): void {
+  expect(result?.success).toBe(false);
+  expect(result?.output).toContain("policy_gate_denied");
+  const payload = JSON.parse(result?.output ?? "{}") as {
+    error?: string;
+    ruleId?: string;
+    guard_class?: string;
+    reason?: string;
+    remediation?: {
+      next_action?: string;
+      hint?: string;
+      ref?: string;
+    };
+  };
+  expect(payload.error).toBe("policy_gate_denied");
+  expect(payload.ruleId).toBe(SPAWN_CONCURRENCY_LIMIT_RULE_ID);
+  expect(payload.guard_class).toBe("authority");
+  expect(payload.reason).toContain("max_concurrent_subagents");
+  expect(payload.remediation?.next_action).toBe("adjust_scope");
+  expect(payload.remediation?.hint).toContain("Wait for an active subagent");
+  expect(payload.remediation?.ref).toBe(SPAWN_LIMITS_POLICY_REF);
+  expect(PolicyGateRemediationSchema.safeParse(payload.remediation).success).toBe(true);
+}
+
 function createSpawnModelRouterStub(): ConstructorParameters<typeof SpawnAgentTool>[0] {
   return {
     getRegistry: () => ({ listModels: () => [] }),
@@ -8695,25 +8911,31 @@ function createSpawnModelRouterStub(): ConstructorParameters<typeof SpawnAgentTo
 }
 
 type AgentControl = NonNullable<ToolContext["agentControl"]>;
+type AgentControlSpawnImplementation = AgentControl["spawn"];
 
-function createAgentControlSpy(): {
+function createAgentControlSpy(options: { spawn?: AgentControlSpawnImplementation } = {}): {
   control: AgentControl;
   getSpawnCalls(): number;
   getLastAgentContext(): unknown;
+  setSpawnImplementation(spawn: AgentControlSpawnImplementation | undefined): void;
 } {
   let spawnCalls = 0;
   let lastAgentContext: unknown;
+  let spawnImplementation = options.spawn;
   const waitResult = async () => ({ statuses: {}, timedOut: false });
   const control: AgentControl = {
     spawn(
-      _agent: unknown,
+      agent: unknown,
       context: unknown,
-      _instruction: string,
-      options?: Parameters<AgentControl["spawn"]>[3]
+      instruction: string,
+      spawnOptions?: Parameters<AgentControl["spawn"]>[3]
     ) {
       spawnCalls += 1;
       lastAgentContext = context;
-      return { agentId: `agent-${spawnCalls}`, label: options?.label ?? "SubAgent" };
+      if (spawnImplementation) {
+        return spawnImplementation(agent, context, instruction, spawnOptions);
+      }
+      return { agentId: `agent-${spawnCalls}`, label: spawnOptions?.label ?? "SubAgent" };
     },
     waitAny: waitResult,
     waitAll: waitResult,
@@ -8733,7 +8955,10 @@ function createAgentControlSpy(): {
   return {
     control,
     getSpawnCalls: () => spawnCalls,
-    getLastAgentContext: () => lastAgentContext
+    getLastAgentContext: () => lastAgentContext,
+    setSpawnImplementation(spawn: AgentControlSpawnImplementation | undefined) {
+      spawnImplementation = spawn;
+    }
   };
 }
 

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -18,6 +18,7 @@ import {
   isReservedAuthorityPolicyRuleIdPrefixImpersonation,
   isReservedAuthorityPolicyRuleId,
   normalizeSpawnAgentInput,
+  MAX_CONCURRENT_SUBAGENTS,
   PolicyGateDecisionValidationError,
   PolicyGuardClassSchema,
   PolicyGateRemediationSchema,
@@ -130,6 +131,10 @@ const policyGatedTools = new WeakSet<BaseTool>();
 const reservedAuthorityPolicyGateEvaluators = new WeakSet<PolicyGateEvaluator>();
 const reservedAuthorityPolicyGateExecutionValidators =
   new WeakSet<PolicyGateExecutionInputValidator>();
+const spawnAgentCapacityReservations = new WeakMap<
+  NonNullable<ToolContext["agentControl"]>,
+  number
+>();
 const ROLE_VISIBLE_TOOL_COUNT_LIMIT = 20;
 const CONTROL_KERNEL_TOOL_GOVERNANCE_REF =
   "docs/02_ARCHITECTURE/Control_Kernel.md#53-工具面治理约定";
@@ -228,6 +233,17 @@ const ZOD_PARAMETER_SCHEMA_MAX_NODES = 20_000;
 const ZOD_PARAMETER_SCHEMA_MAX_OWN_KEYS = 512;
 const ZOD_PARAMETER_SCHEMA_MAX_PROPERTIES = 50_000;
 const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+type PreparedPolicyGateInput = {
+  decision: "allow";
+  executionInput: unknown;
+  evaluatorInput: unknown;
+};
+
+type SpawnAgentCapacityReservation =
+  | { status: "not_applicable" }
+  | { status: "reserved"; agentControl: NonNullable<ToolContext["agentControl"]> }
+  | { status: "deny"; decision: Extract<PolicyGateDecision, { decision: "deny" }> };
 
 export function createShudPolicyGateEvaluator(
   customEvaluate?: PolicyGateEvaluator
@@ -823,6 +839,34 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       );
     }
 
+    const reservation = reserveSpawnAgentCapacity(
+      this.#policyGateToolId,
+      toolContext,
+      role,
+      preparedInput.evaluatorInput
+    );
+    if (reservation.status === "deny") {
+      const durationMs = Date.now() - startTime;
+      return this.finalizePolicyGateResult(
+        toolContext,
+        buildPolicyGateDeniedToolResult(this.#policyGateToolId, reservation.decision),
+        durationMs
+      );
+    }
+
+    try {
+      return await this.runPreparedPolicyGateInput(toolContext, role, preparedInput, startTime);
+    } finally {
+      releaseSpawnAgentCapacity(reservation);
+    }
+  }
+
+  private async runPreparedPolicyGateInput(
+    toolContext: ToolContext,
+    role: HarnessRole | "unknown",
+    preparedInput: PreparedPolicyGateInput,
+    startTime: number
+  ): Promise<ToolResult> {
     if (this.#zodParameterValidatorSnapshot) {
       const parsedInput = parseToolZodParameters(
         this.#policyGateToolId,
@@ -905,7 +949,7 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
         );
       }
 
-      return this.#innerTool.run(toolContext, parsedPreparedInput.executionInput);
+      return await this.#innerTool.run(toolContext, parsedPreparedInput.executionInput);
     }
 
     const executionValidation = this.validatePolicyGateExecutionInput(preparedInput.executionInput);
@@ -951,7 +995,7 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       );
     }
 
-    return this.#innerTool.run(toolContext, preparedInput.executionInput);
+    return await this.#innerTool.run(toolContext, preparedInput.executionInput);
   }
 
   protected async execute(): Promise<ToolResult> {
@@ -1118,6 +1162,103 @@ class PolicyGatedBaseToolAdapter extends BaseTool implements PolicyGatedTool {
       };
     }
   }
+}
+
+function reserveSpawnAgentCapacity(
+  toolId: string,
+  toolContext: ToolContext,
+  role: HarnessRole | "unknown",
+  evaluatorInput: unknown
+): SpawnAgentCapacityReservation {
+  if (toolId !== "spawn_agent" || !toolContext.agentControl) {
+    return { status: "not_applicable" };
+  }
+
+  const agentControl = toolContext.agentControl;
+  let activeCount: number | undefined;
+  try {
+    activeCount = readTrustedNonNegativeInteger(agentControl.activeAgentCount);
+  } catch {
+    activeCount = undefined;
+  }
+  if (activeCount === undefined) {
+    return {
+      status: "deny",
+      decision: buildSpawnAgentConcurrencyReservationDeny(
+        toolId,
+        toolContext,
+        role,
+        evaluatorInput,
+        MAX_CONCURRENT_SUBAGENTS
+      )
+    };
+  }
+
+  const reservedCount = spawnAgentCapacityReservations.get(agentControl) ?? 0;
+  const observedActiveAndReservedCount = activeCount + reservedCount;
+  if (observedActiveAndReservedCount >= MAX_CONCURRENT_SUBAGENTS) {
+    return {
+      status: "deny",
+      decision: buildSpawnAgentConcurrencyReservationDeny(
+        toolId,
+        toolContext,
+        role,
+        evaluatorInput,
+        observedActiveAndReservedCount
+      )
+    };
+  }
+
+  spawnAgentCapacityReservations.set(agentControl, reservedCount + 1);
+  return { status: "reserved", agentControl };
+}
+
+function releaseSpawnAgentCapacity(reservation: SpawnAgentCapacityReservation): void {
+  if (reservation.status !== "reserved") {
+    return;
+  }
+
+  const reservedCount = spawnAgentCapacityReservations.get(reservation.agentControl) ?? 0;
+  if (reservedCount <= 1) {
+    spawnAgentCapacityReservations.delete(reservation.agentControl);
+    return;
+  }
+
+  spawnAgentCapacityReservations.set(reservation.agentControl, reservedCount - 1);
+}
+
+function buildSpawnAgentConcurrencyReservationDeny(
+  toolId: string,
+  toolContext: ToolContext,
+  role: HarnessRole | "unknown",
+  evaluatorInput: unknown,
+  activeSubagentCount: number
+): Extract<PolicyGateDecision, { decision: "deny" }> {
+  const decision = evaluatePolicyGate(
+    {
+      toolId,
+      role,
+      input: evaluatorInput,
+      workDir: toolContext.workDir,
+      activeSubagentCount
+    },
+    { rules: [SPAWN_CONCURRENCY_LIMIT_RULE] }
+  );
+
+  if (decision.decision === "deny") {
+    return decision;
+  }
+
+  return evaluatePolicyGate(
+    {
+      toolId: "spawn_agent",
+      role,
+      input: evaluatorInput,
+      workDir: toolContext.workDir,
+      activeSubagentCount: MAX_CONCURRENT_SUBAGENTS
+    },
+    { rules: [SPAWN_CONCURRENCY_LIMIT_RULE] }
+  ) as Extract<PolicyGateDecision, { decision: "deny" }>;
 }
 
 function buildPolicyGateToolCall(

--- a/packages/core/src/tools/policy-gate-registry.ts
+++ b/packages/core/src/tools/policy-gate-registry.ts
@@ -19,6 +19,7 @@ import {
   isReservedAuthorityPolicyRuleId,
   normalizeSpawnAgentInput,
   MAX_CONCURRENT_SUBAGENTS,
+  MAX_SPAWN_DEPTH,
   PolicyGateDecisionValidationError,
   PolicyGuardClassSchema,
   PolicyGateRemediationSchema,
@@ -1174,6 +1175,20 @@ function reserveSpawnAgentCapacity(
     return { status: "not_applicable" };
   }
 
+  const spawnDepth = resolveTrustedSpawnDepth(toolContext);
+  if (spawnDepth !== undefined && spawnDepth >= MAX_SPAWN_DEPTH) {
+    return {
+      status: "deny",
+      decision: buildSpawnAgentDepthReservationDeny(
+        toolId,
+        toolContext,
+        role,
+        evaluatorInput,
+        spawnDepth
+      )
+    };
+  }
+
   const agentControl = toolContext.agentControl;
   let activeCount: number | undefined;
   try {
@@ -1211,6 +1226,40 @@ function reserveSpawnAgentCapacity(
 
   spawnAgentCapacityReservations.set(agentControl, reservedCount + 1);
   return { status: "reserved", agentControl };
+}
+
+function buildSpawnAgentDepthReservationDeny(
+  toolId: string,
+  toolContext: ToolContext,
+  role: HarnessRole | "unknown",
+  evaluatorInput: unknown,
+  spawnDepth: number
+): Extract<PolicyGateDecision, { decision: "deny" }> {
+  const decision = evaluatePolicyGate(
+    {
+      toolId,
+      role,
+      input: evaluatorInput,
+      workDir: toolContext.workDir,
+      spawnDepth
+    },
+    { rules: [SPAWN_DEPTH_LIMIT_RULE] }
+  );
+
+  if (decision.decision === "deny") {
+    return decision;
+  }
+
+  return evaluatePolicyGate(
+    {
+      toolId: "spawn_agent",
+      role,
+      input: evaluatorInput,
+      workDir: toolContext.workDir,
+      spawnDepth: MAX_SPAWN_DEPTH
+    },
+    { rules: [SPAWN_DEPTH_LIMIT_RULE] }
+  ) as Extract<PolicyGateDecision, { decision: "deny" }>;
 }
 
 function releaseSpawnAgentCapacity(reservation: SpawnAgentCapacityReservation): void {


### PR DESCRIPTION
## Summary

- Add per-`agentControl` spawn capacity reservations in the SHUD policy-gated `spawn_agent` adapter.
- Deny direct concurrent admission with the existing `spawn-concurrency-limit` identity/remediation when active subagents plus reservations meet the M1 cap.
- Preserve existing `spawn-depth-limit` priority when nested spawn and active-limit conditions overlap.
- Add regression tests for direct concurrent calls, validation-denied release, inner spawn failure release, and depth-priority compatibility.
- Record the #61 high-risk OpenSpec fixture/evidence floor under `m1-foundation`.

## Scope Statement

#61 is a #27/#60 direct-entrypoint hardening follow-up. It is not M3 queue scheduling and does not change the pure #27 policy-gate rule semantics; ownership stays in the SHUD wrapper admission layer.

## Validation

- `npx --yes bun@1.2.19 test ./packages/core/src/tools/policy-gate-registry.test.ts`
- `npx --yes bun@1.2.19 run test:policy-gate`
- `npx --yes bun@1.2.19 run typecheck`
- `npx --yes bun@1.2.19 run check`
- `openspec validate m1-foundation --strict --no-interactive`
- `git diff --check`
- `git -C zero diff --quiet`
- CI run `28882135054`, attempt 2: `docs-links`, `linux-base`, `macos-seatbelt`, and `check` passed.

## Agent Review

- Reviewer agents used: `review-correctness`, `review-integration`, `review-security-perf`, `review-test-evidence`, `review-spec-compliance`, `review-invariant-state`, plus Phase 7 final `reviewer` Gap Sweep.
- Reviewed head SHA: `7fff0983a6b89d58ba0e9052f967feee7eb72806`
- Review evidence: [Agent Review Evidence](https://github.com/DankerMu/SHUD-Harness/pull/63#issuecomment-4906186179) | [工作情况说明](https://github.com/DankerMu/SHUD-Harness/pull/63#issuecomment-4906186205)
- Local review artifacts: `.workplans/issue-61/review/round-1/`, `.workplans/issue-61/review/round-2/`, `.workplans/issue-61/review/final-review.md`
- OpenSpec change: `m1-foundation`; fixture level: expanded; repair intensity: high.
- Key findings addressed:
  - `cand-01` confirmed/fixed: depth denial now retains priority before capacity reservation; regression added.
  - `cand-02` confirmed/fixed: PR evidence now states the #27/#60 direct-entrypoint hardening boundary and non-M3/non-pure-rule semantics.
- Latest comprehensive cross-review: round 2 clean at the reviewed head SHA.
- Phase 7 final review: clean.
- Pre-merge gate: pass; residual deferrals `0`; pre-merge skip blocks `0`.

Closes #61
