### PR TITLE
feat(api): add workspace init health skeleton

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
       "name": "@shud-harness/backend",
       "dependencies": {
         "@shud-harness/core": "workspace:*",
+        "hono": "^4.7.0",
       },
     },
     "packages/core": {

--- a/dependency-lock.initial.json
+++ b/dependency-lock.initial.json
@@ -5,7 +5,7 @@
     "name": "bun",
     "version": "1.2.19",
     "lockfile_path": "bun.lock",
-    "lockfile_sha256": "cd5c9b60b977ad6debd0c23634a9c49753ac06c522f0f2dc1f76db269bd66abb"
+    "lockfile_sha256": "f4ae1f772f435473370253485389ae858085cf254ed1e8a2f441b4afcfbe846a"
   },
   "packages": [
     {

--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -642,3 +642,89 @@ Review focus:
 - Denial uses the existing spawn concurrency policy identity/remediation.
 - Reservation release is covered for success and early-failure paths.
 - Existing serialized Zero behavior and #20/#27 spawn guard behavior remain compatible.
+
+## Subagent Workflow Fixture - Issue #28
+
+Fixture level: expanded; repair intensity: high
+Project profile: SHUD-Harness
+
+Expanded-trigger rationale:
+- Core triggers: public REST API entrypoints, workspace directory writes, path/schema/field contracts, readiness state, and error/status compatibility.
+- Profile triggers: `workspace`, `readiness`, snapshot/readiness directories, and API evidence-chain correctness.
+
+Change surface:
+- `packages/backend/src/routes/**` and any backend app/test helpers needed to exercise routes.
+- `packages/core/src/**` workspace directory constants/helpers if implementation shares workspace tree logic.
+- Backend package scripts/tests for workspace init and health endpoints.
+
+Must preserve:
+- Runtime workspace assets remain outside tracked source; tests use temp workspaces only.
+- `workspace/` source-controlled ignore behavior and `zero/` source cleanliness remain unchanged.
+- #29 owns TaskCard creation/snapshot restore; #30 owns idempotency/lock skeleton; #31 owns structured logs; #32 owns perf smoke; #33 owns general path safety helper.
+- Health endpoint paths follow `Schemas_APIs_CLIs.md`: `GET /api/health/live`, `GET /api/health/ready`, and workspace init is `POST /api/workspace/init`.
+
+Must add/change:
+- `POST /api/workspace/init` creates the canonical M1 workspace directory tree, including `readiness/`, and is safe to call repeatedly without overwriting existing files.
+- Live health returns 2xx with `status`, `version`, `uptime_seconds`, and `timestamp`.
+- Ready health returns non-2xx before workspace initialization, and after initialization reports checks including directory tree presence, `snapshot_readable`, and `workspace_writable`.
+- Workspace-not-writable readiness reports `status=not_ready` and `workspace_writable=fail` without attempting unrelated write locations.
+
+Risk packs considered:
+- Public API / CLI / script entry: selected - three REST endpoints are public backend entrypoints.
+- Config / project setup: selected - workspace root configuration/defaulting affects local runtime setup.
+- File IO / path safety / overwrite: selected - init creates directories and readiness probes perform write checks.
+- Schema / columns / units / field names: selected - health response fields and check names are contract fields.
+- Auth / permissions / secrets: not selected - no authenticated route or secret handling in #28; deep health auth is M3+.
+- Concurrency / shared state / ordering: selected - repeated init and ready-before/after-init state transitions must be stable.
+- Resource limits / large input / discovery: selected - directory creation/probing is bounded to the canonical workspace tree.
+- Legacy compatibility / examples: selected - existing backend/ws and package typecheck/check scripts must remain green.
+- Error handling / rollback / partial outputs: selected - failed init/ready must return stable responses and not leave misleading readiness.
+- Release / packaging / dependency compatibility: selected - any backend dependency/script change must remain Bun workspace compatible.
+- Documentation / migration notes: selected - PR evidence must state M1 health skeleton scope and deferred OBS-HEALTH-003/004.
+Domain packs:
+- Scientific governance / PI gate / evidence lineage: not selected - no scientific decision/evidence claim changes.
+- Hydrology runtime / SHUD-rSHUD-AutoSHUD compatibility: not selected - no solver/runtime repo behavior changes.
+- Zero adapter / tool registry / agent role governance: not selected - no Zero adapter/tool governance changes.
+
+Invariant Matrix:
+- Governing invariant: Workspace init and readiness must report only the temp/configured workspace root's actual directory/write state and must never create, overwrite, or probe outside that root.
+- Source-of-truth identity/contract: `Workspace_Conventions.md` canonical runtime directory list, `Schemas_APIs_CLIs.md` endpoint paths, task-api spec workspace/health requirements, and OBS-HEALTH-001/002 field sets.
+- Producers: workspace root resolver/config, init route, and readiness route.
+- Validators/preflight: request method/path routing, workspace root absolute-path validation, directory existence checks, and writable probe.
+- Storage/cache/query: filesystem directories under the configured workspace root; no database or task snapshot persistence in #28.
+- Public routes/entrypoints: `POST /api/workspace/init`, `GET /api/health/live`, `GET /api/health/ready`.
+- Frontend/downstream consumers: future Dashboard/Workbench and M1 acceptance use health/status fields, but no UI data wiring in #28.
+- Failure paths/rollback/stale state: uninitialized, not-writable, and partial-directory states must produce stable not-ready responses; repeated init must be idempotent.
+- Evidence/audit/readiness: focused backend route tests, OpenSpec validation, typecheck/check, diff check, zero diff, and PR evidence.
+- Regression rows:
+  - Fresh temp workspace root -> `POST /api/workspace/init` creates canonical dirs including `readiness/` and `snapshots/`, returns success, and `GET /api/health/ready` returns 2xx with directory tree, `snapshot_readable=ok`, and `workspace_writable=ok`.
+  - Temp workspace already initialized with an existing sentinel file -> second init returns success and does not overwrite or delete the sentinel.
+  - Workspace root absent/uninitialized -> `GET /api/health/ready` returns non-2xx/not_ready while `GET /api/health/live` still returns 2xx with OBS-HEALTH-001 fields.
+  - Workspace root not writable, or writable probe failure injected where chmod is unreliable -> ready returns not_ready and `workspace_writable=fail`.
+  - Unknown or wrong method for these endpoints -> stable API-style 404/405 behavior if route helper exposes it; no framework default HTML leak.
+
+Boundary-surface checklist:
+- Public entrypoints: `POST /api/workspace/init`, `GET /api/health/live`, `GET /api/health/ready`.
+- Write/overwrite surfaces: `mkdir` for canonical workspace dirs and readiness writable probe.
+- Read surfaces: directory existence/readability checks under workspace root.
+- Producer/consumer evidence boundaries: `workspace_writable` check object and health response fields.
+- Stale-state/idempotency boundaries: repeated init, partial existing directories, and ready before/after init.
+- Unchanged downstream consumers: TaskCard API, idempotency/lock service, artifact registry, structured logs, perf smoke, frontend route data wiring.
+
+Required evidence:
+- Backend tests for init idempotency, canonical directory creation including `readiness/`, and existing-file preservation.
+- Backend tests for live health OBS-HEALTH-001 fields and ready health OBS-HEALTH-002 `workspace_writable` ok/fail states.
+- Backend tests prove ready checks include directory tree presence and `snapshot_readable`; #28 checks `snapshots/` directory readability only and does not implement TaskCard snapshot persistence.
+- Backend tests for ready-before-init non-2xx/not_ready with live still 2xx.
+- Evidence that tests use temp workspaces and do not create tracked `workspace/` assets.
+- Existing backend ws tests, typecheck, and package check remain green.
+- `bun run test:backend-api` or focused backend route test command; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`.
+
+Non-goals:
+- TaskCard create/list/detail, task snapshot persistence/restart restore, idempotency key skeleton, artifact registry, path safety helper, structured API logs, perf smoke, deep health auth, disk critical behavior, and ops dashboard.
+
+Review focus:
+- Directory creation is bounded and idempotent; no overwrite/delete of existing workspace content.
+- Health response fields match OBS-HEALTH-001/002 and path registry.
+- Ready failure states are explicit and stable rather than relying on thrown framework errors.
+- Scope stays in #28 and does not pre-implement #29/#31/#32/#33.

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -79,6 +79,16 @@
 ## 6. 后端骨架（task-api）
 
 - [ ] 6.1 `POST /api/workspace/init` 幂等目录树生成（含 `readiness/`）+ health live/ready skeleton（live 响应含 status/version/uptime_seconds/timestamp，OBS-HEALTH-001；ready 检查含 workspace_writable，OBS-HEALTH-002；路径遵 Schemas_APIs_CLIs 注册表）——依赖: 2.1
+  - Evidence floor (#28):
+    - `POST /api/workspace/init` against a fresh temp workspace creates the canonical M1 runtime directory tree from Workspace_Conventions, including `readiness/`, without creating tracked root `workspace/` assets.
+    - Repeating `POST /api/workspace/init` against an already initialized temp workspace succeeds and preserves a pre-existing sentinel file, proving no overwrite/delete behavior.
+    - `GET /api/health/live` returns 2xx with `status`, `version`, `uptime_seconds`, and `timestamp` (OBS-HEALTH-001), and does not depend on workspace readiness.
+    - `GET /api/health/ready` before workspace init returns non-2xx/not_ready while live remains 2xx.
+    - `GET /api/health/ready` after init returns 2xx/ok with checks including directory tree presence, `snapshot_readable=ok`, and `workspace_writable=ok`; #28 checks `snapshots/` directory readability only and does not implement TaskCard snapshot persistence.
+    - A non-writable workspace, or an injected writable-probe failure for platforms where chmod is unreliable, returns not_ready with `workspace_writable=fail` and does not probe outside the configured workspace root.
+    - Endpoint paths follow Schemas_APIs_CLIs: `POST /api/workspace/init`, `GET /api/health/live`, `GET /api/health/ready`.
+    - Existing backend WebSocket tests, typecheck, and package check remain green; #29/#31/#32/#33 surfaces are not pre-implemented.
+    - `bun run test:backend-api` or focused backend route test command; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`.
 - [ ] 6.2 TaskCard 最小链路：`POST/GET /api/tasks`、`GET /api/tasks/:id` + 统一错误 envelope（含 404 路由兜底）+ task snapshot 落盘/重启恢复——依赖: 4.1
 - [ ] 6.3 幂等/锁 service skeleton（相同 Idempotency-Key + 相同 request_digest 重放返回同一对象；相同 key + 不同 digest → 422 标准 envelope；M1 验证载体 = `POST /api/tasks`，key/digest 配方为 change-scoped，见 task-api spec 与 proposal Impact 账本待办）+ Artifact registry skeleton（注册/按 id 查询/落盘）——依赖: 4.1（IdempotencyRecord/LockRecord schema）
 - [ ] 6.4 结构化 NDJSON API 请求日志中间件（OBS-LOG-001 八字段：ts/level/service/event/request_id/route/status/duration_ms；secret 仅以 ref/[REDACTED] 形式出现，OBS-LOG-002）

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test:policy-gate": "bun test ./packages/core/src/tools/policy-gate-core.test.ts ./packages/core/src/tools/policy-gate-registry.test.ts ./packages/core/src/tools/raw-data-sandbox.test.ts",
     "test:tool-registry-governance": "bun test ./packages/core/src/tools/role-tool-map.test.ts",
+    "test:backend-api": "bun test ./packages/backend/src/routes/*.test.ts",
     "test:backend-ws": "bun test ./packages/backend/src/ws/index.test.ts",
     "test:schemas": "bun test ./packages/core/src/domain/schemas/core-schemas.test.ts",
     "schema:generate": "bun scripts/schema/generate.ts",
@@ -18,7 +19,7 @@
     "schema:check": "sh scripts/schema/check.sh",
     "validate:dependency-lock": "node scripts/dependency-lock/validate.mjs",
     "test:dependency-lock": "sh scripts/dependency-lock/self_test.sh",
-    "check": "bun run typecheck && bun run test:policy-gate && bun run test:tool-registry-governance && bun run test:backend-ws && bun run test:schemas"
+    "check": "bun run typecheck && bun run test:policy-gate && bun run test:tool-registry-governance && bun run test:backend-api && bun run test:backend-ws && bun run test:schemas"
   },
   "devDependencies": {
     "typescript": "5.8.3"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@shud-harness/core": "workspace:*"
+    "@shud-harness/core": "workspace:*",
+    "hono": "^4.7.0"
   }
 }

