### PR TITLE
feat(api): add task card routes and snapshots

### DIFF
--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -728,3 +728,112 @@ Review focus:
 - Health response fields match OBS-HEALTH-001/002 and path registry.
 - Ready failure states are explicit and stable rather than relying on thrown framework errors.
 - Scope stays in #28 and does not pre-implement #29/#31/#32/#33.
+
+## Subagent Workflow Fixture - Issue #29
+
+Fixture level: expanded; repair intensity: high
+Project profile: SHUD-Harness
+
+Expanded-trigger rationale:
+- Core triggers: public REST API entrypoints, TaskCard schema/field contract, persisted snapshot file output, configured workspace path boundary, API error envelope, and service restart recovery.
+- Profile triggers: `workspace`, `snapshot`, `idempotency` boundary split, and API evidence-chain correctness.
+
+Change surface:
+- `packages/core/src/domain/services/**` TaskCard service/snapshot persistence.
+- `packages/backend/src/routes/**` task routes, shared API error envelope helper, and API 404 fallback.
+- Backend route tests and package scripts needed to exercise task-api behavior.
+
+Must preserve:
+- #28 workspace init and health endpoints remain unchanged in route path, response shape, and temp-workspace test behavior.
+- Runtime workspace assets remain outside tracked source; `test -z "$(git ls-files workspace)"` stays true.
+- `zero/` remains source-clean.
+- API fallback must not shadow existing registered routes.
+- #30 owns `Idempotency-Key`, idempotency/lock service, and Artifact registry; #33 owns shared path helper wiring; #31 owns structured logs; #32 owns perf smoke; #35 owns frontend Dashboard.
+
+Must add/change:
+- `POST /api/tasks` accepts the M1 create input body:
+  ```json
+  {
+    "type": "engineering",
+    "title": "Add optional event diagnostics",
+    "question_or_goal": "Add event_flux output without breaking old rSHUD readers",
+    "inference_budget": { "mode": "normal" },
+    "created_by": "pi"
+  }
+  ```
+  `created_by` may default to a deterministic M1 actor only when omitted if tests document the default; the stored TaskCard must include `task_id`, `status="created"`, `created_by`, `current_owner`, `reviewer`, empty `linked_jobs`, empty `linked_reports`, and ISO `created_at`/`updated_at`.
+- `GET /api/tasks` returns the list/create shape that #35 Dashboard can consume: an array or object wrapper must be stable and documented in tests; #29 tests become the downstream oracle.
+- `GET /api/tasks/:id` returns the same stored TaskCard by `task_id`.
+- Standard error envelope is used for schema errors, missing task id, malformed snapshots that block recovery, existing non-directory task lanes, and unknown `/api/*` paths.
+- Task persistence writes a workspace-local task snapshot at `workspace/tasks/<task_id>/snapshot.json` plus enough data to reconstruct the full TaskCard after service re-instantiation.
+
+Snapshot shape and recovery source of truth:
+- #29 snapshot file is the M1 task-lane snapshot carrier at the canonical path `workspace/tasks/<task_id>/snapshot.json`.
+- The file must contain canonical TaskSnapshot fields from `Workspace_Snapshot_And_Recovery_Spec.md`: `task_id`, `status`, optional/nullable `runtime_phase`, optional `stack_id`/`data_id`, `linked_jobs`, `linked_runs`, `linked_reports`, `pending_pi_gates`, `latest_seq`, and `updated_at`.
+- Because #29 must restore the TaskCard list before the full M3 event bus exists, the M1 snapshot may also include a nested full `task_card` object. If present, recovery validates `task_card` with `TaskCardSchema` and validates that `task_card.task_id`, `status`, linked jobs/reports, and `updated_at` agree with the outer snapshot fields.
+- `latest_seq` is `0` in M1 skeleton snapshots because the event bus critical section is out of scope.
+- Malformed snapshot JSON, schema-mismatched snapshot fields, task-id mismatches, or an existing regular file where `workspace/tasks/<task_id>/` is needed must fail with a stable envelope and must not silently create a different accepted task. Recovery may skip malformed snapshots only if an explicit test proves the list remains stable and the error is reported through the public endpoint or service result; default preference is fail closed for M1.
+
+Risk packs considered:
+- Public API / CLI / script entry: selected - `POST /api/tasks`, `GET /api/tasks`, `GET /api/tasks/:id`, and API fallback are public backend entrypoints.
+- Config / project setup: selected - all persistence and recovery depends on the configured workspace root and its default/env resolution inherited from #28.
+- File IO / path safety / overwrite: selected - snapshots are written/read under `workspace/tasks/<task_id>/snapshot.json`; task lanes must not overwrite unrelated files or escape the configured root.
+- Schema / columns / units / field names: selected - create body, stored TaskCard, TaskSnapshot carrier, and error envelope fields are structured contracts.
+- Auth / permissions / secrets: not selected - M1 task endpoints are unauthenticated skeletons and must not handle or log secrets.
+- Concurrency / shared state / ordering: selected - create/list/detail state and snapshot writes must remain coherent across sequential and concurrent creates in one process.
+- Resource limits / large input / discovery: selected - startup hydration must scan only `workspace/tasks/*/snapshot.json` and use bounded JSON reads.
+- Legacy compatibility / examples: selected - the API registry example create body and existing #28/#20 backend/ws tests remain compatible.
+- Error handling / rollback / partial outputs: selected - invalid requests and failed persistence/recovery must return canonical envelope and not leave accepted task state behind.
+- Release / packaging / dependency compatibility: selected - no new non-M1 runtime dependency; Bun workspace typecheck/check remain green.
+- Documentation / migration notes: selected - PR body/evidence must state exact #29 response shape, snapshot shape, and deferred #30/#33/#35 boundaries.
+Domain packs:
+- Scientific governance / PI gate / evidence lineage: selected - TaskCard is the PI-visible unit of work; no scientific claims or PI decisions are made in this slice.
+- Hydrology runtime / SHUD-rSHUD-AutoSHUD compatibility: not selected - no solver/runtime behavior changes.
+- Zero adapter / tool registry / agent role governance: not selected - no Zero/tool governance changes.
+
+Invariant Matrix:
+- Governing invariant: Every accepted TaskCard is schema-valid, queryable by id/list, and represented by exactly one workspace-local snapshot; rejected requests, malformed recovery state, and unknown API paths return canonical envelope errors without creating or switching accepted task state.
+- Source-of-truth identity/contract: `task_id`, `TaskCardSchema`, create-body schema, API error envelope fields, configured workspace root, and `workspace/tasks/<task_id>/snapshot.json`.
+- Producers: `POST /api/tasks`, task service create path, task snapshot writer.
+- Validators/preflight: create-body validation, TaskCard schema validation before persistence, TaskSnapshot parse validation during recovery, safe task-id/path-segment validation.
+- Storage/cache/query: in-memory task index hydrated from workspace task snapshots; task snapshot JSON files under configured workspace root.
+- Public routes/entrypoints: `POST /api/tasks`, `GET /api/tasks`, `GET /api/tasks/:id`, API 404 fallback.
+- Frontend/downstream consumers: #35 Dashboard consumes list/create response shapes and refresh recovery; Workbench task-context navigation remains out of scope.
+- Failure paths/rollback/stale state: missing required field, invalid enum, unknown task id, unknown API route, malformed/stale snapshot, existing regular-file task lane, duplicate generated id collision, and service re-instantiation after create.
+- Evidence/audit/readiness: backend route tests, focused core service tests if needed, `test:backend-api`, backend/ws tests, root `check`, OpenSpec validation, diff check, zero diff, and PR evidence.
+- Regression rows:
+  - Valid create body above -> 201 stored TaskCard with generated `task_id`, `status="created"`, default/generated owner fields, empty link arrays, timestamps, and no idempotency record.
+  - Created task -> `GET /api/tasks/:id` and `GET /api/tasks` return the same TaskCard shape; #28 health/live/ready tests still pass.
+  - Created task -> snapshot exists at `workspace/tasks/<task_id>/snapshot.json`, contains required TaskSnapshot fields, and nested `task_card` if used; unrelated files in the task lane survive snapshot rewrite.
+  - Fresh app/service over same workspace -> `GET /api/tasks` includes the prior TaskCard from snapshot.
+  - Missing required field, invalid enum, or malformed JSON -> 400 envelope containing all canonical fields under `error` plus field-level `evidence_refs`; no task snapshot is written.
+  - Unknown `/api/*` path or missing task id -> 404 envelope containing all canonical fields, not a Hono/framework default body.
+  - Malformed snapshot JSON, task-id mismatch, or existing regular file where a task directory is needed -> stable envelope or documented fail-closed recovery result; no alternate task id is created and no workspace outside configured root is touched.
+  - Concurrent or sequential valid creates in one process -> unique task ids, coherent list/detail responses, and one snapshot per accepted task.
+  - Startup hydration with unrelated files/directories under `workspace/tasks/` -> reads only bounded `*/snapshot.json` candidates and ignores/handles unrelated lanes without broad traversal.
+
+Boundary-surface checklist:
+- Public entrypoints: `POST /api/tasks`, `GET /api/tasks`, `GET /api/tasks/:id`, API 404 fallback.
+- Read surfaces: request JSON body, snapshot JSON files under `workspace/tasks/*/snapshot.json`.
+- Write/delete/overwrite surfaces: task lane directory creation and current task snapshot replace/write only; no delete behavior.
+- Producer/consumer evidence boundaries: create body -> stored TaskCard -> TaskSnapshot JSON -> hydrated in-memory list/detail -> #35 Dashboard shape.
+- Stale-state/idempotency boundaries: service restart hydration and explicit non-goal for `Idempotency-Key`.
+- Unchanged downstream consumers: #28 health/workspace routes, backend WS tool.failed tests, future #30 idempotency/locks, #33 path helper, and #35 Dashboard.
+
+Required evidence:
+- Backend route tests for create/list/detail, with exact create input and exact generated/default TaskCard fields asserted.
+- Backend tests for 400 schema error and 404 fallback/missing task id that assert every canonical envelope field: `error_id`, `category`, `severity`, `message`, `user_message`, `evidence_refs`, `retryable`, `recommended_next_actions`.
+- Backend or core tests for snapshot write shape, restart recovery from the same workspace, malformed snapshot handling, existing regular-file task lane, unrelated lane preservation, and bounded hydration scope.
+- Backend tests for concurrent or sequential multi-create coherence and unique `task_id` values.
+- Compatibility: #28 route tests, backend ws tests, typecheck, root check, OpenSpec validation, diff check, zero diff, and no tracked `workspace`.
+
+Non-goals:
+- `Idempotency-Key`, request digest, LockRecord, and Artifact registry (#30).
+- Shared path safety helper and wiring (#33); #29 still keeps task snapshot writes workspace-bounded with route-local checks.
+- Structured API request logging (#31), PERF-API-001 (#32), frontend Dashboard (#35), Workbench navigation, full event bus/latest_seq critical section, task execution/planning, and scientific PI decisions.
+
+Review focus:
+- Create-input schema, generated/default stored fields, TaskCard schema, and TaskSnapshot carrier are internally consistent.
+- Error envelope tests assert the full canonical shape and no framework default error body leaks.
+- Snapshot persistence/recovery is bounded to configured workspace task lanes and does not silently accept malformed state.
+- Existing #28 routes remain reachable and unchanged; fallback ordering does not shadow real routes.

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -90,6 +90,48 @@
     - Existing backend WebSocket tests, typecheck, and package check remain green; #29/#31/#32/#33 surfaces are not pre-implemented.
     - `bun run test:backend-api` or focused backend route test command; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`.
 - [ ] 6.2 TaskCard 最小链路：`POST/GET /api/tasks`、`GET /api/tasks/:id` + 统一错误 envelope（含 404 路由兜底）+ task snapshot 落盘/重启恢复——依赖: 4.1
+  - Fixture (#29): expanded / high
+    - Change surface: `packages/core/src/domain/services/**` TaskCard file service + `packages/backend/src/routes/**` task routes and API fallback; `packages/core/src/domain/schemas/task.ts` is the validation source of truth.
+    - Must preserve: #28 workspace init/health endpoints and tests, fallback ordering for existing routes, backend WebSocket tests, root package check, `workspace/` runtime assets untracked, and `zero/` source diff=0.
+    - Must add/change: `POST /api/tasks`, `GET /api/tasks`, `GET /api/tasks/:id`, standard error envelope for schema errors and 404, task snapshot persistence under the configured workspace, and restart/list recovery.
+    - Create input contract: accepted M1 body contains `type`, `title`, `question_or_goal`, `inference_budget`, and optional `created_by`; stored TaskCard must generate/normalize `task_id`, `status="created"`, `created_by`, `current_owner`, `reviewer`, empty `linked_jobs`, empty `linked_reports`, ISO `created_at`, and ISO `updated_at`.
+    - Snapshot contract: `workspace/tasks/<task_id>/snapshot.json` contains required TaskSnapshot fields (`task_id`, `status`, optional/nullable `runtime_phase`, optional `stack_id`/`data_id`, `linked_jobs`, `linked_runs`, `linked_reports`, `pending_pi_gates`, `latest_seq=0`, `updated_at`) and may include nested full `task_card`; recovery validates TaskSnapshot plus nested `TaskCardSchema` when present and rejects mismatches.
+    - Risk packs considered:
+      - Public API / CLI / script entry: selected - new task endpoints plus API fallback.
+      - Config / project setup: selected - configured workspace root controls persistence/recovery.
+      - File IO / path safety / overwrite: selected - snapshot writes/reads under `workspace/tasks/<task_id>/snapshot.json`, with no overwrite of unrelated lanes.
+      - Schema / columns / units / field names: selected - create body, TaskCard, TaskSnapshot carrier, and envelope fields.
+      - Auth / permissions / secrets: not selected - unauthenticated M1 skeleton; no secret handling.
+      - Concurrency / shared state / ordering: selected - sequential/concurrent creates must keep in-memory list/detail and snapshots coherent.
+      - Resource limits / large input / discovery: selected - startup hydration must scan only bounded `workspace/tasks/*/snapshot.json` candidates and bounded JSON bytes.
+      - Legacy compatibility / examples: selected - API registry example shape and existing #28/backend WS behavior remain compatible.
+      - Error handling / rollback / partial outputs: selected - rejected create/recovery states use envelope and leave no accepted task state.
+      - Release / packaging / dependency compatibility: selected - no new non-M1 runtime dependency; Bun workspace checks remain green.
+      - Documentation / migration notes: selected - PR evidence states response shape, snapshot shape, and deferred #30/#33/#35 boundaries.
+    - Invariant Matrix:
+      - Governing invariant: every accepted TaskCard is schema-valid, queryable by id/list, and represented by exactly one workspace-local snapshot; rejected requests and unknown routes return envelope errors without creating accepted task state.
+      - Source-of-truth identity/contract: `task_id`, create-body schema, TaskCard Zod schema, TaskSnapshot carrier fields, API error envelope fields, configured workspace root, snapshot path `workspace/tasks/<task_id>/snapshot.json`.
+      - Producers: `POST /api/tasks` and TaskCard service create path.
+      - Validators/preflight: request-body validation, task-id/path-segment validation, service-level TaskCard schema validation before persistence, and TaskSnapshot parse validation during recovery.
+      - Storage/cache/query: in-memory task index hydrated from snapshot files plus workspace task snapshot JSON files.
+      - Public routes/entrypoints: `POST /api/tasks`, `GET /api/tasks`, `GET /api/tasks/:id`, API 404 fallback.
+      - Frontend/downstream consumers: Dashboard #35 consumes exact list/create response shapes and refresh recovery; Workbench navigation remains out of scope.
+      - Failure paths/stale state: missing required field, invalid enum, unknown task id, unknown API route, malformed/stale snapshot, existing regular-file task lane, duplicate generated id collision, unrelated task lanes, and service re-instantiation after create.
+      - Evidence/readiness: backend route tests, `test:backend-api`, root `check`, OpenSpec strict validate, diff check, and zero diff.
+      - Regression rows:
+        - Valid create body (`type/title/question_or_goal/inference_budget/created_by`) -> 201 TaskCard status=`created`, generated/default fields present, list/detail return same object, snapshot file exists.
+        - Missing required field, invalid enum, or malformed JSON -> 400 envelope with all canonical `error` fields and field-level evidence; no task snapshot is written.
+        - Unknown `/api/*` path or missing task id -> 404 envelope with all canonical `error` fields, not Hono default body.
+        - Recreated app/service over same workspace -> `GET /api/tasks` includes prior TaskCard from snapshot.
+        - Existing non-directory task lane or malformed/mismatched snapshot -> stable envelope or documented fail-closed recovery result; no alternate accepted task and no workspace outside configured root touched.
+        - Concurrent/sequential valid creates -> unique task ids, coherent list/detail responses, and one snapshot per accepted task.
+        - Startup hydration with unrelated task lanes -> reads only bounded `*/snapshot.json` candidates and preserves unrelated files.
+    - Evidence floor (#29):
+      - Backend route tests cover create/detail/list with exact input and generated/default TaskCard fields, invalid request 400 schema_error with field-level evidence, unknown API path 404 envelope, missing task id 404 envelope, snapshot file creation under `tasks/<task_id>/snapshot.json`, restart recovery by constructing a fresh app over the same temp workspace, malformed/existing-lane recovery behavior, and sequential/concurrent multi-create coherence.
+      - 400/404 tests assert every canonical envelope field under `error`: `error_id`, `category`, `severity`, `message`, `user_message`, `evidence_refs`, `retryable`, `recommended_next_actions`.
+      - Snapshot write uses atomic/no-clobber-or-replace semantics only for the current task snapshot; unrelated existing files under the task lane are preserved; startup hydration is bounded to `workspace/tasks/*/snapshot.json`.
+      - #29 does not implement Idempotency-Key handling, shared path helper, structured request logging, PERF-API-001, frontend Dashboard, or Workbench task navigation.
+      - `bun run test:backend-api`; `bun run test:backend-ws`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 - [ ] 6.3 幂等/锁 service skeleton（相同 Idempotency-Key + 相同 request_digest 重放返回同一对象；相同 key + 不同 digest → 422 标准 envelope；M1 验证载体 = `POST /api/tasks`，key/digest 配方为 change-scoped，见 task-api spec 与 proposal Impact 账本待办）+ Artifact registry skeleton（注册/按 id 查询/落盘）——依赖: 4.1（IdempotencyRecord/LockRecord schema）
 - [ ] 6.4 结构化 NDJSON API 请求日志中间件（OBS-LOG-001 八字段：ts/level/service/event/request_id/route/status/duration_ms；secret 仅以 ref/[REDACTED] 形式出现，OBS-LOG-002）
 - [ ] 6.5 PERF-API-001 冒烟脚本 `bun run test:perf:api`（fixture = mock workspace + 100 tasks；GET /api/tasks、GET /api/tasks/:id、health ready P95 ≤ 300ms）+ 接入 1.2 的 PR CI——依赖: 1.2

--- a/packages/backend/src/routes/index.test.ts
+++ b/packages/backend/src/routes/index.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   access,
+  readdir,
   mkdir,
   mkdtemp,
   readFile,
@@ -12,12 +13,20 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { createBackendApi, type WorkspaceReadyResponse } from "./index";
+import {
+  TaskServiceError,
+  createTaskCardService,
+  type CreateTaskInput,
+  type TaskCard,
+  type TaskSnapshot
+} from "@shud-harness/core";
+import { createBackendApi, type ApiErrorResponse, type WorkspaceReadyResponse } from "./index";
 
 const tempRoots: string[] = [];
 const originalCwd = process.cwd();
 const originalHarnessWorkspaceDir = process.env.HARNESS_WORKSPACE_DIR;
 const originalLegacyWorkspaceRoot = process.env.SHUD_HARNESS_WORKSPACE_ROOT;
+const TASK_HYDRATION_ENTRY_LIMIT = 1024;
 
 const EXPECTED_M1_RUNTIME_DIRECTORIES = [
   "repos",
@@ -444,6 +453,414 @@ describe("backend workspace and health routes", () => {
     expect(readyBody.status).toBe("ok");
     expect(readyBody.checks.snapshot_readable).toBe("ok");
   });
+
+  test("POST /api/tasks creates a TaskCard and list/detail return stable shapes", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:00:00.000Z"),
+      taskIdFactory: () => "TASK-route-create"
+    });
+
+    const response = await postTask(app, {
+      type: "engineering",
+      title: "Add optional event diagnostics",
+      question_or_goal: "Add event_flux output without breaking old rSHUD readers",
+      inference_budget: { mode: "normal" },
+      created_by: "pi"
+    });
+    const task = (await response.json()) as TaskCard;
+
+    expect(response.status).toBe(201);
+    expect(task).toEqual({
+      task_id: "TASK-route-create",
+      type: "engineering",
+      status: "created",
+      title: "Add optional event diagnostics",
+      question_or_goal: "Add event_flux output without breaking old rSHUD readers",
+      created_by: "pi",
+      current_owner: "coordinator",
+      reviewer: "reviewer",
+      inference_budget: { mode: "normal" },
+      linked_jobs: [],
+      linked_reports: [],
+      created_at: "2026-07-07T12:00:00.000Z",
+      updated_at: "2026-07-07T12:00:00.000Z"
+    });
+
+    const listResponse = await app.request("/api/tasks");
+    const detailResponse = await app.request(`/api/tasks/${task.task_id}`);
+
+    expect(listResponse.status).toBe(200);
+    expect(await listResponse.json()).toEqual({ tasks: [task] });
+    expect(detailResponse.status).toBe(200);
+    expect(await detailResponse.json()).toEqual(task);
+  });
+
+  test("POST /api/tasks defaults created_by when omitted", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:01:00.000Z"),
+      taskIdFactory: () => "TASK-default-actor"
+    });
+
+    const response = await postTask(app, validTaskCreateBody({ created_by: undefined }));
+    const task = (await response.json()) as TaskCard;
+
+    expect(response.status).toBe(201);
+    expect(task.created_by).toBe("pi");
+    expect(task.current_owner).toBe("coordinator");
+    expect(task.reviewer).toBe("reviewer");
+  });
+
+  test("POST /api/tasks writes a TaskSnapshot with nested TaskCard recovery data", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:02:00.000Z"),
+      taskIdFactory: () => "TASK-snapshot"
+    });
+
+    const response = await postTask(app, validTaskCreateBody());
+    const task = (await response.json()) as TaskCard;
+    const snapshotPath = join(workspaceRoot, "tasks", task.task_id, "snapshot.json");
+    const snapshot = JSON.parse(await readFile(snapshotPath, "utf8")) as TaskSnapshot & {
+      task_card: TaskCard;
+    };
+
+    expect(response.status).toBe(201);
+    expect(snapshot).toEqual({
+      task_id: task.task_id,
+      status: "created",
+      runtime_phase: null,
+      linked_jobs: [],
+      linked_runs: [],
+      linked_reports: [],
+      pending_pi_gates: [],
+      latest_seq: 0,
+      updated_at: task.updated_at,
+      task_card: task
+    });
+  });
+
+  test("task snapshots recover list and detail after creating a fresh app", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const firstApp = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:00.000Z"),
+      taskIdFactory: () => "TASK-restart"
+    });
+    const createResponse = await postTask(firstApp, validTaskCreateBody());
+    const createdTask = (await createResponse.json()) as TaskCard;
+    const freshApp = createBackendApi({ workspaceRoot });
+
+    const listResponse = await freshApp.request("/api/tasks");
+    const detailResponse = await freshApp.request(`/api/tasks/${createdTask.task_id}`);
+
+    expect(listResponse.status).toBe(200);
+    expect(await listResponse.json()).toEqual({ tasks: [createdTask] });
+    expect(detailResponse.status).toBe(200);
+    expect(await detailResponse.json()).toEqual(createdTask);
+  });
+
+  test("POST /api/tasks preserves unrelated files in an existing task lane", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const taskLane = join(workspaceRoot, "tasks", "TASK-preserve-lane");
+    const sentinelPath = join(taskLane, "sentinel.txt");
+    await mkdir(taskLane, { recursive: true });
+    await writeFile(sentinelPath, "keep this file", { flag: "wx" });
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:04:00.000Z"),
+      taskIdFactory: () => "TASK-preserve-lane"
+    });
+
+    const response = await postTask(app, validTaskCreateBody());
+
+    expect(response.status).toBe(201);
+    expect(await readFile(sentinelPath, "utf8")).toBe("keep this file");
+    expect((await stat(join(taskLane, "snapshot.json"))).isFile()).toBe(true);
+  });
+
+  test("POST /api/tasks rejects invalid request bodies with a canonical schema_error envelope", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({ workspaceRoot });
+
+    const response = await app.request("/api/tasks", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        type: "engineering",
+        title: "Missing goal",
+        inference_budget: { mode: "normal" }
+      })
+    });
+    const body = (await response.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(400);
+    expectCanonicalError(body, "schema_error");
+    expect(body.error.evidence_refs).toContain("request.body.question_or_goal");
+    await expectPathMissing(join(workspaceRoot, "tasks"));
+  });
+
+  test("POST /api/tasks rejects malformed JSON with a canonical schema_error envelope", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({ workspaceRoot });
+
+    const response = await app.request("/api/tasks", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{"
+    });
+    const body = (await response.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(400);
+    expectCanonicalError(body, "schema_error");
+    expect(body.error.evidence_refs).toEqual(["request.body"]);
+  });
+
+  test("unknown API paths and missing task ids return canonical 404 envelopes", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({ workspaceRoot });
+
+    const unknownRouteResponse = await app.request("/api/not-registered");
+    const missingTaskResponse = await app.request("/api/tasks/TASK-missing");
+    const unknownRouteBody = (await unknownRouteResponse.json()) as ApiErrorResponse;
+    const missingTaskBody = (await missingTaskResponse.json()) as ApiErrorResponse;
+
+    expect(unknownRouteResponse.status).toBe(404);
+    expect(missingTaskResponse.status).toBe(404);
+    expectCanonicalError(unknownRouteBody, "not_found");
+    expectCanonicalError(missingTaskBody, "not_found");
+    expect(unknownRouteBody.error.message).toContain("API route not found");
+    expect(missingTaskBody.error.message).toContain("Task not found");
+  });
+
+  test("malformed task snapshots fail closed with a canonical envelope", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    await mkdir(join(workspaceRoot, "tasks", "TASK-malformed"), { recursive: true });
+    await writeFile(join(workspaceRoot, "tasks", "TASK-malformed", "snapshot.json"), "{", {
+      flag: "wx"
+    });
+    const app = createBackendApi({ workspaceRoot });
+
+    const response = await app.request("/api/tasks");
+    const body = (await response.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(500);
+    expectCanonicalError(body, "workspace_error");
+    expect(body.error.evidence_refs.some((ref) => ref.endsWith("TASK-malformed/snapshot.json"))).toBe(
+      true
+    );
+  });
+
+  test("symlinked task snapshots fail closed without reading outside the workspace", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const outsideSnapshot = join(tempRoot, "outside-snapshot.json");
+    const outsideTask = taskCardFixture("TASK-symlink-snapshot", {
+      title: "Outside snapshot must not hydrate"
+    });
+    await mkdir(join(workspaceRoot, "tasks", "TASK-symlink-snapshot"), { recursive: true });
+    await writeTaskSnapshotFixture(outsideSnapshot, outsideTask);
+    await symlink(
+      outsideSnapshot,
+      join(workspaceRoot, "tasks", "TASK-symlink-snapshot", "snapshot.json")
+    );
+    const app = createBackendApi({ workspaceRoot });
+
+    const response = await app.request("/api/tasks");
+    const body = (await response.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(500);
+    expectCanonicalError(body, "workspace_error");
+    expect(body.error.evidence_refs.some((ref) => ref.endsWith("TASK-symlink-snapshot/snapshot.json"))).toBe(
+      true
+    );
+  });
+
+  test("task snapshot leaf swaps during recovery fail closed without hydrating outside snapshots", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const laneTaskId = "TASK-leaf-swap";
+    const taskLane = join(workspaceRoot, "tasks", laneTaskId);
+    const snapshotPath = join(taskLane, "snapshot.json");
+    const outsideSnapshot = join(tempRoot, "outside-leaf-swap.json");
+    await mkdir(taskLane, { recursive: true });
+    await writeTaskSnapshotFixture(
+      snapshotPath,
+      taskCardFixture(laneTaskId, { title: "Original workspace snapshot" })
+    );
+    await writeTaskSnapshotFixture(
+      outsideSnapshot,
+      taskCardFixture(laneTaskId, { title: "Outside swapped snapshot must not hydrate" })
+    );
+    let swapped = false;
+    const service = createTaskCardService({
+      workspaceRoot,
+      snapshotReadHooks: {
+        beforeSnapshotOpen: async ({ snapshotPath: candidatePath, laneTaskId: candidateTaskId }) => {
+          expect(candidatePath).toBe(snapshotPath);
+          expect(candidateTaskId).toBe(laneTaskId);
+          swapped = true;
+          await rm(candidatePath);
+          await symlink(outsideSnapshot, candidatePath);
+        }
+      }
+    });
+
+    try {
+      await service.listTasks();
+      throw new Error("Expected snapshot leaf swap to fail closed.");
+    } catch (error) {
+      expect(error).toBeInstanceOf(TaskServiceError);
+      const taskError = error as TaskServiceError;
+      expect(taskError.code).toBe("task_snapshot_malformed");
+      expect(taskError.evidenceRefs).toEqual([snapshotPath]);
+    }
+    expect(swapped).toBe(true);
+  });
+
+  test("regular-file task lanes fail closed with a canonical envelope", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    await mkdir(join(workspaceRoot, "tasks"), { recursive: true });
+    await writeFile(join(workspaceRoot, "tasks", "TASK-file-lane"), "not a directory", {
+      flag: "wx"
+    });
+    const app = createBackendApi({ workspaceRoot });
+
+    const response = await app.request("/api/tasks");
+    const body = (await response.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(500);
+    expectCanonicalError(body, "workspace_error");
+    expect(body.error.evidence_refs).toContain("workspace/tasks/TASK-file-lane");
+  });
+
+  test("startup hydration ignores unrelated files and only reads bounded task snapshot candidates", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const firstApp = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:05:00.000Z"),
+      taskIdFactory: () => "TASK-bounded"
+    });
+    const createResponse = await postTask(firstApp, validTaskCreateBody());
+    const task = (await createResponse.json()) as TaskCard;
+    await writeFile(join(workspaceRoot, "tasks", "README.txt"), "not a task lane", {
+      flag: "wx"
+    });
+    await mkdir(join(workspaceRoot, "tasks", "notes"), { recursive: true });
+    await writeFile(join(workspaceRoot, "tasks", "notes", "snapshot.json"), "{", {
+      flag: "wx"
+    });
+    await mkdir(join(workspaceRoot, "tasks", "TASK-empty"), { recursive: true });
+    await mkdir(join(workspaceRoot, "tasks", "TASK-bounded", "nested"), { recursive: true });
+    await writeFile(join(workspaceRoot, "tasks", "TASK-bounded", "nested", "snapshot.json"), "{", {
+      flag: "wx"
+    });
+    const freshApp = createBackendApi({ workspaceRoot });
+
+    const listResponse = await freshApp.request("/api/tasks");
+
+    expect(listResponse.status).toBe(200);
+    expect(await listResponse.json()).toEqual({ tasks: [task] });
+  });
+
+  test("GET /api/tasks fails closed when workspace task entry count exceeds the M1 hydration limit", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const tasksRoot = join(workspaceRoot, "tasks");
+    const hiddenTask = taskCardFixture("TASK-hidden-valid", {
+      title: "Hidden valid snapshot must not hydrate past the entry limit"
+    });
+    await mkdir(join(tasksRoot, hiddenTask.task_id), { recursive: true });
+    await writeTaskSnapshotFixture(
+      join(tasksRoot, hiddenTask.task_id, "snapshot.json"),
+      hiddenTask
+    );
+    await writeFillerTaskEntries(tasksRoot, TASK_HYDRATION_ENTRY_LIMIT);
+    const app = createBackendApi({ workspaceRoot });
+
+    const response = await app.request("/api/tasks");
+    const body = (await response.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(500);
+    expectCanonicalError(body, "workspace_error");
+    expect(body.error.evidence_refs).toContain("workspace/tasks:entry_count");
+    expect(body.error.message).toContain("exceeding the M1 hydration limit");
+    expect(JSON.stringify(body)).not.toContain(hiddenTask.title);
+  });
+
+  test("concurrent task creates keep unique ids, coherent list/detail, and one snapshot per task", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    let nextId = 0;
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:06:00.000Z"),
+      taskIdFactory: () => {
+        nextId += 1;
+        return `TASK-concurrent-${nextId}`;
+      }
+    });
+
+    const responses = await Promise.all(
+      Array.from({ length: 4 }, (_, index) =>
+        postTask(app, validTaskCreateBody({ title: `Concurrent task ${index + 1}` }))
+      )
+    );
+    const tasks = (await Promise.all(responses.map((response) => response.json()))) as TaskCard[];
+    const taskIds = tasks.map((task) => task.task_id);
+
+    expect(responses.map((response) => response.status)).toEqual([201, 201, 201, 201]);
+    expect(new Set(taskIds).size).toBe(4);
+    expect((await app.request("/api/tasks").then((response) => response.json()))).toEqual({
+      tasks
+    });
+    for (const task of tasks) {
+      expect(await app.request(`/api/tasks/${task.task_id}`).then((response) => response.json())).toEqual(
+        task
+      );
+      expect((await stat(join(workspaceRoot, "tasks", task.task_id, "snapshot.json"))).isFile()).toBe(
+        true
+      );
+    }
+    expect((await readdir(join(workspaceRoot, "tasks"))).filter((entry) => entry.startsWith("TASK-")).sort()).toEqual(
+      taskIds.sort()
+    );
+  });
+
+  test("task snapshot writes reject a symlinked tasks root without writing outside", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const outsideRoot = join(tempRoot, "outside-tasks");
+    await mkdir(workspaceRoot, { recursive: true });
+    await mkdir(outsideRoot);
+    await symlink(outsideRoot, join(workspaceRoot, "tasks"), "dir");
+    const app = createBackendApi({
+      workspaceRoot,
+      taskIdFactory: () => "TASK-symlink-blocked"
+    });
+
+    const response = await postTask(app, validTaskCreateBody());
+    const body = (await response.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(500);
+    expectCanonicalError(body, "workspace_error");
+    await expectPathMissing(join(outsideRoot, "TASK-symlink-blocked"));
+  });
 });
 
 async function createTempWorkspacePath(): Promise<{ tempRoot: string; workspaceRoot: string }> {
@@ -479,6 +896,109 @@ async function expectPathMissing(path: string): Promise<void> {
   }
 
   throw new Error(`Expected path to be missing: ${path}`);
+}
+
+function fixedNow(isoTimestamp: string): () => Date {
+  return () => new Date(isoTimestamp);
+}
+
+function validTaskCreateBody(overrides: Partial<CreateTaskInput> = {}): CreateTaskInput {
+  return {
+    type: "engineering",
+    title: "Add optional event diagnostics",
+    question_or_goal: "Add event_flux output without breaking old rSHUD readers",
+    inference_budget: { mode: "normal" },
+    created_by: "pi",
+    ...overrides
+  };
+}
+
+function taskCardFixture(taskId: string, overrides: Partial<TaskCard> = {}): TaskCard {
+  return {
+    task_id: taskId,
+    type: "engineering",
+    status: "created",
+    title: "Recovered task fixture",
+    question_or_goal: "Recover task fixture from a persisted snapshot",
+    created_by: "pi",
+    current_owner: "coordinator",
+    reviewer: "reviewer",
+    inference_budget: { mode: "normal" },
+    linked_jobs: [],
+    linked_reports: [],
+    created_at: "2026-07-07T12:00:00.000Z",
+    updated_at: "2026-07-07T12:00:00.000Z",
+    ...overrides
+  };
+}
+
+async function writeTaskSnapshotFixture(snapshotPath: string, task: TaskCard): Promise<void> {
+  const snapshot: TaskSnapshot & { task_card: TaskCard } = {
+    task_id: task.task_id,
+    status: task.status,
+    runtime_phase: task.runtime_phase ?? null,
+    stack_id: task.stack_id,
+    data_id: task.data_id,
+    linked_jobs: task.linked_jobs,
+    linked_runs: [],
+    linked_reports: task.linked_reports,
+    active_analysis_plan_id: undefined,
+    latest_report_id: undefined,
+    pending_pi_gates: [],
+    latest_seq: 0,
+    updated_at: task.updated_at,
+    task_card: task
+  };
+  await writeFile(snapshotPath, `${JSON.stringify(snapshot)}\n`, { flag: "wx" });
+}
+
+async function writeFillerTaskEntries(tasksRoot: string, count: number): Promise<void> {
+  const batchSize = 64;
+  for (let offset = 0; offset < count; offset += batchSize) {
+    const batchCount = Math.min(batchSize, count - offset);
+    await Promise.all(
+      Array.from({ length: batchCount }, (_, index) =>
+        writeFile(join(tasksRoot, `note-${String(offset + index).padStart(4, "0")}.txt`), "", {
+          flag: "wx"
+        })
+      )
+    );
+  }
+}
+
+async function postTask(
+  app: ReturnType<typeof createBackendApi>,
+  body: CreateTaskInput
+): Promise<Response> {
+  return await app.request("/api/tasks", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+function expectCanonicalError(body: ApiErrorResponse, category: string): void {
+  expect(Object.keys(body.error).sort()).toEqual(
+    [
+      "category",
+      "error_id",
+      "evidence_refs",
+      "message",
+      "recommended_next_actions",
+      "retryable",
+      "severity",
+      "user_message"
+    ].sort()
+  );
+  expect(body.error.error_id.startsWith("api_error_")).toBe(true);
+  expect(body.error.category).toBe(category);
+  expect(body.error.severity).toBe("error");
+  expect(body.error.message.length).toBeGreaterThan(0);
+  expect(body.error.user_message.length).toBeGreaterThan(0);
+  expect(Array.isArray(body.error.evidence_refs)).toBe(true);
+  expect(typeof body.error.retryable).toBe("boolean");
+  expect(Array.isArray(body.error.recommended_next_actions)).toBe(true);
+  expect(body.error.recommended_next_actions.length).toBeGreaterThan(0);
 }
 
 function restoreEnv(name: string, value: string | undefined): void {

--- a/packages/backend/src/routes/index.test.ts
+++ b/packages/backend/src/routes/index.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { execFile as execFileWithCallback } from "node:child_process";
 import {
   access,
   readdir,
@@ -13,7 +14,9 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { promisify } from "node:util";
 import {
+  MAX_TASK_SNAPSHOT_BYTES,
   TaskServiceError,
   createTaskCardService,
   type CreateTaskInput,
@@ -27,6 +30,7 @@ const originalCwd = process.cwd();
 const originalHarnessWorkspaceDir = process.env.HARNESS_WORKSPACE_DIR;
 const originalLegacyWorkspaceRoot = process.env.SHUD_HARNESS_WORKSPACE_ROOT;
 const TASK_HYDRATION_ENTRY_LIMIT = 1024;
+const execFile = promisify(execFileWithCallback);
 
 const EXPECTED_M1_RUNTIME_DIRECTORIES = [
   "repos",
@@ -627,6 +631,83 @@ describe("backend workspace and health routes", () => {
     expect(body.error.evidence_refs).toEqual(["request.body"]);
   });
 
+  test("POST /api/tasks rejects invalid enum values without creating task state", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({
+      workspaceRoot,
+      taskIdFactory: () => "TASK-invalid-enum"
+    });
+
+    const response = await app.request("/api/tasks", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ...validTaskCreateBody(),
+        type: "unsupported"
+      })
+    });
+    const body = (await response.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(400);
+    expectCanonicalError(body, "schema_error");
+    expect(body.error.evidence_refs).toContain("request.body.type");
+    await expectPathMissing(join(workspaceRoot, "tasks"));
+  });
+
+  test("POST /api/tasks rejects oversized task snapshots before accepting state", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({
+      workspaceRoot,
+      taskIdFactory: () => "TASK-too-large"
+    });
+
+    const response = await postTask(
+      app,
+      validTaskCreateBody({
+        question_or_goal: "x".repeat(MAX_TASK_SNAPSHOT_BYTES + 1)
+      })
+    );
+    const body = (await response.json()) as ApiErrorResponse;
+    const freshApp = createBackendApi({ workspaceRoot });
+    const listResponse = await freshApp.request("/api/tasks");
+
+    expect(response.status).toBe(400);
+    expectCanonicalError(body, "schema_error");
+    expect(body.error.evidence_refs).toEqual(["request.body"]);
+    await expectPathMissing(join(workspaceRoot, "tasks"));
+    expect(listResponse.status).toBe(200);
+    expect(await listResponse.json()).toEqual({ tasks: [] });
+  });
+
+  test("POST /api/tasks accepts and recovers large snapshots below the M1 byte cap", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:04:30.000Z"),
+      taskIdFactory: () => "TASK-large-under-cap"
+    });
+
+    const response = await postTask(
+      app,
+      validTaskCreateBody({
+        question_or_goal: "x".repeat(900_000)
+      })
+    );
+    const task = (await response.json()) as TaskCard;
+    const freshApp = createBackendApi({ workspaceRoot });
+    const listResponse = await freshApp.request("/api/tasks");
+
+    expect(response.status).toBe(201);
+    expect((await stat(join(workspaceRoot, "tasks", task.task_id, "snapshot.json"))).size).toBeLessThanOrEqual(
+      MAX_TASK_SNAPSHOT_BYTES
+    );
+    expect(listResponse.status).toBe(200);
+    expect(await listResponse.json()).toEqual({ tasks: [task] });
+  });
+
   test("unknown API paths and missing task ids return canonical 404 envelopes", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -659,9 +740,8 @@ describe("backend workspace and health routes", () => {
 
     expect(response.status).toBe(500);
     expectCanonicalError(body, "workspace_error");
-    expect(body.error.evidence_refs.some((ref) => ref.endsWith("TASK-malformed/snapshot.json"))).toBe(
-      true
-    );
+    expect(body.error.evidence_refs).toContain("workspace/tasks/TASK-malformed/snapshot.json");
+    expectNoAbsoluteWorkspacePath(body, tempRoot, workspaceRoot);
   });
 
   test("symlinked task snapshots fail closed without reading outside the workspace", async () => {
@@ -684,9 +764,8 @@ describe("backend workspace and health routes", () => {
 
     expect(response.status).toBe(500);
     expectCanonicalError(body, "workspace_error");
-    expect(body.error.evidence_refs.some((ref) => ref.endsWith("TASK-symlink-snapshot/snapshot.json"))).toBe(
-      true
-    );
+    expect(body.error.evidence_refs).toContain("workspace/tasks/TASK-symlink-snapshot/snapshot.json");
+    expectNoAbsoluteWorkspacePath(body, tempRoot, workspaceRoot);
   });
 
   test("task snapshot leaf swaps during recovery fail closed without hydrating outside snapshots", async () => {
@@ -726,9 +805,198 @@ describe("backend workspace and health routes", () => {
       expect(error).toBeInstanceOf(TaskServiceError);
       const taskError = error as TaskServiceError;
       expect(taskError.code).toBe("task_snapshot_malformed");
-      expect(taskError.evidenceRefs).toEqual([snapshotPath]);
+      expect(taskError.evidenceRefs).toEqual(["workspace/tasks/TASK-leaf-swap/snapshot.json"]);
     }
     expect(swapped).toBe(true);
+  });
+
+  test("task snapshot parent-lane swaps during recovery fail closed without outside hydration", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const laneTaskId = "TASK-parent-swap";
+    const taskLane = join(workspaceRoot, "tasks", laneTaskId);
+    const snapshotPath = join(taskLane, "snapshot.json");
+    const outsideLane = join(tempRoot, "outside-parent-swap");
+    await mkdir(taskLane, { recursive: true });
+    await mkdir(outsideLane);
+    await writeTaskSnapshotFixture(
+      snapshotPath,
+      taskCardFixture(laneTaskId, { title: "Original workspace snapshot" })
+    );
+    await writeTaskSnapshotFixture(
+      join(outsideLane, "snapshot.json"),
+      taskCardFixture(laneTaskId, { title: "Outside parent swap must not hydrate" })
+    );
+    let swapped = false;
+    const service = createTaskCardService({
+      workspaceRoot,
+      snapshotReadHooks: {
+        beforeSnapshotOpen: async () => {
+          swapped = true;
+          await rm(taskLane, { recursive: true, force: true });
+          await symlink(outsideLane, taskLane, "dir");
+        }
+      }
+    });
+
+    try {
+      await service.listTasks();
+      throw new Error("Expected snapshot parent swap to fail closed.");
+    } catch (error) {
+      expect(error).toBeInstanceOf(TaskServiceError);
+      const taskError = error as TaskServiceError;
+      expect(taskError.code).toBe("task_lane_not_directory");
+      expect(taskError.evidenceRefs).toEqual(["workspace/tasks/TASK-parent-swap"]);
+      expect(JSON.stringify(error)).not.toContain("Outside parent swap must not hydrate");
+    }
+    expect(swapped).toBe(true);
+  });
+
+  test("task snapshot writes reject parent-lane swaps before writing outside", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const outsideLane = join(tempRoot, "outside-write-swap");
+    await mkdir(outsideLane);
+    let swapped = false;
+    const service = createTaskCardService({
+      workspaceRoot,
+      taskIdFactory: () => "TASK-write-parent-swap",
+      snapshotWriteHooks: {
+        beforeSnapshotWrite: async ({ taskDirectory }) => {
+          swapped = true;
+          await rm(taskDirectory, { recursive: true, force: true });
+          await symlink(outsideLane, taskDirectory, "dir");
+        }
+      }
+    });
+
+    try {
+      await service.createTask(validTaskCreateBody());
+      throw new Error("Expected snapshot write parent swap to fail closed.");
+    } catch (error) {
+      expect(error).toBeInstanceOf(TaskServiceError);
+      const taskError = error as TaskServiceError;
+      expect(taskError.code).toBe("task_lane_not_directory");
+      expect(taskError.evidenceRefs).toEqual(["workspace/tasks/TASK-write-parent-swap"]);
+    }
+    expect(swapped).toBe(true);
+    await expectPathMissing(join(outsideLane, "snapshot.json"));
+  });
+
+  test("special-file task snapshots fail closed before opening", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const snapshotPath = join(workspaceRoot, "tasks", "TASK-fifo", "snapshot.json");
+    await mkdir(join(workspaceRoot, "tasks", "TASK-fifo"), { recursive: true });
+    await execFile("mkfifo", [snapshotPath]);
+    const app = createBackendApi({ workspaceRoot });
+
+    const response = await Promise.race([
+      app.request("/api/tasks"),
+      timeoutAfter(1_000, "GET /api/tasks hung on a special snapshot file")
+    ]);
+    const body = (await response.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(500);
+    expectCanonicalError(body, "workspace_error");
+    expect(body.error.evidence_refs).toContain("workspace/tasks/TASK-fifo/snapshot.json");
+  });
+
+  test("task snapshot recovery rejects unsafe and mismatched task ids with workspace envelopes", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const tasksRoot = join(workspaceRoot, "tasks");
+    await mkdir(join(tasksRoot, "TASK-unsafe-snapshot-id"), { recursive: true });
+    await writeTaskSnapshotFixture(
+      join(tasksRoot, "TASK-unsafe-snapshot-id", "snapshot.json"),
+      taskCardFixture("bad")
+    );
+    const unsafeApp = createBackendApi({ workspaceRoot });
+
+    const unsafeResponse = await unsafeApp.request("/api/tasks");
+    const unsafeBody = (await unsafeResponse.json()) as ApiErrorResponse;
+
+    expect(unsafeResponse.status).toBe(500);
+    expectCanonicalError(unsafeBody, "workspace_error");
+    expect(unsafeBody.error.evidence_refs).toContain(
+      "workspace/tasks/TASK-unsafe-snapshot-id/snapshot.json"
+    );
+    expect(unsafeBody.error.evidence_refs).toContain("snapshot.task_id");
+
+    await rm(join(tasksRoot, "TASK-unsafe-snapshot-id"), { recursive: true, force: true });
+    await mkdir(join(tasksRoot, "TASK-lane-mismatch"), { recursive: true });
+    await writeTaskSnapshotFixture(
+      join(tasksRoot, "TASK-lane-mismatch", "snapshot.json"),
+      taskCardFixture("TASK-other")
+    );
+    const mismatchApp = createBackendApi({ workspaceRoot });
+
+    const mismatchResponse = await mismatchApp.request("/api/tasks");
+    const mismatchBody = (await mismatchResponse.json()) as ApiErrorResponse;
+
+    expect(mismatchResponse.status).toBe(500);
+    expectCanonicalError(mismatchBody, "workspace_error");
+    expect(mismatchBody.error.evidence_refs).toContain(
+      "workspace/tasks/TASK-lane-mismatch/snapshot.json"
+    );
+    expect(mismatchBody.error.evidence_refs).toContain("snapshot.task_id:TASK-other");
+  });
+
+  test("task snapshot recovery rejects nested task_card mismatches and nonzero latest_seq", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const tasksRoot = join(workspaceRoot, "tasks");
+    const nestedMismatchTask = taskCardFixture("TASK-nested-mismatch");
+    await mkdir(join(tasksRoot, nestedMismatchTask.task_id), { recursive: true });
+    await writeTaskSnapshotFixture(
+      join(tasksRoot, nestedMismatchTask.task_id, "snapshot.json"),
+      nestedMismatchTask,
+      {
+        task_card: taskCardFixture(nestedMismatchTask.task_id, { status: "done" })
+      }
+    );
+    const nestedMismatchApp = createBackendApi({ workspaceRoot });
+
+    const nestedMismatchResponse = await nestedMismatchApp.request("/api/tasks");
+    const nestedMismatchBody = (await nestedMismatchResponse.json()) as ApiErrorResponse;
+
+    expect(nestedMismatchResponse.status).toBe(500);
+    expectCanonicalError(nestedMismatchBody, "workspace_error");
+    expect(nestedMismatchBody.error.evidence_refs).toContain("snapshot.status");
+
+    await rm(join(tasksRoot, nestedMismatchTask.task_id), { recursive: true, force: true });
+    const latestSeqTask = taskCardFixture("TASK-latest-seq");
+    await mkdir(join(tasksRoot, latestSeqTask.task_id), { recursive: true });
+    await writeTaskSnapshotFixture(
+      join(tasksRoot, latestSeqTask.task_id, "snapshot.json"),
+      latestSeqTask,
+      { latest_seq: 1 }
+    );
+    const latestSeqApp = createBackendApi({ workspaceRoot });
+
+    const latestSeqResponse = await latestSeqApp.request("/api/tasks");
+    const latestSeqBody = (await latestSeqResponse.json()) as ApiErrorResponse;
+
+    expect(latestSeqResponse.status).toBe(500);
+    expectCanonicalError(latestSeqBody, "workspace_error");
+    expect(latestSeqBody.error.evidence_refs).toContain("snapshot.latest_seq");
+  });
+
+  test("oversized existing task snapshots fail closed without leaking task content", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const snapshotPath = join(workspaceRoot, "tasks", "TASK-oversized-read", "snapshot.json");
+    await mkdir(join(workspaceRoot, "tasks", "TASK-oversized-read"), { recursive: true });
+    await writeFile(snapshotPath, "x".repeat(MAX_TASK_SNAPSHOT_BYTES + 1), { flag: "wx" });
+    const app = createBackendApi({ workspaceRoot });
+
+    const response = await app.request("/api/tasks");
+    const body = (await response.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(500);
+    expectCanonicalError(body, "workspace_error");
+    expect(body.error.evidence_refs).toContain("workspace/tasks/TASK-oversized-read/snapshot.json");
+    expect(JSON.stringify(body)).not.toContain("Recovered task fixture");
   });
 
   test("regular-file task lanes fail closed with a canonical envelope", async () => {
@@ -746,6 +1014,7 @@ describe("backend workspace and health routes", () => {
     expect(response.status).toBe(500);
     expectCanonicalError(body, "workspace_error");
     expect(body.error.evidence_refs).toContain("workspace/tasks/TASK-file-lane");
+    expectNoAbsoluteWorkspacePath(body, tempRoot, workspaceRoot);
   });
 
   test("startup hydration ignores unrelated files and only reads bounded task snapshot candidates", async () => {
@@ -801,6 +1070,64 @@ describe("backend workspace and health routes", () => {
     expect(body.error.evidence_refs).toContain("workspace/tasks:entry_count");
     expect(body.error.message).toContain("exceeding the M1 hydration limit");
     expect(JSON.stringify(body)).not.toContain(hiddenTask.title);
+  });
+
+  test("duplicate generated task ids retry safely and fail without adding accepted state", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const generatedIds = ["TASK-duplicate", "TASK-duplicate", "TASK-retry"];
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:05:30.000Z"),
+      taskIdFactory: () => generatedIds.shift() ?? "TASK-retry"
+    });
+
+    const firstResponse = await postTask(app, validTaskCreateBody({ title: "First task" }));
+    const secondResponse = await postTask(app, validTaskCreateBody({ title: "Second task" }));
+    const firstTask = (await firstResponse.json()) as TaskCard;
+    const secondTask = (await secondResponse.json()) as TaskCard;
+
+    expect(firstResponse.status).toBe(201);
+    expect(secondResponse.status).toBe(201);
+    expect(firstTask.task_id).toBe("TASK-duplicate");
+    expect(secondTask.task_id).toBe("TASK-retry");
+
+    const failingApp = createBackendApi({
+      workspaceRoot,
+      taskIdFactory: () => "TASK-duplicate"
+    });
+    const failureResponse = await postTask(failingApp, validTaskCreateBody({ title: "Third task" }));
+    const failureBody = (await failureResponse.json()) as ApiErrorResponse;
+
+    expect(failureResponse.status).toBe(500);
+    expectCanonicalError(failureBody, "workspace_error");
+    expect(await app.request("/api/tasks").then((response) => response.json())).toEqual({
+      tasks: [firstTask, secondTask]
+    });
+    expect((await readdir(join(workspaceRoot, "tasks"))).filter((entry) => entry.startsWith("TASK-")).sort()).toEqual(
+      ["TASK-duplicate", "TASK-retry"]
+    );
+  });
+
+  test("task hydration failures can be repaired and retried in the same service", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const snapshotPath = join(workspaceRoot, "tasks", "TASK-repairable", "snapshot.json");
+    const repairedTask = taskCardFixture("TASK-repairable");
+    await mkdir(join(workspaceRoot, "tasks", repairedTask.task_id), { recursive: true });
+    await writeFile(snapshotPath, "{", { flag: "wx" });
+    const app = createBackendApi({ workspaceRoot });
+
+    const failedResponse = await app.request("/api/tasks");
+    const failedBody = (await failedResponse.json()) as ApiErrorResponse;
+    await rm(snapshotPath);
+    await writeTaskSnapshotFixture(snapshotPath, repairedTask);
+    const repairedResponse = await app.request("/api/tasks");
+
+    expect(failedResponse.status).toBe(500);
+    expectCanonicalError(failedBody, "workspace_error");
+    expect(repairedResponse.status).toBe(200);
+    expect(await repairedResponse.json()).toEqual({ tasks: [repairedTask] });
   });
 
   test("concurrent task creates keep unique ids, coherent list/detail, and one snapshot per task", async () => {
@@ -932,7 +1259,11 @@ function taskCardFixture(taskId: string, overrides: Partial<TaskCard> = {}): Tas
   };
 }
 
-async function writeTaskSnapshotFixture(snapshotPath: string, task: TaskCard): Promise<void> {
+async function writeTaskSnapshotFixture(
+  snapshotPath: string,
+  task: TaskCard,
+  overrides: Partial<TaskSnapshot & { task_card: TaskCard }> = {}
+): Promise<void> {
   const snapshot: TaskSnapshot & { task_card: TaskCard } = {
     task_id: task.task_id,
     status: task.status,
@@ -947,7 +1278,8 @@ async function writeTaskSnapshotFixture(snapshotPath: string, task: TaskCard): P
     pending_pi_gates: [],
     latest_seq: 0,
     updated_at: task.updated_at,
-    task_card: task
+    task_card: task,
+    ...overrides
   };
   await writeFile(snapshotPath, `${JSON.stringify(snapshot)}\n`, { flag: "wx" });
 }
@@ -999,6 +1331,21 @@ function expectCanonicalError(body: ApiErrorResponse, category: string): void {
   expect(typeof body.error.retryable).toBe("boolean");
   expect(Array.isArray(body.error.recommended_next_actions)).toBe(true);
   expect(body.error.recommended_next_actions.length).toBeGreaterThan(0);
+}
+
+function expectNoAbsoluteWorkspacePath(
+  body: ApiErrorResponse,
+  tempRoot: string,
+  workspaceRoot: string
+): void {
+  const serialized = JSON.stringify(body);
+  expect(serialized).not.toContain(tempRoot);
+  expect(serialized).not.toContain(workspaceRoot);
+}
+
+async function timeoutAfter(milliseconds: number, message: string): Promise<never> {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
+  throw new Error(message);
 }
 
 function restoreEnv(name: string, value: string | undefined): void {

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -2,7 +2,15 @@ import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import { access, lstat, mkdir, unlink, writeFile } from "node:fs/promises";
 import { dirname, join, parse, resolve, sep } from "node:path";
-import { Hono } from "hono";
+import {
+  CreateTaskInputSchema,
+  TaskServiceError,
+  createTaskCardService,
+  isSafeTaskId
+} from "@shud-harness/core";
+import { Hono, type Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { ZodError } from "zod";
 
 export const BACKEND_ROUTES_NAMESPACE = "backend/routes" as const;
 
@@ -66,6 +74,7 @@ export interface BackendApiOptions {
   version?: string;
   startTimeMs?: number;
   now?: () => Date;
+  taskIdFactory?: () => string;
   writableProbe?: WorkspaceWritableProbe;
   snapshotReadableProbe?: WorkspaceSnapshotReadableProbe;
 }
@@ -100,9 +109,28 @@ interface WorkspaceRoutesService {
   ready: () => Promise<WorkspaceReadyResponse>;
 }
 
+export interface ApiErrorResponse {
+  error: {
+    error_id: string;
+    category: string;
+    severity: "info" | "warn" | "error" | "critical";
+    message: string;
+    user_message: string;
+    evidence_refs: string[];
+    retryable: boolean;
+    recommended_next_actions: string[];
+  };
+}
+
 export function createBackendApi(options: BackendApiOptions = {}): Hono {
   const app = new Hono();
-  const service = createWorkspaceRoutesService(options);
+  const workspaceRoot = resolveWorkspaceRoot(options);
+  const service = createWorkspaceRoutesService({ ...options, workspaceRoot });
+  const taskService = createTaskCardService({
+    workspaceRoot,
+    now: options.now,
+    taskIdFactory: options.taskIdFactory
+  });
 
   app.post("/api/workspace/init", async (c) => {
     try {
@@ -119,7 +147,173 @@ export function createBackendApi(options: BackendApiOptions = {}): Hono {
     return c.json(readiness, readiness.status === "ok" ? 200 : 503);
   });
 
+  app.post("/api/tasks", async (c) => {
+    let rawBody: unknown;
+    try {
+      rawBody = await c.req.json();
+    } catch {
+      return jsonApiError(
+        c,
+        {
+          category: "schema_error",
+          severity: "error",
+          message: "Request body is not valid JSON.",
+          userMessage: "The task request body must be valid JSON.",
+          evidenceRefs: ["request.body"],
+          retryable: false,
+          recommendedNextActions: ["Submit a JSON body matching the TaskCard create schema."]
+        },
+        400
+      );
+    }
+
+    const parsedBody = CreateTaskInputSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
+      return jsonApiError(
+        c,
+        {
+          category: "schema_error",
+          severity: "error",
+          message: "Task create request failed schema validation.",
+          userMessage: "The task request is missing required fields or contains invalid values.",
+          evidenceRefs: zodEvidenceRefs(parsedBody.error),
+          retryable: false,
+          recommendedNextActions: ["Fix the highlighted request fields and submit again."]
+        },
+        400
+      );
+    }
+
+    try {
+      return c.json(await taskService.createTask(parsedBody.data), 201);
+    } catch (error) {
+      return jsonTaskServiceError(c, error);
+    }
+  });
+
+  app.get("/api/tasks", async (c) => {
+    try {
+      return c.json({ tasks: await taskService.listTasks() }, 200);
+    } catch (error) {
+      return jsonTaskServiceError(c, error);
+    }
+  });
+
+  app.get("/api/tasks/:id", async (c) => {
+    const taskId = c.req.param("id");
+    if (!isSafeTaskId(taskId)) {
+      return jsonApiError(
+        c,
+        {
+          category: "not_found",
+          severity: "error",
+          message: `Task not found: ${taskId}`,
+          userMessage: "The requested task does not exist.",
+          evidenceRefs: [`path.task_id:${taskId}`],
+          retryable: false,
+          recommendedNextActions: ["Refresh the task list and choose an existing task."]
+        },
+        404
+      );
+    }
+
+    try {
+      return c.json(await taskService.getTask(taskId), 200);
+    } catch (error) {
+      return jsonTaskServiceError(c, error);
+    }
+  });
+
+  app.notFound((c) => {
+    const pathname = new URL(c.req.url).pathname;
+    if (pathname.startsWith("/api/")) {
+      return jsonApiError(
+        c,
+        {
+          category: "not_found",
+          severity: "error",
+          message: `API route not found: ${pathname}`,
+          userMessage: "The requested API route does not exist.",
+          evidenceRefs: [`path:${pathname}`],
+          retryable: false,
+          recommendedNextActions: ["Use one of the registered API routes."]
+        },
+        404
+      );
+    }
+
+    return c.text("Not Found", 404);
+  });
+
   return app;
+}
+
+function jsonTaskServiceError(c: Context, error: unknown): Response {
+  if (error instanceof TaskServiceError) {
+    return jsonApiError(
+      c,
+      {
+        category: error.category,
+        severity: "error",
+        message: error.message,
+        userMessage: error.userMessage,
+        evidenceRefs: error.evidenceRefs,
+        retryable: error.retryable,
+        recommendedNextActions: error.recommendedNextActions
+      },
+      error.status
+    );
+  }
+
+  return jsonApiError(
+    c,
+    {
+      category: "workspace_error",
+      severity: "error",
+      message: "Unexpected backend route failure.",
+      userMessage: "The backend could not complete the request.",
+      evidenceRefs: ["backend/routes"],
+      retryable: false,
+      recommendedNextActions: ["Inspect backend logs before retrying."]
+    },
+    500
+  );
+}
+
+function jsonApiError(
+  c: Context,
+  input: Omit<ApiErrorResponse["error"], "error_id" | "user_message" | "evidence_refs" | "recommended_next_actions"> & {
+    userMessage: string;
+    evidenceRefs: string[];
+    recommendedNextActions: string[];
+  },
+  status: ContentfulStatusCode
+): Response {
+  return c.json(
+    {
+      error: {
+        error_id: `api_error_${randomUUID()}`,
+        category: input.category,
+        severity: input.severity,
+        message: input.message,
+        user_message: input.userMessage,
+        evidence_refs: input.evidenceRefs,
+        retryable: input.retryable,
+        recommended_next_actions: input.recommendedNextActions
+      }
+    } satisfies ApiErrorResponse,
+    status
+  );
+}
+
+function zodEvidenceRefs(error: ZodError): string[] {
+  return Array.from(
+    new Set(
+      error.issues.map((issue) =>
+        issue.path.length > 0 ? `request.body.${issue.path.join(".")}` : "request.body"
+      )
+    )
+  );
 }
 
 export function createWorkspaceRoutesService(

--- a/packages/core/src/domain/services/index.ts
+++ b/packages/core/src/domain/services/index.ts
@@ -1,3 +1,5 @@
 export const CORE_SERVICE_NAMESPACE = "core/domain/services" as const;
 
 export type CoreServiceNamespace = typeof CORE_SERVICE_NAMESPACE;
+
+export * from "./task-card-service";

--- a/packages/core/src/domain/services/task-card-service.ts
+++ b/packages/core/src/domain/services/task-card-service.ts
@@ -1,0 +1,732 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { lstat, mkdir, open, readdir, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, parse, relative, resolve, sep } from "node:path";
+import { z } from "zod";
+import {
+  InferenceBudgetSchema,
+  TaskCardSchema,
+  TaskRuntimePhaseSchema,
+  TaskStatusSchema,
+  TaskTypeSchema,
+  type TaskCard
+} from "../schemas/task";
+
+export const DEFAULT_TASK_CREATED_BY = "pi" as const;
+export const DEFAULT_TASK_CURRENT_OWNER = "coordinator" as const;
+export const DEFAULT_TASK_REVIEWER = "reviewer" as const;
+export const TASK_SNAPSHOT_LATEST_SEQ = 0 as const;
+
+const TASK_ID_PATTERN = /^TASK-[A-Za-z0-9][A-Za-z0-9_-]*$/;
+const MAX_TASK_ID_ATTEMPTS = 20;
+// M1 skeleton bound: cap workspace/tasks fan-out before opening any task snapshots.
+const MAX_TASK_HYDRATION_ENTRIES = 1024;
+const MAX_TASK_SNAPSHOT_BYTES = 1024 * 1024;
+const TASK_SNAPSHOT_OPEN_FLAGS = constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0);
+
+export const CreateTaskInputSchema = z.object({
+  type: TaskTypeSchema,
+  title: z.string().min(1),
+  question_or_goal: z.string().min(1),
+  inference_budget: InferenceBudgetSchema,
+  created_by: z.string().trim().min(1).optional()
+});
+
+export const TaskSnapshotSchema = z.object({
+  task_id: z.string().min(1),
+  status: TaskStatusSchema,
+  runtime_phase: TaskRuntimePhaseSchema.nullable().optional(),
+  stack_id: z.string().min(1).optional(),
+  data_id: z.string().min(1).optional(),
+  linked_jobs: z.array(z.string().min(1)),
+  linked_runs: z.array(z.string().min(1)),
+  linked_reports: z.array(z.string().min(1)),
+  active_analysis_plan_id: z.string().min(1).optional(),
+  latest_report_id: z.string().min(1).optional(),
+  pending_pi_gates: z.array(z.string().min(1)),
+  latest_seq: z.number().int().nonnegative(),
+  updated_at: z.string().min(1),
+  task_card: TaskCardSchema.optional()
+});
+
+export type CreateTaskInput = z.infer<typeof CreateTaskInputSchema>;
+export type TaskSnapshot = z.infer<typeof TaskSnapshotSchema>;
+
+export type TaskServiceErrorCode =
+  | "schema_error"
+  | "task_not_found"
+  | "task_id_not_safe"
+  | "workspace_path_not_safe"
+  | "task_lane_not_directory"
+  | "task_snapshot_malformed"
+  | "task_snapshot_mismatch"
+  | "task_snapshot_missing_card"
+  | "task_id_generation_failed";
+
+export interface TaskServiceErrorOptions {
+  code: TaskServiceErrorCode;
+  message: string;
+  userMessage: string;
+  status: 400 | 404 | 500;
+  category: string;
+  evidenceRefs?: string[];
+  retryable?: boolean;
+  recommendedNextActions?: string[];
+}
+
+export class TaskServiceError extends Error {
+  readonly code: TaskServiceErrorCode;
+  readonly status: 400 | 404 | 500;
+  readonly category: string;
+  readonly userMessage: string;
+  readonly evidenceRefs: string[];
+  readonly retryable: boolean;
+  readonly recommendedNextActions: string[];
+
+  constructor(options: TaskServiceErrorOptions) {
+    super(options.message);
+    this.name = "TaskServiceError";
+    this.code = options.code;
+    this.status = options.status;
+    this.category = options.category;
+    this.userMessage = options.userMessage;
+    this.evidenceRefs = options.evidenceRefs ?? [];
+    this.retryable = options.retryable ?? false;
+    this.recommendedNextActions = options.recommendedNextActions ?? [
+      "Inspect the workspace task snapshot state before retrying."
+    ];
+  }
+}
+
+export interface TaskCardServiceOptions {
+  workspaceRoot: string;
+  now?: () => Date;
+  taskIdFactory?: () => string;
+  snapshotReadHooks?: TaskSnapshotReadHooks;
+}
+
+export interface TaskCardService {
+  createTask: (input: CreateTaskInput) => Promise<TaskCard>;
+  listTasks: () => Promise<TaskCard[]>;
+  getTask: (taskId: string) => Promise<TaskCard>;
+}
+
+type FileStat = Awaited<ReturnType<typeof lstat>>;
+type SnapshotFileHandle = Awaited<ReturnType<typeof open>>;
+
+export interface TaskSnapshotReadHookInput {
+  snapshotPath: string;
+  laneTaskId: string;
+}
+
+export interface TaskSnapshotReadHooks {
+  beforeSnapshotOpen?: (input: TaskSnapshotReadHookInput) => Promise<void> | void;
+}
+
+export function createTaskCardService(options: TaskCardServiceOptions): TaskCardService {
+  const workspaceRoot = resolve(options.workspaceRoot);
+  const now = options.now ?? (() => new Date());
+  const taskIdFactory = options.taskIdFactory ?? (() => `TASK-${randomUUID()}`);
+  const snapshotReadHooks = options.snapshotReadHooks;
+  const tasks = new Map<string, TaskCard>();
+  const reservedTaskIds = new Set<string>();
+  let hydration: Promise<void> | undefined;
+
+  async function ensureHydrated(): Promise<void> {
+    hydration ??= hydrateTasksFromDisk(workspaceRoot, tasks, snapshotReadHooks);
+    await hydration;
+  }
+
+  return {
+    async createTask(input: CreateTaskInput): Promise<TaskCard> {
+      const parsedInput = CreateTaskInputSchema.safeParse(input);
+      if (!parsedInput.success) {
+        throw new TaskServiceError({
+          code: "schema_error",
+          status: 400,
+          category: "schema_error",
+          message: "Task create input failed schema validation.",
+          userMessage: "The task request is missing required fields or contains invalid values.",
+          evidenceRefs: toSchemaEvidenceRefs(parsedInput.error)
+        });
+      }
+
+      await ensureHydrated();
+
+      const timestamp = now().toISOString();
+      const taskId = nextTaskId(tasks, reservedTaskIds, taskIdFactory);
+      reservedTaskIds.add(taskId);
+
+      try {
+        const task: TaskCard = TaskCardSchema.parse({
+          task_id: taskId,
+          type: parsedInput.data.type,
+          status: "created",
+          title: parsedInput.data.title,
+          question_or_goal: parsedInput.data.question_or_goal,
+          created_by: parsedInput.data.created_by ?? DEFAULT_TASK_CREATED_BY,
+          current_owner: DEFAULT_TASK_CURRENT_OWNER,
+          reviewer: DEFAULT_TASK_REVIEWER,
+          inference_budget: parsedInput.data.inference_budget,
+          linked_jobs: [],
+          linked_reports: [],
+          created_at: timestamp,
+          updated_at: timestamp
+        });
+
+        await persistTaskSnapshot(workspaceRoot, task);
+        tasks.set(task.task_id, task);
+        return task;
+      } finally {
+        reservedTaskIds.delete(taskId);
+      }
+    },
+
+    async listTasks(): Promise<TaskCard[]> {
+      await ensureHydrated();
+      return Array.from(tasks.values()).sort(compareTaskCards);
+    },
+
+    async getTask(taskId: string): Promise<TaskCard> {
+      await ensureHydrated();
+      assertSafeTaskId(taskId, `path.task_id:${taskId}`);
+      const task = tasks.get(taskId);
+      if (!task) {
+        throw new TaskServiceError({
+          code: "task_not_found",
+          status: 404,
+          category: "not_found",
+          message: `Task not found: ${taskId}`,
+          userMessage: "The requested task does not exist.",
+          evidenceRefs: [`path.task_id:${taskId}`],
+          recommendedNextActions: ["Refresh the task list and choose an existing task."]
+        });
+      }
+
+      return task;
+    }
+  };
+}
+
+export function isSafeTaskId(taskId: string): boolean {
+  return TASK_ID_PATTERN.test(taskId);
+}
+
+function nextTaskId(
+  tasks: ReadonlyMap<string, TaskCard>,
+  reservedTaskIds: ReadonlySet<string>,
+  taskIdFactory: () => string
+): string {
+  for (let attempt = 0; attempt < MAX_TASK_ID_ATTEMPTS; attempt += 1) {
+    const taskId = taskIdFactory();
+    assertSafeTaskId(taskId, `generated_task_id:${taskId}`);
+    if (!tasks.has(taskId) && !reservedTaskIds.has(taskId)) {
+      return taskId;
+    }
+  }
+
+  throw new TaskServiceError({
+    code: "task_id_generation_failed",
+    status: 500,
+    category: "workspace_error",
+    message: "Unable to generate a unique task id.",
+    userMessage: "The service could not allocate a new task id.",
+    evidenceRefs: ["generated_task_id"]
+  });
+}
+
+async function hydrateTasksFromDisk(
+  workspaceRoot: string,
+  tasks: Map<string, TaskCard>,
+  snapshotReadHooks?: TaskSnapshotReadHooks
+): Promise<void> {
+  const workspaceEntry = await maybeLstat(workspaceRoot);
+  if (!workspaceEntry) {
+    return;
+  }
+  if (!(await isSafeExistingDirectoryPath(workspaceRoot))) {
+    throw workspaceError(
+      "workspace_path_not_safe",
+      "Configured workspace root is not a safe directory.",
+      "The configured workspace root is not usable.",
+      ["workspace"]
+    );
+  }
+
+  const tasksRoot = join(workspaceRoot, "tasks");
+  const tasksRootEntry = await maybeLstat(tasksRoot);
+  if (!tasksRootEntry) {
+    return;
+  }
+  if (!(await isSafeExistingDirectoryPath(tasksRoot))) {
+    throw workspaceError(
+      "workspace_path_not_safe",
+      "Workspace tasks root is not a safe directory.",
+      "The workspace tasks directory is not usable.",
+      ["workspace/tasks"]
+    );
+  }
+
+  const entries = await readdir(tasksRoot, { withFileTypes: true });
+  if (entries.length > MAX_TASK_HYDRATION_ENTRIES) {
+    throw workspaceError(
+      "workspace_path_not_safe",
+      `Workspace tasks root contains ${entries.length} entries, exceeding the M1 hydration limit of ${MAX_TASK_HYDRATION_ENTRIES}.`,
+      "The workspace tasks directory has too many entries to hydrate safely.",
+      ["workspace/tasks", "workspace/tasks:entry_count"]
+    );
+  }
+
+  for (const entry of entries) {
+    if (!isSafeTaskId(entry.name)) {
+      continue;
+    }
+
+    const lanePath = join(tasksRoot, entry.name);
+    if (!entry.isDirectory() || entry.isSymbolicLink() || !(await isSafeExistingDirectoryPath(lanePath))) {
+      throw workspaceError(
+        "task_lane_not_directory",
+        `Task lane is not a safe directory: ${entry.name}`,
+        "A task snapshot lane is blocked by a non-directory filesystem entry.",
+        [`workspace/tasks/${entry.name}`]
+      );
+    }
+
+    const snapshotPath = join(lanePath, "snapshot.json");
+    if (!(await maybeLstat(snapshotPath))) {
+      continue;
+    }
+
+    await snapshotReadHooks?.beforeSnapshotOpen?.({ snapshotPath, laneTaskId: entry.name });
+    const snapshot = await readTaskSnapshot(snapshotPath, entry.name);
+    tasks.set(snapshot.task_id, snapshot.task_card);
+  }
+}
+
+async function readTaskSnapshot(
+  snapshotPath: string,
+  laneTaskId: string
+): Promise<TaskSnapshot & { task_card: TaskCard }> {
+  let snapshotFile: SnapshotFileHandle;
+  try {
+    snapshotFile = await open(snapshotPath, TASK_SNAPSHOT_OPEN_FLAGS);
+  } catch (error) {
+    throw workspaceError(
+      "task_snapshot_malformed",
+      "Task snapshot cannot be opened safely.",
+      "A task snapshot cannot be read safely.",
+      [snapshotPath],
+      error
+    );
+  }
+
+  try {
+    const snapshotEntry = await snapshotFile.stat().catch((error: unknown) => {
+      throw workspaceError(
+        "task_snapshot_malformed",
+        "Task snapshot cannot be inspected.",
+        "A task snapshot cannot be read safely.",
+        [snapshotPath],
+        error
+      );
+    });
+    if (!snapshotEntry.isFile() || snapshotEntry.isSymbolicLink()) {
+      throw workspaceError(
+        "task_snapshot_malformed",
+        "Task snapshot is not a safe regular file.",
+        "A task snapshot cannot be read safely.",
+        [snapshotPath]
+      );
+    }
+    if (snapshotEntry.size > MAX_TASK_SNAPSHOT_BYTES) {
+      throw workspaceError(
+        "task_snapshot_malformed",
+        "Task snapshot exceeds the M1 bounded read size.",
+        "A task snapshot is too large to load safely.",
+        [snapshotPath]
+      );
+    }
+
+    const rawSnapshotText = await readBoundedTaskSnapshot(snapshotFile, snapshotPath);
+    let rawSnapshot: unknown;
+    try {
+      rawSnapshot = JSON.parse(rawSnapshotText) as unknown;
+    } catch (error) {
+      throw workspaceError(
+        "task_snapshot_malformed",
+        "Task snapshot is not valid JSON.",
+        "A task snapshot is malformed and recovery has been stopped.",
+        [snapshotPath],
+        error
+      );
+    }
+
+    const parsedSnapshot = TaskSnapshotSchema.safeParse(rawSnapshot);
+    if (!parsedSnapshot.success) {
+      throw workspaceError(
+        "task_snapshot_malformed",
+        "Task snapshot failed schema validation.",
+        "A task snapshot is malformed and recovery has been stopped.",
+        [snapshotPath, ...toSchemaEvidenceRefs(parsedSnapshot.error, "snapshot")]
+      );
+    }
+
+    assertSafeTaskId(parsedSnapshot.data.task_id, `snapshot.task_id:${parsedSnapshot.data.task_id}`);
+    if (parsedSnapshot.data.task_id !== laneTaskId) {
+      throw workspaceError(
+        "task_snapshot_mismatch",
+        "Task snapshot id does not match its lane.",
+        "A task snapshot does not match its task directory.",
+        [
+          `workspace/tasks/${laneTaskId}/snapshot.json`,
+          `snapshot.task_id:${parsedSnapshot.data.task_id}`
+        ]
+      );
+    }
+
+    if (!parsedSnapshot.data.task_card) {
+      throw workspaceError(
+        "task_snapshot_missing_card",
+        "Task snapshot does not include the M1 task_card recovery payload.",
+        "A task snapshot is missing the data needed for recovery.",
+        [`workspace/tasks/${laneTaskId}/snapshot.json`]
+      );
+    }
+
+    validateSnapshotTaskCardConsistency(parsedSnapshot.data, snapshotPath);
+    return parsedSnapshot.data as TaskSnapshot & { task_card: TaskCard };
+  } finally {
+    await snapshotFile.close().catch(() => undefined);
+  }
+}
+
+async function readBoundedTaskSnapshot(
+  snapshotFile: SnapshotFileHandle,
+  snapshotPath: string
+): Promise<string> {
+  const buffer = Buffer.allocUnsafe(MAX_TASK_SNAPSHOT_BYTES + 1);
+  let offset = 0;
+
+  try {
+    while (offset < buffer.length) {
+      const { bytesRead } = await snapshotFile.read(buffer, offset, buffer.length - offset, offset);
+      if (bytesRead === 0) {
+        break;
+      }
+      offset += bytesRead;
+    }
+  } catch (error) {
+    throw workspaceError(
+      "task_snapshot_malformed",
+      "Task snapshot cannot be read safely.",
+      "A task snapshot cannot be read safely.",
+      [snapshotPath],
+      error
+    );
+  }
+
+  if (offset > MAX_TASK_SNAPSHOT_BYTES) {
+    throw workspaceError(
+      "task_snapshot_malformed",
+      "Task snapshot exceeds the M1 bounded read size.",
+      "A task snapshot is too large to load safely.",
+      [snapshotPath]
+    );
+  }
+
+  return buffer.subarray(0, offset).toString("utf8");
+}
+
+async function persistTaskSnapshot(workspaceRoot: string, task: TaskCard): Promise<void> {
+  const taskDirectory = await ensureTaskDirectory(workspaceRoot, task.task_id);
+  const snapshot = createTaskSnapshot(task);
+  const snapshotPath = join(taskDirectory, "snapshot.json");
+  assertPathInsideWorkspace(workspaceRoot, snapshotPath, `workspace/tasks/${task.task_id}/snapshot.json`);
+
+  const temporaryPath = join(taskDirectory, `.snapshot-${process.pid}-${randomUUID()}.tmp`);
+  assertPathInsideWorkspace(workspaceRoot, temporaryPath, `workspace/tasks/${task.task_id}/snapshot.tmp`);
+
+  let wroteTemporary = false;
+  try {
+    await writeFile(temporaryPath, `${JSON.stringify(snapshot, null, 2)}\n`, { flag: "wx" });
+    wroteTemporary = true;
+    await rename(temporaryPath, snapshotPath);
+    wroteTemporary = false;
+  } catch (error) {
+    throw workspaceError(
+      "workspace_path_not_safe",
+      "Failed to persist task snapshot under the configured workspace.",
+      "The task snapshot could not be written safely.",
+      [`workspace/tasks/${task.task_id}/snapshot.json`],
+      error
+    );
+  } finally {
+    if (wroteTemporary) {
+      await unlink(temporaryPath).catch(() => undefined);
+    }
+  }
+}
+
+function createTaskSnapshot(task: TaskCard): TaskSnapshot & { task_card: TaskCard } {
+  return TaskSnapshotSchema.parse({
+    task_id: task.task_id,
+    status: task.status,
+    runtime_phase: task.runtime_phase ?? null,
+    ...(task.stack_id ? { stack_id: task.stack_id } : {}),
+    ...(task.data_id ? { data_id: task.data_id } : {}),
+    linked_jobs: task.linked_jobs,
+    linked_runs: [],
+    linked_reports: task.linked_reports,
+    pending_pi_gates: [],
+    latest_seq: TASK_SNAPSHOT_LATEST_SEQ,
+    updated_at: task.updated_at,
+    task_card: task
+  }) as TaskSnapshot & { task_card: TaskCard };
+}
+
+async function ensureTaskDirectory(workspaceRoot: string, taskId: string): Promise<string> {
+  assertSafeTaskId(taskId, `task.task_id:${taskId}`);
+  await ensureSafeDirectory(workspaceRoot, "workspace_path_not_safe");
+
+  const tasksRoot = join(workspaceRoot, "tasks");
+  assertPathInsideWorkspace(workspaceRoot, tasksRoot, "workspace/tasks");
+  await ensureSafeDirectory(tasksRoot, "workspace_path_not_safe");
+
+  const taskDirectory = join(tasksRoot, taskId);
+  assertPathInsideWorkspace(workspaceRoot, taskDirectory, `workspace/tasks/${taskId}`);
+  await ensureSafeDirectory(taskDirectory, "task_lane_not_directory");
+
+  return taskDirectory;
+}
+
+async function ensureSafeDirectory(
+  path: string,
+  errorCode: Extract<TaskServiceErrorCode, "workspace_path_not_safe" | "task_lane_not_directory">
+): Promise<void> {
+  const existingEntry = await maybeLstat(path);
+  if (existingEntry) {
+    if (!(await isSafeExistingDirectoryPath(path))) {
+      throw workspaceError(
+        errorCode,
+        `Path is not a safe directory: ${path}`,
+        "A required workspace path is not a safe directory.",
+        [path]
+      );
+    }
+    return;
+  }
+
+  const parentPath = dirname(path);
+  if (parentPath === path || !(await isSafeExistingDirectoryPath(parentPath))) {
+    throw workspaceError(
+      errorCode,
+      `Parent path is not a safe directory: ${parentPath}`,
+      "A required workspace parent path is not a safe directory.",
+      [parentPath]
+    );
+  }
+
+  try {
+    await mkdir(path);
+  } catch (error) {
+    if (hasErrorCode(error, "EEXIST")) {
+      if (await isSafeExistingDirectoryPath(path)) {
+        return;
+      }
+      throw workspaceError(
+        errorCode,
+        `Existing path is not a safe directory: ${path}`,
+        "A required workspace path is not a safe directory.",
+        [path],
+        error
+      );
+    }
+
+    throw workspaceError(
+      errorCode,
+      `Failed to create workspace directory: ${path}`,
+      "A required workspace directory could not be created safely.",
+      [path],
+      error
+    );
+  }
+
+  if (!(await isSafeExistingDirectoryPath(path))) {
+    throw workspaceError(
+      errorCode,
+      `Created path is not a safe directory: ${path}`,
+      "A required workspace path is not a safe directory.",
+      [path]
+    );
+  }
+}
+
+async function isSafeExistingDirectoryPath(path: string): Promise<boolean> {
+  const { rootPath, segments } = getPathParts(path);
+  const rootEntry = await maybeLstat(rootPath);
+  if (!isSafeDirectoryEntry(rootEntry)) {
+    return false;
+  }
+
+  let currentPath = rootPath;
+  for (const segment of segments) {
+    currentPath = join(currentPath, segment);
+    const entry = await maybeLstat(currentPath);
+    if (!isSafeDirectoryEntry(entry)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function getPathParts(path: string): { rootPath: string; segments: string[] } {
+  const resolvedPath = resolve(path);
+  const rootPath = parse(resolvedPath).root;
+  return {
+    rootPath,
+    segments: resolvedPath.slice(rootPath.length).split(sep).filter(Boolean)
+  };
+}
+
+function isSafeDirectoryEntry(entry: FileStat | undefined): boolean {
+  return Boolean(entry?.isDirectory() && !entry.isSymbolicLink());
+}
+
+async function maybeLstat(path: string): Promise<FileStat | undefined> {
+  try {
+    return await lstat(path);
+  } catch {
+    return undefined;
+  }
+}
+
+function assertSafeTaskId(taskId: string, evidenceRef: string): void {
+  if (isSafeTaskId(taskId)) {
+    return;
+  }
+
+  throw new TaskServiceError({
+    code: "task_id_not_safe",
+    status: 404,
+    category: "not_found",
+    message: `Task id is not safe: ${taskId}`,
+    userMessage: "The requested task id is not valid.",
+    evidenceRefs: [evidenceRef],
+    recommendedNextActions: ["Refresh the task list and choose an existing task."]
+  });
+}
+
+function assertPathInsideWorkspace(
+  workspaceRoot: string,
+  targetPath: string,
+  evidenceRef: string
+): void {
+  const relativePath = relative(workspaceRoot, resolve(targetPath));
+  if (relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath))) {
+    return;
+  }
+
+  throw workspaceError(
+    "workspace_path_not_safe",
+    `Resolved path escapes workspace: ${targetPath}`,
+    "A workspace path resolved outside the configured workspace.",
+    [evidenceRef]
+  );
+}
+
+function validateSnapshotTaskCardConsistency(snapshot: TaskSnapshot, snapshotPath: string): void {
+  const taskCard = snapshot.task_card;
+  if (!taskCard) {
+    return;
+  }
+
+  const mismatches: string[] = [];
+  if (taskCard.task_id !== snapshot.task_id) {
+    mismatches.push("task_id");
+  }
+  if (taskCard.status !== snapshot.status) {
+    mismatches.push("status");
+  }
+  if ((taskCard.runtime_phase ?? null) !== (snapshot.runtime_phase ?? null)) {
+    mismatches.push("runtime_phase");
+  }
+  if (taskCard.stack_id !== snapshot.stack_id) {
+    mismatches.push("stack_id");
+  }
+  if (taskCard.data_id !== snapshot.data_id) {
+    mismatches.push("data_id");
+  }
+  if (!stringArraysEqual(taskCard.linked_jobs, snapshot.linked_jobs)) {
+    mismatches.push("linked_jobs");
+  }
+  if (!stringArraysEqual(taskCard.linked_reports, snapshot.linked_reports)) {
+    mismatches.push("linked_reports");
+  }
+  if (taskCard.updated_at !== snapshot.updated_at) {
+    mismatches.push("updated_at");
+  }
+
+  if (mismatches.length > 0) {
+    throw workspaceError(
+      "task_snapshot_mismatch",
+      "Task snapshot outer fields do not match nested task_card.",
+      "A task snapshot is inconsistent and recovery has been stopped.",
+      [snapshotPath, ...mismatches.map((field) => `snapshot.${field}`)]
+    );
+  }
+}
+
+function stringArraysEqual(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function compareTaskCards(left: TaskCard, right: TaskCard): number {
+  return (
+    left.created_at.localeCompare(right.created_at) || left.task_id.localeCompare(right.task_id)
+  );
+}
+
+function toSchemaEvidenceRefs(error: z.ZodError, prefix = "request.body"): string[] {
+  return Array.from(
+    new Set(
+      error.issues.map((issue) =>
+        issue.path.length > 0 ? `${prefix}.${issue.path.join(".")}` : prefix
+      )
+    )
+  );
+}
+
+function workspaceError(
+  code: Exclude<TaskServiceErrorCode, "schema_error" | "task_not_found" | "task_id_not_safe">,
+  message: string,
+  userMessage: string,
+  evidenceRefs: string[],
+  cause?: unknown
+): TaskServiceError {
+  const error = new TaskServiceError({
+    code,
+    status: 500,
+    category: "workspace_error",
+    message,
+    userMessage,
+    evidenceRefs,
+    retryable: false,
+    recommendedNextActions: ["Inspect the workspace task snapshot state before retrying."]
+  });
+
+  if (cause instanceof Error) {
+    error.cause = cause;
+  }
+
+  return error;
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === code
+  );
+}

--- a/packages/core/src/domain/services/task-card-service.ts
+++ b/packages/core/src/domain/services/task-card-service.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { constants } from "node:fs";
-import { lstat, mkdir, open, readdir, rename, unlink, writeFile } from "node:fs/promises";
+import { constants, type Dirent } from "node:fs";
+import { lstat, mkdir, open, opendir, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, parse, relative, resolve, sep } from "node:path";
 import { z } from "zod";
 import {
@@ -21,7 +21,7 @@ const TASK_ID_PATTERN = /^TASK-[A-Za-z0-9][A-Za-z0-9_-]*$/;
 const MAX_TASK_ID_ATTEMPTS = 20;
 // M1 skeleton bound: cap workspace/tasks fan-out before opening any task snapshots.
 const MAX_TASK_HYDRATION_ENTRIES = 1024;
-const MAX_TASK_SNAPSHOT_BYTES = 1024 * 1024;
+export const MAX_TASK_SNAPSHOT_BYTES = 1024 * 1024;
 const TASK_SNAPSHOT_OPEN_FLAGS = constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0);
 
 export const CreateTaskInputSchema = z.object({
@@ -61,6 +61,7 @@ export type TaskServiceErrorCode =
   | "task_snapshot_malformed"
   | "task_snapshot_mismatch"
   | "task_snapshot_missing_card"
+  | "task_snapshot_too_large"
   | "task_id_generation_failed";
 
 export interface TaskServiceErrorOptions {
@@ -103,6 +104,7 @@ export interface TaskCardServiceOptions {
   now?: () => Date;
   taskIdFactory?: () => string;
   snapshotReadHooks?: TaskSnapshotReadHooks;
+  snapshotWriteHooks?: TaskSnapshotWriteHooks;
 }
 
 export interface TaskCardService {
@@ -123,18 +125,39 @@ export interface TaskSnapshotReadHooks {
   beforeSnapshotOpen?: (input: TaskSnapshotReadHookInput) => Promise<void> | void;
 }
 
+export interface TaskSnapshotWriteHookInput {
+  taskDirectory: string;
+  taskId: string;
+}
+
+export interface TaskSnapshotWriteHooks {
+  beforeSnapshotWrite?: (input: TaskSnapshotWriteHookInput) => Promise<void> | void;
+}
+
 export function createTaskCardService(options: TaskCardServiceOptions): TaskCardService {
   const workspaceRoot = resolve(options.workspaceRoot);
   const now = options.now ?? (() => new Date());
   const taskIdFactory = options.taskIdFactory ?? (() => `TASK-${randomUUID()}`);
   const snapshotReadHooks = options.snapshotReadHooks;
+  const snapshotWriteHooks = options.snapshotWriteHooks;
   const tasks = new Map<string, TaskCard>();
   const reservedTaskIds = new Set<string>();
   let hydration: Promise<void> | undefined;
 
   async function ensureHydrated(): Promise<void> {
-    hydration ??= hydrateTasksFromDisk(workspaceRoot, tasks, snapshotReadHooks);
-    await hydration;
+    hydration ??= hydrateTasksFromDisk(workspaceRoot, snapshotReadHooks).then((hydratedTasks) => {
+      tasks.clear();
+      for (const [taskId, task] of hydratedTasks) {
+        tasks.set(taskId, task);
+      }
+    });
+
+    try {
+      await hydration;
+    } catch (error) {
+      hydration = undefined;
+      throw error;
+    }
   }
 
   return {
@@ -174,7 +197,7 @@ export function createTaskCardService(options: TaskCardServiceOptions): TaskCard
           updated_at: timestamp
         });
 
-        await persistTaskSnapshot(workspaceRoot, task);
+        await persistTaskSnapshot(workspaceRoot, task, snapshotWriteHooks);
         tasks.set(task.task_id, task);
         return task;
       } finally {
@@ -237,12 +260,12 @@ function nextTaskId(
 
 async function hydrateTasksFromDisk(
   workspaceRoot: string,
-  tasks: Map<string, TaskCard>,
   snapshotReadHooks?: TaskSnapshotReadHooks
-): Promise<void> {
+): Promise<Map<string, TaskCard>> {
+  const tasks = new Map<string, TaskCard>();
   const workspaceEntry = await maybeLstat(workspaceRoot);
   if (!workspaceEntry) {
-    return;
+    return tasks;
   }
   if (!(await isSafeExistingDirectoryPath(workspaceRoot))) {
     throw workspaceError(
@@ -256,7 +279,7 @@ async function hydrateTasksFromDisk(
   const tasksRoot = join(workspaceRoot, "tasks");
   const tasksRootEntry = await maybeLstat(tasksRoot);
   if (!tasksRootEntry) {
-    return;
+    return tasks;
   }
   if (!(await isSafeExistingDirectoryPath(tasksRoot))) {
     throw workspaceError(
@@ -267,15 +290,7 @@ async function hydrateTasksFromDisk(
     );
   }
 
-  const entries = await readdir(tasksRoot, { withFileTypes: true });
-  if (entries.length > MAX_TASK_HYDRATION_ENTRIES) {
-    throw workspaceError(
-      "workspace_path_not_safe",
-      `Workspace tasks root contains ${entries.length} entries, exceeding the M1 hydration limit of ${MAX_TASK_HYDRATION_ENTRIES}.`,
-      "The workspace tasks directory has too many entries to hydrate safely.",
-      ["workspace/tasks", "workspace/tasks:entry_count"]
-    );
-  }
+  const entries = await readBoundedTaskEntries(tasksRoot);
 
   for (const entry of entries) {
     if (!isSafeTaskId(entry.name)) {
@@ -283,7 +298,8 @@ async function hydrateTasksFromDisk(
     }
 
     const lanePath = join(tasksRoot, entry.name);
-    if (!entry.isDirectory() || entry.isSymbolicLink() || !(await isSafeExistingDirectoryPath(lanePath))) {
+    assertSafeTaskLaneEntry(entry, lanePath);
+    if (!(await isSafeExistingDirectoryPath(lanePath))) {
       throw workspaceError(
         "task_lane_not_directory",
         `Task lane is not a safe directory: ${entry.name}`,
@@ -293,20 +309,88 @@ async function hydrateTasksFromDisk(
     }
 
     const snapshotPath = join(lanePath, "snapshot.json");
+    const snapshotEvidenceRef = taskSnapshotEvidenceRef(entry.name);
     if (!(await maybeLstat(snapshotPath))) {
       continue;
     }
 
     await snapshotReadHooks?.beforeSnapshotOpen?.({ snapshotPath, laneTaskId: entry.name });
-    const snapshot = await readTaskSnapshot(snapshotPath, entry.name);
+    if (!(await isSafeExistingDirectoryPath(lanePath))) {
+      throw workspaceError(
+        "task_lane_not_directory",
+        `Task lane is not a safe directory: ${entry.name}`,
+        "A task snapshot lane is blocked by a non-directory filesystem entry.",
+        [`workspace/tasks/${entry.name}`]
+      );
+    }
+
+    const snapshot = await readTaskSnapshot(
+      snapshotPath,
+      entry.name,
+      lanePath,
+      snapshotEvidenceRef
+    );
     tasks.set(snapshot.task_id, snapshot.task_card);
   }
+
+  return tasks;
+}
+
+async function readBoundedTaskEntries(tasksRoot: string): Promise<Dirent[]> {
+  const entries: Dirent[] = [];
+  let entryCount = 0;
+
+  try {
+    const directory = await opendir(tasksRoot);
+    for await (const entry of directory) {
+      entryCount += 1;
+      if (entryCount > MAX_TASK_HYDRATION_ENTRIES) {
+        throw workspaceError(
+          "workspace_path_not_safe",
+          `Workspace tasks root contains more than ${MAX_TASK_HYDRATION_ENTRIES} entries, exceeding the M1 hydration limit.`,
+          "The workspace tasks directory has too many entries to hydrate safely.",
+          ["workspace/tasks", "workspace/tasks:entry_count"]
+        );
+      }
+      entries.push(entry);
+    }
+  } catch (error) {
+    if (error instanceof TaskServiceError) {
+      throw error;
+    }
+    throw workspaceError(
+      "workspace_path_not_safe",
+      "Workspace tasks root cannot be scanned safely.",
+      "The workspace tasks directory is not usable.",
+      ["workspace/tasks"],
+      error
+    );
+  }
+
+  return entries;
+}
+
+function assertSafeTaskLaneEntry(entry: Dirent, lanePath: string): void {
+  if (entry.isDirectory() && !entry.isSymbolicLink()) {
+    return;
+  }
+
+  throw workspaceError(
+    "task_lane_not_directory",
+    `Task lane is not a safe directory: ${entry.name}`,
+    "A task snapshot lane is blocked by a non-directory filesystem entry.",
+    [taskLaneEvidenceRef(lanePath)]
+  );
 }
 
 async function readTaskSnapshot(
   snapshotPath: string,
-  laneTaskId: string
+  laneTaskId: string,
+  lanePath: string,
+  evidenceRef: string
 ): Promise<TaskSnapshot & { task_card: TaskCard }> {
+  await assertSafeSnapshotLeaf(snapshotPath, evidenceRef);
+
   let snapshotFile: SnapshotFileHandle;
   try {
     snapshotFile = await open(snapshotPath, TASK_SNAPSHOT_OPEN_FLAGS);
@@ -315,18 +399,27 @@ async function readTaskSnapshot(
       "task_snapshot_malformed",
       "Task snapshot cannot be opened safely.",
       "A task snapshot cannot be read safely.",
-      [snapshotPath],
+      [evidenceRef],
       error
     );
   }
 
   try {
+    if (!(await isSafeExistingDirectoryPath(lanePath))) {
+      throw workspaceError(
+        "task_lane_not_directory",
+        `Task lane is not a safe directory: ${laneTaskId}`,
+        "A task snapshot lane is blocked by a non-directory filesystem entry.",
+        [`workspace/tasks/${laneTaskId}`]
+      );
+    }
+
     const snapshotEntry = await snapshotFile.stat().catch((error: unknown) => {
       throw workspaceError(
         "task_snapshot_malformed",
         "Task snapshot cannot be inspected.",
         "A task snapshot cannot be read safely.",
-        [snapshotPath],
+        [evidenceRef],
         error
       );
     });
@@ -335,7 +428,7 @@ async function readTaskSnapshot(
         "task_snapshot_malformed",
         "Task snapshot is not a safe regular file.",
         "A task snapshot cannot be read safely.",
-        [snapshotPath]
+        [evidenceRef]
       );
     }
     if (snapshotEntry.size > MAX_TASK_SNAPSHOT_BYTES) {
@@ -343,11 +436,11 @@ async function readTaskSnapshot(
         "task_snapshot_malformed",
         "Task snapshot exceeds the M1 bounded read size.",
         "A task snapshot is too large to load safely.",
-        [snapshotPath]
+        [evidenceRef]
       );
     }
 
-    const rawSnapshotText = await readBoundedTaskSnapshot(snapshotFile, snapshotPath);
+    const rawSnapshotText = await readBoundedTaskSnapshot(snapshotFile, evidenceRef);
     let rawSnapshot: unknown;
     try {
       rawSnapshot = JSON.parse(rawSnapshotText) as unknown;
@@ -356,7 +449,7 @@ async function readTaskSnapshot(
         "task_snapshot_malformed",
         "Task snapshot is not valid JSON.",
         "A task snapshot is malformed and recovery has been stopped.",
-        [snapshotPath],
+        [evidenceRef],
         error
       );
     }
@@ -367,11 +460,19 @@ async function readTaskSnapshot(
         "task_snapshot_malformed",
         "Task snapshot failed schema validation.",
         "A task snapshot is malformed and recovery has been stopped.",
-        [snapshotPath, ...toSchemaEvidenceRefs(parsedSnapshot.error, "snapshot")]
+        [evidenceRef, ...toSchemaEvidenceRefs(parsedSnapshot.error, "snapshot")]
       );
     }
 
-    assertSafeTaskId(parsedSnapshot.data.task_id, `snapshot.task_id:${parsedSnapshot.data.task_id}`);
+    if (!isSafeTaskId(parsedSnapshot.data.task_id)) {
+      throw workspaceError(
+        "task_snapshot_malformed",
+        "Task snapshot id is not safe.",
+        "A task snapshot is malformed and recovery has been stopped.",
+        [evidenceRef, "snapshot.task_id"]
+      );
+    }
+
     if (parsedSnapshot.data.task_id !== laneTaskId) {
       throw workspaceError(
         "task_snapshot_mismatch",
@@ -384,25 +485,62 @@ async function readTaskSnapshot(
       );
     }
 
+    if (parsedSnapshot.data.latest_seq !== TASK_SNAPSHOT_LATEST_SEQ) {
+      throw workspaceError(
+        "task_snapshot_mismatch",
+        "Task snapshot latest sequence is not supported by M1 recovery.",
+        "A task snapshot is inconsistent and recovery has been stopped.",
+        [evidenceRef, "snapshot.latest_seq"]
+      );
+    }
+
     if (!parsedSnapshot.data.task_card) {
       throw workspaceError(
         "task_snapshot_missing_card",
         "Task snapshot does not include the M1 task_card recovery payload.",
         "A task snapshot is missing the data needed for recovery.",
-        [`workspace/tasks/${laneTaskId}/snapshot.json`]
+        [evidenceRef]
       );
     }
 
-    validateSnapshotTaskCardConsistency(parsedSnapshot.data, snapshotPath);
+    validateSnapshotTaskCardConsistency(parsedSnapshot.data, evidenceRef);
     return parsedSnapshot.data as TaskSnapshot & { task_card: TaskCard };
   } finally {
     await snapshotFile.close().catch(() => undefined);
   }
 }
 
+async function assertSafeSnapshotLeaf(snapshotPath: string, evidenceRef: string): Promise<void> {
+  const snapshotEntry = await maybeLstat(snapshotPath);
+  if (!snapshotEntry) {
+    throw workspaceError(
+      "task_snapshot_malformed",
+      "Task snapshot cannot be inspected.",
+      "A task snapshot cannot be read safely.",
+      [evidenceRef]
+    );
+  }
+  if (!snapshotEntry.isFile() || snapshotEntry.isSymbolicLink()) {
+    throw workspaceError(
+      "task_snapshot_malformed",
+      "Task snapshot is not a safe regular file.",
+      "A task snapshot cannot be read safely.",
+      [evidenceRef]
+    );
+  }
+  if (snapshotEntry.size > MAX_TASK_SNAPSHOT_BYTES) {
+    throw workspaceError(
+      "task_snapshot_malformed",
+      "Task snapshot exceeds the M1 bounded read size.",
+      "A task snapshot is too large to load safely.",
+      [evidenceRef]
+    );
+  }
+}
+
 async function readBoundedTaskSnapshot(
   snapshotFile: SnapshotFileHandle,
-  snapshotPath: string
+  evidenceRef: string
 ): Promise<string> {
   const buffer = Buffer.allocUnsafe(MAX_TASK_SNAPSHOT_BYTES + 1);
   let offset = 0;
@@ -420,7 +558,7 @@ async function readBoundedTaskSnapshot(
       "task_snapshot_malformed",
       "Task snapshot cannot be read safely.",
       "A task snapshot cannot be read safely.",
-      [snapshotPath],
+      [evidenceRef],
       error
     );
   }
@@ -430,16 +568,42 @@ async function readBoundedTaskSnapshot(
       "task_snapshot_malformed",
       "Task snapshot exceeds the M1 bounded read size.",
       "A task snapshot is too large to load safely.",
-      [snapshotPath]
+      [evidenceRef]
     );
   }
 
   return buffer.subarray(0, offset).toString("utf8");
 }
 
-async function persistTaskSnapshot(workspaceRoot: string, task: TaskCard): Promise<void> {
-  const taskDirectory = await ensureTaskDirectory(workspaceRoot, task.task_id);
+async function persistTaskSnapshot(
+  workspaceRoot: string,
+  task: TaskCard,
+  snapshotWriteHooks?: TaskSnapshotWriteHooks
+): Promise<void> {
   const snapshot = createTaskSnapshot(task);
+  const snapshotText = `${JSON.stringify(snapshot, null, 2)}\n`;
+  if (Buffer.byteLength(snapshotText, "utf8") > MAX_TASK_SNAPSHOT_BYTES) {
+    throw new TaskServiceError({
+      code: "task_snapshot_too_large",
+      status: 400,
+      category: "schema_error",
+      message: "Task snapshot would exceed the M1 bounded recovery size.",
+      userMessage: "The task request is too large to persist safely.",
+      evidenceRefs: ["request.body"],
+      recommendedNextActions: ["Shorten the task title, goal, or creator fields and submit again."]
+    });
+  }
+
+  const taskDirectory = await ensureTaskDirectory(workspaceRoot, task.task_id);
+  await snapshotWriteHooks?.beforeSnapshotWrite?.({ taskDirectory, taskId: task.task_id });
+  if (!(await isSafeExistingDirectoryPath(taskDirectory))) {
+    throw workspaceError(
+      "task_lane_not_directory",
+      `Task lane is not a safe directory: ${task.task_id}`,
+      "A task snapshot lane is blocked by a non-directory filesystem entry.",
+      [`workspace/tasks/${task.task_id}`]
+    );
+  }
   const snapshotPath = join(taskDirectory, "snapshot.json");
   assertPathInsideWorkspace(workspaceRoot, snapshotPath, `workspace/tasks/${task.task_id}/snapshot.json`);
 
@@ -448,9 +612,25 @@ async function persistTaskSnapshot(workspaceRoot: string, task: TaskCard): Promi
 
   let wroteTemporary = false;
   try {
-    await writeFile(temporaryPath, `${JSON.stringify(snapshot, null, 2)}\n`, { flag: "wx" });
+    await writeFile(temporaryPath, snapshotText, { flag: "wx" });
     wroteTemporary = true;
+    if (!(await isSafeExistingDirectoryPath(taskDirectory))) {
+      throw workspaceError(
+        "task_lane_not_directory",
+        `Task lane is not a safe directory: ${task.task_id}`,
+        "A task snapshot lane is blocked by a non-directory filesystem entry.",
+        [`workspace/tasks/${task.task_id}`]
+      );
+    }
     await rename(temporaryPath, snapshotPath);
+    if (!(await isSafeExistingDirectoryPath(taskDirectory))) {
+      throw workspaceError(
+        "task_lane_not_directory",
+        `Task lane is not a safe directory: ${task.task_id}`,
+        "A task snapshot lane is blocked by a non-directory filesystem entry.",
+        [`workspace/tasks/${task.task_id}`]
+      );
+    }
     wroteTemporary = false;
   } catch (error) {
     throw workspaceError(
@@ -486,31 +666,32 @@ function createTaskSnapshot(task: TaskCard): TaskSnapshot & { task_card: TaskCar
 
 async function ensureTaskDirectory(workspaceRoot: string, taskId: string): Promise<string> {
   assertSafeTaskId(taskId, `task.task_id:${taskId}`);
-  await ensureSafeDirectory(workspaceRoot, "workspace_path_not_safe");
+  await ensureSafeDirectory(workspaceRoot, "workspace_path_not_safe", "workspace");
 
   const tasksRoot = join(workspaceRoot, "tasks");
   assertPathInsideWorkspace(workspaceRoot, tasksRoot, "workspace/tasks");
-  await ensureSafeDirectory(tasksRoot, "workspace_path_not_safe");
+  await ensureSafeDirectory(tasksRoot, "workspace_path_not_safe", "workspace/tasks");
 
   const taskDirectory = join(tasksRoot, taskId);
   assertPathInsideWorkspace(workspaceRoot, taskDirectory, `workspace/tasks/${taskId}`);
-  await ensureSafeDirectory(taskDirectory, "task_lane_not_directory");
+  await ensureSafeDirectory(taskDirectory, "task_lane_not_directory", `workspace/tasks/${taskId}`);
 
   return taskDirectory;
 }
 
 async function ensureSafeDirectory(
   path: string,
-  errorCode: Extract<TaskServiceErrorCode, "workspace_path_not_safe" | "task_lane_not_directory">
+  errorCode: Extract<TaskServiceErrorCode, "workspace_path_not_safe" | "task_lane_not_directory">,
+  evidenceRef: string
 ): Promise<void> {
   const existingEntry = await maybeLstat(path);
   if (existingEntry) {
     if (!(await isSafeExistingDirectoryPath(path))) {
       throw workspaceError(
         errorCode,
-        `Path is not a safe directory: ${path}`,
+        "Path is not a safe directory.",
         "A required workspace path is not a safe directory.",
-        [path]
+        [evidenceRef]
       );
     }
     return;
@@ -520,9 +701,9 @@ async function ensureSafeDirectory(
   if (parentPath === path || !(await isSafeExistingDirectoryPath(parentPath))) {
     throw workspaceError(
       errorCode,
-      `Parent path is not a safe directory: ${parentPath}`,
+      "Parent path is not a safe directory.",
       "A required workspace parent path is not a safe directory.",
-      [parentPath]
+      [`${evidenceRef}:parent`]
     );
   }
 
@@ -535,18 +716,18 @@ async function ensureSafeDirectory(
       }
       throw workspaceError(
         errorCode,
-        `Existing path is not a safe directory: ${path}`,
+        "Existing path is not a safe directory.",
         "A required workspace path is not a safe directory.",
-        [path],
+        [evidenceRef],
         error
       );
     }
 
     throw workspaceError(
       errorCode,
-      `Failed to create workspace directory: ${path}`,
+      "Failed to create workspace directory.",
       "A required workspace directory could not be created safely.",
-      [path],
+      [evidenceRef],
       error
     );
   }
@@ -554,9 +735,9 @@ async function ensureSafeDirectory(
   if (!(await isSafeExistingDirectoryPath(path))) {
     throw workspaceError(
       errorCode,
-      `Created path is not a safe directory: ${path}`,
+      "Created path is not a safe directory.",
       "A required workspace path is not a safe directory.",
-      [path]
+      [evidenceRef]
     );
   }
 }
@@ -635,7 +816,7 @@ function assertPathInsideWorkspace(
   );
 }
 
-function validateSnapshotTaskCardConsistency(snapshot: TaskSnapshot, snapshotPath: string): void {
+function validateSnapshotTaskCardConsistency(snapshot: TaskSnapshot, evidenceRef: string): void {
   const taskCard = snapshot.task_card;
   if (!taskCard) {
     return;
@@ -672,7 +853,7 @@ function validateSnapshotTaskCardConsistency(snapshot: TaskSnapshot, snapshotPat
       "task_snapshot_mismatch",
       "Task snapshot outer fields do not match nested task_card.",
       "A task snapshot is inconsistent and recovery has been stopped.",
-      [snapshotPath, ...mismatches.map((field) => `snapshot.${field}`)]
+      [evidenceRef, ...mismatches.map((field) => `snapshot.${field}`)]
     );
   }
 }
@@ -720,6 +901,15 @@ function workspaceError(
   }
 
   return error;
+}
+
+function taskSnapshotEvidenceRef(taskId: string): string {
+  return `workspace/tasks/${taskId}/snapshot.json`;
+}
+
+function taskLaneEvidenceRef(path: string): string {
+  const name = parse(path).base;
+  return isSafeTaskId(name) ? `workspace/tasks/${name}` : "workspace/tasks";
 }
 
 function hasErrorCode(error: unknown, code: string): boolean {


### PR DESCRIPTION
## Summary

Implements the M1 TaskCard API slice for #29:

- Adds a core TaskCard service for create/list/detail with schema validation and generated/default TaskCard fields.
- Adds `POST /api/tasks`, `GET /api/tasks`, `GET /api/tasks/:id`, and canonical `/api/*` 404 envelopes.
- Persists task snapshots at `workspace/tasks/<task_id>/snapshot.json` and hydrates list/detail state after service restart.
- Bounds snapshot recovery to workspace-local task lanes, rejects malformed or unsafe recovery state fail-closed, opens snapshots with no-follow semantics, bounds JSON bytes, and caps startup hydration fan-out.
- Updates the #29 OpenSpec fixture with the expanded/high risk contract and downstream boundary notes.

## Public Shape

- `POST /api/tasks` returns `201` with a `TaskCard` body.
- `GET /api/tasks/:id` returns `200` with the same stored `TaskCard` body.
- `GET /api/tasks` returns `200` with `{ "tasks": TaskCard[] }`.
- Canonical task API errors return `{ "error": { "error_id", "category", "severity", "message", "user_message", "evidence_refs", "retryable", "recommended_next_actions" } }`.

## Snapshot Shape

`workspace/tasks/<task_id>/snapshot.json` stores the M1 TaskSnapshot carrier:

- `task_id`
- `status`
- optional/nullable `runtime_phase`
- optional `stack_id`
- optional `data_id`
- `linked_jobs`
- `linked_runs`
- `linked_reports`
- `pending_pi_gates`
- `latest_seq: 0`
- `updated_at`
- nested full `task_card` for M1 restart recovery

## Scope Boundary

This PR intentionally does not implement:

- `Idempotency-Key`, request digest replay, LockRecord service, or Artifact registry (#30).
- Shared core path helper wiring (#33).
- Structured request logging (#31).
- PERF-API-001 smoke script (#32).
- Frontend Dashboard or Workbench navigation (#35).
- Full event bus/latest sequence critical section or task execution semantics.

## Verification

- `npx --yes bun@1.2.19 run test:backend-api`
- `npx --yes bun@1.2.19 run test:backend-ws`
- `npx --yes bun@1.2.19 run typecheck`
- `npx --yes bun@1.2.19 run check`
- `npx --yes bun@1.2.19 run schema:check`
- `npx --yes bun@1.2.19 run validate:dependency-lock`
- `openspec validate m1-foundation --strict --no-interactive`
- `git diff --check`
- `git -C zero diff --quiet`
- `test -z "$(git ls-files workspace)"`

## Agent Review

- Phase 4 round 1: 6-reviewer expanded/high cross-review raised 11 candidates; verifier marked all 11 CONFIRMED.
- Fix round: `be94064` closes confirmed findings with snapshot byte preflight, streaming hydration cap, logical evidence refs, retryable hydration, `latest_seq=0` recovery guard, safer snapshot leaf/lane checks, and expanded evidence tests.
- Phase 4 round 2: 6-reviewer follow-up raised 2 candidates; verifier marked both PLAUSIBLE, not CONFIRMED blockers.
- Residual `request-body-byte-cap`: realistic public large-body risk, but #29 fixture only clearly requires persisted snapshot/read bounds; record for later API resource-bound work.
- Residual `parent-lane-descriptor-bound`: realistic descriptor-bound TOCTOU residual; #29 keeps route-local checks and tests, while full shared path helper/directory-identity binding remains #33 scope.

Closes #29