--- a/packages/backend/src/routes/index.test.ts
+++ b/packages/backend/src/routes/index.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  createBackendApi,
+  WORKSPACE_CANONICAL_DIRECTORIES,
+  type WorkspaceReadyResponse
+} from "./index";
+
+const tempRoots: string[] = [];
+
+describe("backend workspace and health routes", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempRoots.splice(0).map((tempRoot) => rm(tempRoot, { recursive: true, force: true }))
+    );
+  });
+
+  test("POST /api/workspace/init creates the canonical M1 runtime directory tree", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({ workspaceRoot });
+
+    const response = await app.request("/api/workspace/init", { method: "POST" });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      status: "ok",
+      directory_count: WORKSPACE_CANONICAL_DIRECTORIES.length,
+      directories: WORKSPACE_CANONICAL_DIRECTORIES
+    });
+    expect(body.directories).toContain("readiness");
+    expect(body.directories).toContain("snapshots");
+
+    for (const relativeDir of WORKSPACE_CANONICAL_DIRECTORIES) {
+      expect((await stat(join(workspaceRoot, relativeDir))).isDirectory()).toBe(true);
+    }
+  });
+
+  test("POST /api/workspace/init is idempotent and preserves existing files", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({ workspaceRoot });
+    const sentinelPath = join(workspaceRoot, "readiness", "sentinel.txt");
+
+    expect((await app.request("/api/workspace/init", { method: "POST" })).status).toBe(200);
+    await writeFile(sentinelPath, "preserve me", { flag: "wx" });
+
+    const response = await app.request("/api/workspace/init", { method: "POST" });
+
+    expect(response.status).toBe(200);
+    expect(await readFile(sentinelPath, "utf8")).toBe("preserve me");
+  });
+
+  test("GET /api/health/live returns OBS-HEALTH-001 fields without workspace readiness", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({
+      workspaceRoot,
+      version: "test-version",
+      startTimeMs: Date.parse("2026-07-07T00:00:00.000Z"),
+      now: () => new Date("2026-07-07T00:00:03.500Z")
+    });
+
+    const response = await app.request("/api/health/live");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      status: "ok",
+      version: "test-version",
+      uptime_seconds: 3.5,
+      timestamp: "2026-07-07T00:00:03.500Z"
+    });
+  });
+
+  test("GET /api/health/ready is not_ready before init while live stays ok", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({ workspaceRoot });
+
+    const readyResponse = await app.request("/api/health/ready");
+    const readyBody = (await readyResponse.json()) as WorkspaceReadyResponse;
+    const liveResponse = await app.request("/api/health/live");
+
+    expect(readyResponse.status).toBe(503);
+    expect(readyBody.status).toBe("not_ready");
+    expect(readyBody.checks.directory_tree).toBe("fail");
+    expect(readyBody.checks.snapshot_readable).toBe("fail");
+    expect(readyBody.checks.workspace_writable).toBe("fail");
+    expect(liveResponse.status).toBe(200);
+  });
+
+  test("GET /api/health/ready is ok after init with directory, snapshot, and writable checks", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({ workspaceRoot });
+
+    expect((await app.request("/api/workspace/init", { method: "POST" })).status).toBe(200);
+    const readyResponse = await app.request("/api/health/ready");
+    const readyBody = (await readyResponse.json()) as WorkspaceReadyResponse;
+
+    expect(readyResponse.status).toBe(200);
+    expect(readyBody.status).toBe("ok");
+    expect(readyBody.checks).toEqual({
+      directory_tree: "ok",
+      snapshot_readable: "ok",
+      workspace_writable: "ok"
+    });
+    expect(readyBody.missing_directories).toBeUndefined();
+  });
+
+  test("GET /api/health/ready reports injected workspace_writable failure in the configured root", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const probeRoots: string[] = [];
+    const app = createBackendApi({
+      workspaceRoot,
+      writableProbe: ({ workspaceRoot: probeRoot }) => {
+        probeRoots.push(probeRoot);
+        return false;
+      }
+    });
+
+    expect((await app.request("/api/workspace/init", { method: "POST" })).status).toBe(200);
+    const readyResponse = await app.request("/api/health/ready");
+    const readyBody = (await readyResponse.json()) as WorkspaceReadyResponse;
+
+    expect(readyResponse.status).toBe(503);
+    expect(readyBody.status).toBe("not_ready");
+    expect(readyBody.checks.directory_tree).toBe("ok");
+    expect(readyBody.checks.snapshot_readable).toBe("ok");
+    expect(readyBody.checks.workspace_writable).toBe("fail");
+    expect(probeRoots).toEqual([resolve(workspaceRoot)]);
+  });
+});
+
+async function createTempWorkspacePath(): Promise<{ tempRoot: string; workspaceRoot: string }> {
+  const tempRoot = await mkdtemp(join(tmpdir(), "shud-harness-backend-routes-"));
+  return {
+    tempRoot,
+    workspaceRoot: join(tempRoot, "workspace")
+  };
+}

--- a/packages/backend/src/routes/index.test.ts
+++ b/packages/backend/src/routes/index.test.ts
@@ -67,6 +67,7 @@ describe("backend workspace and health routes", () => {
     tempRoots.push(tempRoot);
     const app = createBackendApi({ workspaceRoot });
 
+    await expectPathMissing(workspaceRoot);
     const response = await app.request("/api/workspace/init", { method: "POST" });
     const body = await response.json();
 
@@ -93,6 +94,21 @@ describe("backend workspace and health routes", () => {
       snapshot_readable: "ok",
       workspace_writable: "ok"
     });
+  });
+
+  test("POST /api/workspace/init creates an absent workspace root leaf when its parent is safe", async () => {
+    const tempRoot = await createTempRoot("shud-harness-backend-routes-leaf-");
+    tempRoots.push(tempRoot);
+    const workspaceRoot = join(tempRoot, "workspace");
+    const app = createBackendApi({ workspaceRoot });
+
+    await expectPathMissing(workspaceRoot);
+    const response = await app.request("/api/workspace/init", { method: "POST" });
+
+    expect(response.status).toBe(200);
+    expect((await stat(workspaceRoot)).isDirectory()).toBe(true);
+    expect((await stat(join(workspaceRoot, "snapshots"))).isDirectory()).toBe(true);
+    expect((await stat(join(workspaceRoot, "readiness"))).isDirectory()).toBe(true);
   });
 
   test("POST /api/workspace/init is idempotent and preserves existing files", async () => {
@@ -242,6 +258,19 @@ describe("backend workspace and health routes", () => {
     expect(readyBody.status).toBe("ok");
     expect((await stat(join(workspaceRoot, "readiness"))).isDirectory()).toBe(true);
     await expectPathMissing(join(legacyRoot, "readiness"));
+  });
+
+  test("POST /api/workspace/init rejects a missing parent outside the configured root leaf", async () => {
+    const tempRoot = await createTempRoot("shud-harness-backend-routes-missing-parent-");
+    tempRoots.push(tempRoot);
+    const missingParent = join(tempRoot, "missing-parent");
+    const workspaceRoot = join(missingParent, "workspace");
+    const app = createBackendApi({ workspaceRoot });
+
+    const response = await app.request("/api/workspace/init", { method: "POST" });
+
+    expect(response.status).toBe(500);
+    await expectPathMissing(missingParent);
   });
 
   test("POST /api/workspace/init rejects a symlinked canonical parent without writing outside", async () => {
@@ -394,6 +423,26 @@ describe("backend workspace and health routes", () => {
       snapshot_readable: "fail",
       workspace_writable: "ok"
     });
+  });
+
+  test("GET /api/health/ready accepts a default snapshot readability probe with many entries", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({ workspaceRoot });
+
+    expect((await app.request("/api/workspace/init", { method: "POST" })).status).toBe(200);
+    await Promise.all(
+      Array.from({ length: 512 }, (_, index) =>
+        writeFile(join(workspaceRoot, "snapshots", `snapshot-${index}.json`), "{}")
+      )
+    );
+
+    const readyResponse = await app.request("/api/health/ready");
+    const readyBody = (await readyResponse.json()) as WorkspaceReadyResponse;
+
+    expect(readyResponse.status).toBe(200);
+    expect(readyBody.status).toBe("ok");
+    expect(readyBody.checks.snapshot_readable).toBe("ok");
   });
 });
 

--- a/packages/backend/src/routes/index.test.ts
+++ b/packages/backend/src/routes/index.test.ts
@@ -4,6 +4,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  realpath,
   rm,
   stat,
   symlink,
@@ -109,6 +110,23 @@ describe("backend workspace and health routes", () => {
     expect(await readFile(sentinelPath, "utf8")).toBe("preserve me");
   });
 
+  test("POST /api/workspace/init tolerates concurrent duplicate requests", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({ workspaceRoot });
+
+    const responses = await Promise.all(
+      Array.from({ length: 6 }, () =>
+        app.request("/api/workspace/init", { method: "POST" })
+      )
+    );
+
+    expect(responses.map((response) => response.status)).toEqual([200, 200, 200, 200, 200, 200]);
+    for (const relativeDir of EXPECTED_M1_RUNTIME_DIRECTORIES) {
+      expect((await stat(join(workspaceRoot, relativeDir))).isDirectory()).toBe(true);
+    }
+  });
+
   test("GET /api/health/live returns OBS-HEALTH-001 fields without workspace readiness", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -192,7 +210,7 @@ describe("backend workspace and health routes", () => {
   });
 
   test("blank workspace option and env values fall back to workspace under the current cwd", async () => {
-    const tempRoot = await mkdtemp(join(tmpdir(), "shud-harness-backend-routes-cwd-"));
+    const tempRoot = await createTempRoot("shud-harness-backend-routes-cwd-");
     tempRoots.push(tempRoot);
     process.chdir(tempRoot);
     process.env.HARNESS_WORKSPACE_DIR = "   ";
@@ -208,7 +226,7 @@ describe("backend workspace and health routes", () => {
   });
 
   test("HARNESS_WORKSPACE_DIR configures workspace root and takes precedence over the legacy env", async () => {
-    const tempRoot = await mkdtemp(join(tmpdir(), "shud-harness-backend-routes-env-"));
+    const tempRoot = await createTempRoot("shud-harness-backend-routes-env-");
     tempRoots.push(tempRoot);
     const workspaceRoot = join(tempRoot, "canonical-workspace");
     const legacyRoot = join(tempRoot, "legacy-workspace");
@@ -246,6 +264,47 @@ describe("backend workspace and health routes", () => {
     expect(readyBody.checks.directory_tree).toBe("fail");
   });
 
+  test("POST /api/workspace/init rejects a symlinked configured ancestor without writing outside", async () => {
+    const tempRoot = await createTempRoot("shud-harness-backend-routes-link-");
+    tempRoots.push(tempRoot);
+    const baseRoot = join(tempRoot, "base");
+    const outsideRoot = join(tempRoot, "outside");
+    const linkPath = join(baseRoot, "link");
+    const workspaceRoot = join(linkPath, "workspace");
+    await mkdir(baseRoot);
+    await mkdir(outsideRoot);
+    await symlink(outsideRoot, linkPath, "dir");
+    const app = createBackendApi({ workspaceRoot });
+
+    const response = await app.request("/api/workspace/init", { method: "POST" });
+    const readyResponse = await app.request("/api/health/ready");
+    const readyBody = (await readyResponse.json()) as WorkspaceReadyResponse;
+
+    expect(response.status).toBe(500);
+    await expectPathMissing(join(outsideRoot, "workspace", "readiness"));
+    expect(readyResponse.status).toBe(503);
+    expect(readyBody.status).toBe("not_ready");
+    expect(readyBody.checks).toEqual({
+      directory_tree: "fail",
+      snapshot_readable: "fail",
+      workspace_writable: "fail"
+    });
+  });
+
+  test("POST /api/workspace/init rejects a symlinked workspace root without writing outside", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const outsideRoot = join(tempRoot, "outside-root");
+    await mkdir(outsideRoot);
+    await symlink(outsideRoot, workspaceRoot, "dir");
+    const app = createBackendApi({ workspaceRoot });
+
+    const response = await app.request("/api/workspace/init", { method: "POST" });
+
+    expect(response.status).toBe(500);
+    await expectPathMissing(join(outsideRoot, "readiness"));
+  });
+
   test("GET /api/health/ready rejects a symlinked canonical leaf as not readable", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -263,6 +322,33 @@ describe("backend workspace and health routes", () => {
     expect(readyBody.checks.directory_tree).toBe("fail");
     expect(readyBody.checks.snapshot_readable).toBe("fail");
     expect(readyBody.checks.workspace_writable).toBe("ok");
+  });
+
+  test("GET /api/health/ready revalidates a snapshot symlink swap after probing", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const outsideSnapshots = join(tempRoot, "outside-snapshots");
+    await mkdir(outsideSnapshots, { recursive: true });
+    await createExpectedRuntimeTree(workspaceRoot);
+    const app = createBackendApi({
+      workspaceRoot,
+      snapshotReadableProbe: async ({ snapshotsPath }) => {
+        await rm(snapshotsPath, { recursive: true, force: true });
+        await symlink(outsideSnapshots, snapshotsPath, "dir");
+        return true;
+      }
+    });
+
+    const readyResponse = await app.request("/api/health/ready");
+    const readyBody = (await readyResponse.json()) as WorkspaceReadyResponse;
+
+    expect(readyResponse.status).toBe(503);
+    expect(readyBody.status).toBe("not_ready");
+    expect(readyBody.checks).toEqual({
+      directory_tree: "ok",
+      snapshot_readable: "fail",
+      workspace_writable: "ok"
+    });
   });
 
   test("GET /api/health/ready does not run the writable probe for a symlinked workspace root", async () => {
@@ -312,11 +398,15 @@ describe("backend workspace and health routes", () => {
 });
 
 async function createTempWorkspacePath(): Promise<{ tempRoot: string; workspaceRoot: string }> {
-  const tempRoot = await mkdtemp(join(tmpdir(), "shud-harness-backend-routes-"));
+  const tempRoot = await createTempRoot("shud-harness-backend-routes-");
   return {
     tempRoot,
     workspaceRoot: join(tempRoot, "workspace")
   };
+}
+
+async function createTempRoot(prefix: string): Promise<string> {
+  return await realpath(await mkdtemp(join(tmpdir(), prefix)));
 }
 
 async function createExpectedRuntimeTree(

--- a/packages/backend/src/routes/index.test.ts
+++ b/packages/backend/src/routes/index.test.ts
@@ -1,17 +1,61 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import {
-  createBackendApi,
-  WORKSPACE_CANONICAL_DIRECTORIES,
-  type WorkspaceReadyResponse
-} from "./index";
+import { createBackendApi, type WorkspaceReadyResponse } from "./index";
 
 const tempRoots: string[] = [];
+const originalCwd = process.cwd();
+const originalHarnessWorkspaceDir = process.env.HARNESS_WORKSPACE_DIR;
+const originalLegacyWorkspaceRoot = process.env.SHUD_HARNESS_WORKSPACE_ROOT;
+
+const EXPECTED_M1_RUNTIME_DIRECTORIES = [
+  "repos",
+  "repos/SHUD",
+  "repos/rSHUD",
+  "repos/AutoSHUD",
+  "repos/zero",
+  "stacks",
+  "data",
+  "tasks",
+  "jobs",
+  "runs",
+  "artifacts",
+  "artifacts/logs",
+  "artifacts/figures",
+  "artifacts/metrics",
+  "artifacts/reports",
+  "artifacts/patches",
+  "artifacts/repo_context",
+  "artifacts/toolcalls",
+  "artifacts/manifests",
+  "reports",
+  "sessions",
+  "warehouse",
+  "tmp",
+  "snapshots",
+  "locks",
+  "exports",
+  "packages",
+  "notifications",
+  "readiness"
+] as const;
 
 describe("backend workspace and health routes", () => {
   afterEach(async () => {
+    process.chdir(originalCwd);
+    restoreEnv("HARNESS_WORKSPACE_DIR", originalHarnessWorkspaceDir);
+    restoreEnv("SHUD_HARNESS_WORKSPACE_ROOT", originalLegacyWorkspaceRoot);
+
     await Promise.all(
       tempRoots.splice(0).map((tempRoot) => rm(tempRoot, { recursive: true, force: true }))
     );
@@ -28,15 +72,26 @@ describe("backend workspace and health routes", () => {
     expect(response.status).toBe(200);
     expect(body).toEqual({
       status: "ok",
-      directory_count: WORKSPACE_CANONICAL_DIRECTORIES.length,
-      directories: WORKSPACE_CANONICAL_DIRECTORIES
+      directory_count: EXPECTED_M1_RUNTIME_DIRECTORIES.length,
+      directories: EXPECTED_M1_RUNTIME_DIRECTORIES
     });
     expect(body.directories).toContain("readiness");
     expect(body.directories).toContain("snapshots");
 
-    for (const relativeDir of WORKSPACE_CANONICAL_DIRECTORIES) {
+    for (const relativeDir of EXPECTED_M1_RUNTIME_DIRECTORIES) {
       expect((await stat(join(workspaceRoot, relativeDir))).isDirectory()).toBe(true);
     }
+
+    const readyResponse = await app.request("/api/health/ready");
+    const readyBody = (await readyResponse.json()) as WorkspaceReadyResponse;
+
+    expect(readyResponse.status).toBe(200);
+    expect(readyBody.status).toBe("ok");
+    expect(readyBody.checks).toEqual({
+      directory_tree: "ok",
+      snapshot_readable: "ok",
+      workspace_writable: "ok"
+    });
   });
 
   test("POST /api/workspace/init is idempotent and preserves existing files", async () => {
@@ -135,6 +190,125 @@ describe("backend workspace and health routes", () => {
     expect(readyBody.checks.workspace_writable).toBe("fail");
     expect(probeRoots).toEqual([resolve(workspaceRoot)]);
   });
+
+  test("blank workspace option and env values fall back to workspace under the current cwd", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "shud-harness-backend-routes-cwd-"));
+    tempRoots.push(tempRoot);
+    process.chdir(tempRoot);
+    process.env.HARNESS_WORKSPACE_DIR = "   ";
+    process.env.SHUD_HARNESS_WORKSPACE_ROOT = "";
+    const app = createBackendApi({ workspaceRoot: "\n\t " });
+
+    const response = await app.request("/api/workspace/init", { method: "POST" });
+
+    expect(response.status).toBe(200);
+    for (const relativeDir of EXPECTED_M1_RUNTIME_DIRECTORIES) {
+      expect((await stat(join(tempRoot, "workspace", relativeDir))).isDirectory()).toBe(true);
+    }
+  });
+
+  test("HARNESS_WORKSPACE_DIR configures workspace root and takes precedence over the legacy env", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "shud-harness-backend-routes-env-"));
+    tempRoots.push(tempRoot);
+    const workspaceRoot = join(tempRoot, "canonical-workspace");
+    const legacyRoot = join(tempRoot, "legacy-workspace");
+    process.env.HARNESS_WORKSPACE_DIR = workspaceRoot;
+    process.env.SHUD_HARNESS_WORKSPACE_ROOT = legacyRoot;
+    const app = createBackendApi();
+
+    expect((await app.request("/api/workspace/init", { method: "POST" })).status).toBe(200);
+    const readyResponse = await app.request("/api/health/ready");
+    const readyBody = (await readyResponse.json()) as WorkspaceReadyResponse;
+
+    expect(readyResponse.status).toBe(200);
+    expect(readyBody.status).toBe("ok");
+    expect((await stat(join(workspaceRoot, "readiness"))).isDirectory()).toBe(true);
+    await expectPathMissing(join(legacyRoot, "readiness"));
+  });
+
+  test("POST /api/workspace/init rejects a symlinked canonical parent without writing outside", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const outsideRoot = join(tempRoot, "outside-repos");
+    await mkdir(workspaceRoot, { recursive: true });
+    await mkdir(outsideRoot);
+    await symlink(outsideRoot, join(workspaceRoot, "repos"), "dir");
+    const app = createBackendApi({ workspaceRoot });
+
+    const response = await app.request("/api/workspace/init", { method: "POST" });
+    const readyResponse = await app.request("/api/health/ready");
+    const readyBody = (await readyResponse.json()) as WorkspaceReadyResponse;
+
+    expect(response.status).toBe(500);
+    await expectPathMissing(join(outsideRoot, "SHUD"));
+    expect(readyResponse.status).toBe(503);
+    expect(readyBody.status).toBe("not_ready");
+    expect(readyBody.checks.directory_tree).toBe("fail");
+  });
+
+  test("GET /api/health/ready rejects a symlinked canonical leaf as not readable", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const outsideSnapshots = join(tempRoot, "outside-snapshots");
+    await mkdir(outsideSnapshots, { recursive: true });
+    await createExpectedRuntimeTree(workspaceRoot, { skip: new Set(["snapshots"]) });
+    await symlink(outsideSnapshots, join(workspaceRoot, "snapshots"), "dir");
+    const app = createBackendApi({ workspaceRoot });
+
+    const readyResponse = await app.request("/api/health/ready");
+    const readyBody = (await readyResponse.json()) as WorkspaceReadyResponse;
+
+    expect(readyResponse.status).toBe(503);
+    expect(readyBody.status).toBe("not_ready");
+    expect(readyBody.checks.directory_tree).toBe("fail");
+    expect(readyBody.checks.snapshot_readable).toBe("fail");
+    expect(readyBody.checks.workspace_writable).toBe("ok");
+  });
+
+  test("GET /api/health/ready does not run the writable probe for a symlinked workspace root", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const outsideRoot = join(tempRoot, "outside-root");
+    await mkdir(outsideRoot);
+    await symlink(outsideRoot, workspaceRoot, "dir");
+    const probeRoots: string[] = [];
+    const app = createBackendApi({
+      workspaceRoot,
+      writableProbe: ({ workspaceRoot: probeRoot }) => {
+        probeRoots.push(probeRoot);
+        return true;
+      }
+    });
+
+    const readyResponse = await app.request("/api/health/ready");
+    const readyBody = (await readyResponse.json()) as WorkspaceReadyResponse;
+
+    expect(readyResponse.status).toBe(503);
+    expect(readyBody.status).toBe("not_ready");
+    expect(readyBody.checks.workspace_writable).toBe("fail");
+    expect(probeRoots).toEqual([]);
+  });
+
+  test("GET /api/health/ready isolates injected snapshot_readable failure after init", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({
+      workspaceRoot,
+      snapshotReadableProbe: () => false
+    });
+
+    expect((await app.request("/api/workspace/init", { method: "POST" })).status).toBe(200);
+    const readyResponse = await app.request("/api/health/ready");
+    const readyBody = (await readyResponse.json()) as WorkspaceReadyResponse;
+
+    expect(readyResponse.status).toBe(503);
+    expect(readyBody.status).toBe("not_ready");
+    expect(readyBody.checks).toEqual({
+      directory_tree: "ok",
+      snapshot_readable: "fail",
+      workspace_writable: "ok"
+    });
+  });
 });
 
 async function createTempWorkspacePath(): Promise<{ tempRoot: string; workspaceRoot: string }> {
@@ -143,4 +317,36 @@ async function createTempWorkspacePath(): Promise<{ tempRoot: string; workspaceR
     tempRoot,
     workspaceRoot: join(tempRoot, "workspace")
   };
+}
+
+async function createExpectedRuntimeTree(
+  workspaceRoot: string,
+  options: { skip?: ReadonlySet<string> } = {}
+): Promise<void> {
+  await mkdir(workspaceRoot, { recursive: true });
+  for (const relativeDir of EXPECTED_M1_RUNTIME_DIRECTORIES) {
+    if (options.skip?.has(relativeDir)) {
+      continue;
+    }
+    await mkdir(join(workspaceRoot, relativeDir), { recursive: true });
+  }
+}
+
+async function expectPathMissing(path: string): Promise<void> {
+  try {
+    await access(path);
+  } catch {
+    return;
+  }
+
+  throw new Error(`Expected path to be missing: ${path}`);
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
 }

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -1,3 +1,238 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readdir, stat, unlink, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { Hono } from "hono";
+
 export const BACKEND_ROUTES_NAMESPACE = "backend/routes" as const;
 
 export type BackendRoutesNamespace = typeof BACKEND_ROUTES_NAMESPACE;
+
+export const WORKSPACE_CANONICAL_DIRECTORIES = [
+  "repos",
+  "repos/SHUD",
+  "repos/rSHUD",
+  "repos/AutoSHUD",
+  "repos/zero",
+  "stacks",
+  "data",
+  "tasks",
+  "jobs",
+  "runs",
+  "artifacts",
+  "artifacts/logs",
+  "artifacts/figures",
+  "artifacts/metrics",
+  "artifacts/reports",
+  "artifacts/patches",
+  "artifacts/repo_context",
+  "artifacts/toolcalls",
+  "artifacts/manifests",
+  "reports",
+  "sessions",
+  "warehouse",
+  "tmp",
+  "snapshots",
+  "locks",
+  "exports",
+  "packages",
+  "notifications",
+  "readiness"
+] as const;
+
+export type WorkspaceCanonicalDirectory = (typeof WORKSPACE_CANONICAL_DIRECTORIES)[number];
+export type WorkspaceHealthCheckStatus = "ok" | "fail";
+export type WorkspaceReadyStatus = "ok" | "not_ready";
+
+export interface WorkspaceWritableProbeInput {
+  workspaceRoot: string;
+}
+
+export type WorkspaceWritableProbe = (
+  input: WorkspaceWritableProbeInput
+) => Promise<boolean> | boolean;
+
+export interface BackendApiOptions {
+  workspaceRoot?: string;
+  version?: string;
+  startTimeMs?: number;
+  now?: () => Date;
+  writableProbe?: WorkspaceWritableProbe;
+}
+
+export interface WorkspaceInitResponse {
+  status: "ok";
+  directory_count: number;
+  directories: readonly WorkspaceCanonicalDirectory[];
+}
+
+export interface WorkspaceLiveResponse {
+  status: "ok";
+  version: string;
+  uptime_seconds: number;
+  timestamp: string;
+}
+
+export interface WorkspaceReadyResponse {
+  status: WorkspaceReadyStatus;
+  timestamp: string;
+  checks: {
+    directory_tree: WorkspaceHealthCheckStatus;
+    snapshot_readable: WorkspaceHealthCheckStatus;
+    workspace_writable: WorkspaceHealthCheckStatus;
+  };
+  missing_directories?: readonly WorkspaceCanonicalDirectory[];
+}
+
+interface WorkspaceRoutesService {
+  initWorkspace: () => Promise<WorkspaceInitResponse>;
+  live: () => WorkspaceLiveResponse;
+  ready: () => Promise<WorkspaceReadyResponse>;
+}
+
+export function createBackendApi(options: BackendApiOptions = {}): Hono {
+  const app = new Hono();
+  const service = createWorkspaceRoutesService(options);
+
+  app.post("/api/workspace/init", async (c) => {
+    try {
+      return c.json(await service.initWorkspace(), 200);
+    } catch {
+      return c.json({ status: "error", error: "workspace_init_failed" }, 500);
+    }
+  });
+
+  app.get("/api/health/live", (c) => c.json(service.live(), 200));
+
+  app.get("/api/health/ready", async (c) => {
+    const readiness = await service.ready();
+    return c.json(readiness, readiness.status === "ok" ? 200 : 503);
+  });
+
+  return app;
+}
+
+export function createWorkspaceRoutesService(
+  options: BackendApiOptions = {}
+): WorkspaceRoutesService {
+  const workspaceRoot = resolve(
+    options.workspaceRoot ?? process.env.SHUD_HARNESS_WORKSPACE_ROOT ?? "workspace"
+  );
+  const version = options.version ?? process.env.npm_package_version ?? "0.0.0";
+  const now = options.now ?? (() => new Date());
+  const startTimeMs = options.startTimeMs ?? Date.now();
+  const writableProbe = options.writableProbe ?? defaultWorkspaceWritableProbe;
+
+  return {
+    async initWorkspace(): Promise<WorkspaceInitResponse> {
+      await mkdir(workspaceRoot, { recursive: true });
+      for (const relativeDir of WORKSPACE_CANONICAL_DIRECTORIES) {
+        await mkdir(join(workspaceRoot, relativeDir), { recursive: true });
+      }
+
+      return {
+        status: "ok",
+        directory_count: WORKSPACE_CANONICAL_DIRECTORIES.length,
+        directories: WORKSPACE_CANONICAL_DIRECTORIES
+      };
+    },
+
+    live(): WorkspaceLiveResponse {
+      const currentTime = now();
+      return {
+        status: "ok",
+        version,
+        uptime_seconds: Math.max(0, (currentTime.getTime() - startTimeMs) / 1000),
+        timestamp: currentTime.toISOString()
+      };
+    },
+
+    async ready(): Promise<WorkspaceReadyResponse> {
+      const missingDirectories = await findMissingWorkspaceDirectories(workspaceRoot);
+      const snapshotReadable = await isReadableDirectory(join(workspaceRoot, "snapshots"));
+      const workspaceWritable = await probeWorkspaceWritable(workspaceRoot, writableProbe);
+      const checks = {
+        directory_tree: statusFromBoolean(missingDirectories.length === 0),
+        snapshot_readable: statusFromBoolean(snapshotReadable),
+        workspace_writable: statusFromBoolean(workspaceWritable)
+      };
+      const isReady = Object.values(checks).every((status) => status === "ok");
+
+      return {
+        status: isReady ? "ok" : "not_ready",
+        timestamp: now().toISOString(),
+        checks,
+        ...(missingDirectories.length > 0 ? { missing_directories: missingDirectories } : {})
+      };
+    }
+  };
+}
+
+async function findMissingWorkspaceDirectories(
+  workspaceRoot: string
+): Promise<WorkspaceCanonicalDirectory[]> {
+  const missingDirectories: WorkspaceCanonicalDirectory[] = [];
+
+  for (const relativeDir of WORKSPACE_CANONICAL_DIRECTORIES) {
+    if (!(await isDirectory(join(workspaceRoot, relativeDir)))) {
+      missingDirectories.push(relativeDir);
+    }
+  }
+
+  return missingDirectories;
+}
+
+async function isReadableDirectory(directoryPath: string): Promise<boolean> {
+  if (!(await isDirectory(directoryPath))) {
+    return false;
+  }
+
+  try {
+    await readdir(directoryPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isDirectory(directoryPath: string): Promise<boolean> {
+  try {
+    return (await stat(directoryPath)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function probeWorkspaceWritable(
+  workspaceRoot: string,
+  writableProbe: WorkspaceWritableProbe
+): Promise<boolean> {
+  try {
+    return await writableProbe({ workspaceRoot });
+  } catch {
+    return false;
+  }
+}
+
+function statusFromBoolean(value: boolean): WorkspaceHealthCheckStatus {
+  return value ? "ok" : "fail";
+}
+
+async function defaultWorkspaceWritableProbe(input: WorkspaceWritableProbeInput): Promise<boolean> {
+  if (!(await isDirectory(input.workspaceRoot))) {
+    return false;
+  }
+
+  const probePath = join(
+    input.workspaceRoot,
+    `.health-write-probe-${process.pid}-${randomUUID()}`
+  );
+
+  try {
+    await writeFile(probePath, "", { flag: "wx" });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await unlink(probePath).catch(() => undefined);
+  }
+}

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { lstat, mkdir, readdir, unlink, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { dirname, join, parse, resolve, sep } from "node:path";
 import { Hono } from "hono";
 
 export const BACKEND_ROUTES_NAMESPACE = "backend/routes" as const;
@@ -221,20 +221,7 @@ async function findMissingWorkspaceDirectories(
 }
 
 async function ensureWorkspaceRootDirectory(workspaceRoot: string): Promise<void> {
-  const existingRoot = await maybeLstat(workspaceRoot);
-  if (existingRoot) {
-    if (!existingRoot.isDirectory() || existingRoot.isSymbolicLink()) {
-      throw new Error("workspace_root_not_safe");
-    }
-    return;
-  }
-
-  await mkdir(workspaceRoot, { recursive: true });
-
-  const createdRoot = await maybeLstat(workspaceRoot);
-  if (!createdRoot?.isDirectory() || createdRoot.isSymbolicLink()) {
-    throw new Error("workspace_root_not_safe");
-  }
+  await ensureSafeDirectoryPath(workspaceRoot, "workspace_root_not_safe");
 }
 
 async function ensureSafeWorkspaceDirectory(
@@ -246,21 +233,7 @@ async function ensureSafeWorkspaceDirectory(
   let currentPath = workspaceRoot;
   for (const segment of relativeDir.split("/")) {
     currentPath = join(currentPath, segment);
-    const existingEntry = await maybeLstat(currentPath);
-
-    if (existingEntry) {
-      if (!existingEntry.isDirectory() || existingEntry.isSymbolicLink()) {
-        throw new Error("workspace_directory_not_safe");
-      }
-      continue;
-    }
-
-    await mkdir(currentPath);
-
-    const createdEntry = await maybeLstat(currentPath);
-    if (!createdEntry?.isDirectory() || createdEntry.isSymbolicLink()) {
-      throw new Error("workspace_directory_not_safe");
-    }
+    await ensureSafeDirectorySegment(currentPath, "workspace_directory_not_safe");
   }
 }
 
@@ -274,7 +247,8 @@ async function probeSnapshotReadable(
   }
 
   try {
-    return await snapshotReadableProbe({ workspaceRoot, snapshotsPath });
+    const readable = await snapshotReadableProbe({ workspaceRoot, snapshotsPath });
+    return Boolean(readable) && (await isSafeWorkspaceDirectory(workspaceRoot, "snapshots"));
   } catch {
     return false;
   }
@@ -295,25 +269,11 @@ async function isSafeWorkspaceDirectory(
   workspaceRoot: string,
   relativeDir: WorkspaceCanonicalDirectory
 ): Promise<boolean> {
-  if (!(await isAcceptedWorkspaceRootDirectory(workspaceRoot))) {
-    return false;
-  }
-
-  let currentPath = workspaceRoot;
-  for (const segment of relativeDir.split("/")) {
-    currentPath = join(currentPath, segment);
-    const entry = await maybeLstat(currentPath);
-    if (!entry?.isDirectory() || entry.isSymbolicLink()) {
-      return false;
-    }
-  }
-
-  return true;
+  return await isSafeExistingDirectoryPath(join(workspaceRoot, relativeDir));
 }
 
 async function isAcceptedWorkspaceRootDirectory(workspaceRoot: string): Promise<boolean> {
-  const entry = await maybeLstat(workspaceRoot);
-  return Boolean(entry?.isDirectory() && !entry.isSymbolicLink());
+  return await isSafeExistingDirectoryPath(workspaceRoot);
 }
 
 async function maybeLstat(path: string): Promise<Awaited<ReturnType<typeof lstat>> | undefined> {
@@ -333,7 +293,8 @@ async function probeWorkspaceWritable(
   }
 
   try {
-    return await writableProbe({ workspaceRoot });
+    const writable = await writableProbe({ workspaceRoot });
+    return Boolean(writable) && (await isAcceptedWorkspaceRootDirectory(workspaceRoot));
   } catch {
     return false;
   }
@@ -353,12 +314,100 @@ async function defaultWorkspaceWritableProbe(input: WorkspaceWritableProbeInput)
     `.health-write-probe-${process.pid}-${randomUUID()}`
   );
 
+  let createdProbe = false;
   try {
     await writeFile(probePath, "", { flag: "wx" });
-    return true;
+    createdProbe = true;
+    return await isAcceptedWorkspaceRootDirectory(input.workspaceRoot);
   } catch {
     return false;
   } finally {
-    await unlink(probePath).catch(() => undefined);
+    if (createdProbe && (await isAcceptedWorkspaceRootDirectory(input.workspaceRoot))) {
+      await unlink(probePath).catch(() => undefined);
+    }
   }
+}
+
+async function ensureSafeDirectoryPath(path: string, errorCode: string): Promise<void> {
+  const { rootPath, segments } = getPathParts(path);
+  const rootEntry = await maybeLstat(rootPath);
+  if (!isSafeDirectoryEntry(rootEntry)) {
+    throw new Error(errorCode);
+  }
+
+  let currentPath = rootPath;
+  for (const segment of segments) {
+    currentPath = join(currentPath, segment);
+    await ensureSafeDirectorySegment(currentPath, errorCode);
+  }
+}
+
+async function ensureSafeDirectorySegment(path: string, errorCode: string): Promise<void> {
+  const existingEntry = await maybeLstat(path);
+  if (existingEntry) {
+    if (!(await isSafeExistingDirectoryPath(path))) {
+      throw new Error(errorCode);
+    }
+    return;
+  }
+
+  const parentPath = dirname(path);
+  if (parentPath !== path && !(await isSafeExistingDirectoryPath(parentPath))) {
+    throw new Error(errorCode);
+  }
+
+  try {
+    await mkdir(path);
+  } catch (error) {
+    if (!hasErrorCode(error, "EEXIST")) {
+      throw error;
+    }
+  }
+
+  if (!(await isSafeExistingDirectoryPath(path))) {
+    throw new Error(errorCode);
+  }
+}
+
+async function isSafeExistingDirectoryPath(path: string): Promise<boolean> {
+  const { rootPath, segments } = getPathParts(path);
+  const rootEntry = await maybeLstat(rootPath);
+  if (!isSafeDirectoryEntry(rootEntry)) {
+    return false;
+  }
+
+  let currentPath = rootPath;
+  for (const segment of segments) {
+    currentPath = join(currentPath, segment);
+    const entry = await maybeLstat(currentPath);
+    if (!isSafeDirectoryEntry(entry)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function getPathParts(path: string): { rootPath: string; segments: string[] } {
+  const resolvedPath = resolve(path);
+  const rootPath = parse(resolvedPath).root;
+  return {
+    rootPath,
+    segments: resolvedPath.slice(rootPath.length).split(sep).filter(Boolean)
+  };
+}
+
+function isSafeDirectoryEntry(
+  entry: Awaited<ReturnType<typeof lstat>> | undefined
+): boolean {
+  return Boolean(entry?.isDirectory() && !entry.isSymbolicLink());
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === code
+  );
 }

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { lstat, mkdir, readdir, unlink, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { access, lstat, mkdir, unlink, writeFile } from "node:fs/promises";
 import { dirname, join, parse, resolve, sep } from "node:path";
 import { Hono } from "hono";
 
@@ -221,7 +222,30 @@ async function findMissingWorkspaceDirectories(
 }
 
 async function ensureWorkspaceRootDirectory(workspaceRoot: string): Promise<void> {
-  await ensureSafeDirectoryPath(workspaceRoot, "workspace_root_not_safe");
+  const existingEntry = await maybeLstat(workspaceRoot);
+  if (existingEntry) {
+    if (!(await isSafeExistingDirectoryPath(workspaceRoot))) {
+      throw new Error("workspace_root_not_safe");
+    }
+    return;
+  }
+
+  const parentPath = dirname(workspaceRoot);
+  if (parentPath === workspaceRoot || !(await isSafeExistingDirectoryPath(parentPath))) {
+    throw new Error("workspace_root_not_safe");
+  }
+
+  try {
+    await mkdir(workspaceRoot);
+  } catch (error) {
+    if (!hasErrorCode(error, "EEXIST")) {
+      throw error;
+    }
+  }
+
+  if (!(await isSafeExistingDirectoryPath(workspaceRoot))) {
+    throw new Error("workspace_root_not_safe");
+  }
 }
 
 async function ensureSafeWorkspaceDirectory(
@@ -258,7 +282,7 @@ async function defaultSnapshotReadableProbe(
   input: WorkspaceSnapshotReadableProbeInput
 ): Promise<boolean> {
   try {
-    await readdir(input.snapshotsPath);
+    await access(input.snapshotsPath, constants.R_OK);
     return true;
   } catch {
     return false;
@@ -325,20 +349,6 @@ async function defaultWorkspaceWritableProbe(input: WorkspaceWritableProbeInput)
     if (createdProbe && (await isAcceptedWorkspaceRootDirectory(input.workspaceRoot))) {
       await unlink(probePath).catch(() => undefined);
     }
-  }
-}
-
-async function ensureSafeDirectoryPath(path: string, errorCode: string): Promise<void> {
-  const { rootPath, segments } = getPathParts(path);
-  const rootEntry = await maybeLstat(rootPath);
-  if (!isSafeDirectoryEntry(rootEntry)) {
-    throw new Error(errorCode);
-  }
-
-  let currentPath = rootPath;
-  for (const segment of segments) {
-    currentPath = join(currentPath, segment);
-    await ensureSafeDirectorySegment(currentPath, errorCode);
   }
 }
 

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readdir, stat, unlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readdir, unlink, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { Hono } from "hono";
 
@@ -51,12 +51,22 @@ export type WorkspaceWritableProbe = (
   input: WorkspaceWritableProbeInput
 ) => Promise<boolean> | boolean;
 
+export interface WorkspaceSnapshotReadableProbeInput {
+  workspaceRoot: string;
+  snapshotsPath: string;
+}
+
+export type WorkspaceSnapshotReadableProbe = (
+  input: WorkspaceSnapshotReadableProbeInput
+) => Promise<boolean> | boolean;
+
 export interface BackendApiOptions {
   workspaceRoot?: string;
   version?: string;
   startTimeMs?: number;
   now?: () => Date;
   writableProbe?: WorkspaceWritableProbe;
+  snapshotReadableProbe?: WorkspaceSnapshotReadableProbe;
 }
 
 export interface WorkspaceInitResponse {
@@ -114,19 +124,19 @@ export function createBackendApi(options: BackendApiOptions = {}): Hono {
 export function createWorkspaceRoutesService(
   options: BackendApiOptions = {}
 ): WorkspaceRoutesService {
-  const workspaceRoot = resolve(
-    options.workspaceRoot ?? process.env.SHUD_HARNESS_WORKSPACE_ROOT ?? "workspace"
-  );
+  const workspaceRoot = resolveWorkspaceRoot(options);
   const version = options.version ?? process.env.npm_package_version ?? "0.0.0";
   const now = options.now ?? (() => new Date());
   const startTimeMs = options.startTimeMs ?? Date.now();
   const writableProbe = options.writableProbe ?? defaultWorkspaceWritableProbe;
+  const snapshotReadableProbe =
+    options.snapshotReadableProbe ?? defaultSnapshotReadableProbe;
 
   return {
     async initWorkspace(): Promise<WorkspaceInitResponse> {
-      await mkdir(workspaceRoot, { recursive: true });
+      await ensureWorkspaceRootDirectory(workspaceRoot);
       for (const relativeDir of WORKSPACE_CANONICAL_DIRECTORIES) {
-        await mkdir(join(workspaceRoot, relativeDir), { recursive: true });
+        await ensureSafeWorkspaceDirectory(workspaceRoot, relativeDir);
       }
 
       return {
@@ -148,7 +158,10 @@ export function createWorkspaceRoutesService(
 
     async ready(): Promise<WorkspaceReadyResponse> {
       const missingDirectories = await findMissingWorkspaceDirectories(workspaceRoot);
-      const snapshotReadable = await isReadableDirectory(join(workspaceRoot, "snapshots"));
+      const snapshotReadable = await probeSnapshotReadable(
+        workspaceRoot,
+        snapshotReadableProbe
+      );
       const workspaceWritable = await probeWorkspaceWritable(workspaceRoot, writableProbe);
       const checks = {
         directory_tree: statusFromBoolean(missingDirectories.length === 0),
@@ -167,13 +180,39 @@ export function createWorkspaceRoutesService(
   };
 }
 
+function resolveWorkspaceRoot(options: BackendApiOptions): string {
+  return resolve(
+    firstNonBlankString(
+      options.workspaceRoot,
+      process.env.HARNESS_WORKSPACE_DIR,
+      process.env.SHUD_HARNESS_WORKSPACE_ROOT,
+      "workspace"
+    )
+  );
+}
+
+function firstNonBlankString(...values: Array<string | undefined>): string {
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const trimmedValue = value.trim();
+    if (trimmedValue.length > 0) {
+      return trimmedValue;
+    }
+  }
+
+  return "workspace";
+}
+
 async function findMissingWorkspaceDirectories(
   workspaceRoot: string
 ): Promise<WorkspaceCanonicalDirectory[]> {
   const missingDirectories: WorkspaceCanonicalDirectory[] = [];
 
   for (const relativeDir of WORKSPACE_CANONICAL_DIRECTORIES) {
-    if (!(await isDirectory(join(workspaceRoot, relativeDir)))) {
+    if (!(await isSafeWorkspaceDirectory(workspaceRoot, relativeDir))) {
       missingDirectories.push(relativeDir);
     }
   }
@@ -181,24 +220,107 @@ async function findMissingWorkspaceDirectories(
   return missingDirectories;
 }
 
-async function isReadableDirectory(directoryPath: string): Promise<boolean> {
-  if (!(await isDirectory(directoryPath))) {
+async function ensureWorkspaceRootDirectory(workspaceRoot: string): Promise<void> {
+  const existingRoot = await maybeLstat(workspaceRoot);
+  if (existingRoot) {
+    if (!existingRoot.isDirectory() || existingRoot.isSymbolicLink()) {
+      throw new Error("workspace_root_not_safe");
+    }
+    return;
+  }
+
+  await mkdir(workspaceRoot, { recursive: true });
+
+  const createdRoot = await maybeLstat(workspaceRoot);
+  if (!createdRoot?.isDirectory() || createdRoot.isSymbolicLink()) {
+    throw new Error("workspace_root_not_safe");
+  }
+}
+
+async function ensureSafeWorkspaceDirectory(
+  workspaceRoot: string,
+  relativeDir: WorkspaceCanonicalDirectory
+): Promise<void> {
+  await ensureWorkspaceRootDirectory(workspaceRoot);
+
+  let currentPath = workspaceRoot;
+  for (const segment of relativeDir.split("/")) {
+    currentPath = join(currentPath, segment);
+    const existingEntry = await maybeLstat(currentPath);
+
+    if (existingEntry) {
+      if (!existingEntry.isDirectory() || existingEntry.isSymbolicLink()) {
+        throw new Error("workspace_directory_not_safe");
+      }
+      continue;
+    }
+
+    await mkdir(currentPath);
+
+    const createdEntry = await maybeLstat(currentPath);
+    if (!createdEntry?.isDirectory() || createdEntry.isSymbolicLink()) {
+      throw new Error("workspace_directory_not_safe");
+    }
+  }
+}
+
+async function probeSnapshotReadable(
+  workspaceRoot: string,
+  snapshotReadableProbe: WorkspaceSnapshotReadableProbe
+): Promise<boolean> {
+  const snapshotsPath = join(workspaceRoot, "snapshots");
+  if (!(await isSafeWorkspaceDirectory(workspaceRoot, "snapshots"))) {
     return false;
   }
 
   try {
-    await readdir(directoryPath);
+    return await snapshotReadableProbe({ workspaceRoot, snapshotsPath });
+  } catch {
+    return false;
+  }
+}
+
+async function defaultSnapshotReadableProbe(
+  input: WorkspaceSnapshotReadableProbeInput
+): Promise<boolean> {
+  try {
+    await readdir(input.snapshotsPath);
     return true;
   } catch {
     return false;
   }
 }
 
-async function isDirectory(directoryPath: string): Promise<boolean> {
-  try {
-    return (await stat(directoryPath)).isDirectory();
-  } catch {
+async function isSafeWorkspaceDirectory(
+  workspaceRoot: string,
+  relativeDir: WorkspaceCanonicalDirectory
+): Promise<boolean> {
+  if (!(await isAcceptedWorkspaceRootDirectory(workspaceRoot))) {
     return false;
+  }
+
+  let currentPath = workspaceRoot;
+  for (const segment of relativeDir.split("/")) {
+    currentPath = join(currentPath, segment);
+    const entry = await maybeLstat(currentPath);
+    if (!entry?.isDirectory() || entry.isSymbolicLink()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+async function isAcceptedWorkspaceRootDirectory(workspaceRoot: string): Promise<boolean> {
+  const entry = await maybeLstat(workspaceRoot);
+  return Boolean(entry?.isDirectory() && !entry.isSymbolicLink());
+}
+
+async function maybeLstat(path: string): Promise<Awaited<ReturnType<typeof lstat>> | undefined> {
+  try {
+    return await lstat(path);
+  } catch {
+    return undefined;
   }
 }
 
@@ -206,6 +328,10 @@ async function probeWorkspaceWritable(
   workspaceRoot: string,
   writableProbe: WorkspaceWritableProbe
 ): Promise<boolean> {
+  if (!(await isAcceptedWorkspaceRootDirectory(workspaceRoot))) {
+    return false;
+  }
+
   try {
     return await writableProbe({ workspaceRoot });
   } catch {
@@ -218,7 +344,7 @@ function statusFromBoolean(value: boolean): WorkspaceHealthCheckStatus {
 }
 
 async function defaultWorkspaceWritableProbe(input: WorkspaceWritableProbeInput): Promise<boolean> {
-  if (!(await isDirectory(input.workspaceRoot))) {
+  if (!(await isAcceptedWorkspaceRootDirectory(input.workspaceRoot))) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

- Add a Hono backend API factory with `POST /api/workspace/init`, `GET /api/health/live`, and `GET /api/health/ready`.
- Create the canonical M1 workspace directory tree idempotently, including `readiness/` and `snapshots/`, without overwriting existing files.
- Add live/ready health skeleton responses with OBS-HEALTH-001 fields and ready checks for directory tree, `snapshot_readable`, and `workspace_writable`.
- Add focused backend route tests and wire `test:backend-api` into root `check`.
- Record the #28 expanded/high OpenSpec fixture and synchronize backend `hono` dependency lock evidence.

## Scope Statement

#28 implements only the task-api workspace init + live/ready health skeleton. It does not implement TaskCard endpoints (#29), idempotency/lock skeleton (#30), structured API logs (#31), PERF-API-001 (#32), general path safety helper (#33), OBS-HEALTH-003 disk critical behavior, or OBS-HEALTH-004 deep health auth.

## Validation

Final head SHA: `3df0eea99796780b25c33ff157b278565b7ad2f6`

- `npx --yes bun@1.2.19 test ./packages/backend/src/routes/*.test.ts`
- `npx --yes bun@1.2.19 run test:backend-api`
- `npx --yes bun@1.2.19 run test:backend-ws`
- `npx --yes bun@1.2.19 run typecheck`
- `npx --yes bun@1.2.19 run check`
- `npx --yes bun@1.2.19 run schema:check`
- `npx --yes bun@1.2.19 run validate:dependency-lock`
- `npx --yes bun@1.2.19 install --frozen-lockfile --lockfile-only`
- `openspec validate m1-foundation --strict --no-interactive`
- `git diff --check`
- `git -C zero diff --quiet`
- `test -z "$(git ls-files workspace)"`

GitHub CI at final SHA: `docs-links`, `linux-base`, `macos-seatbelt`, and `check` all SUCCESS. PR merge state: `CLEAN`.

## Agent Review

Subagent workflow completed through Phase 8 for final head SHA `3df0eea99796780b25c33ff157b278565b7ad2f6`.

- Comprehensive review rounds: 4.
- Verified blocking findings fixed before final gate: 10 total across earlier rounds.
- Round 4 post-gate review: five clean reviewer reports plus one evidence-freshness candidate.
- Independent verifier verdict for the only Round 4 candidate: `REFUTED` after final SHA-bound CI and local gate completed.
- Phase 7 final clean-context review: clean, no merge-blocking findings.
- Known residual routed outside #28: descriptor-bound shared path safety primitive remains tracked by #33.

Closes #28
