### PR TITLE
feat(api): add idempotency and artifact skeleton (#30)

### DIFF
--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -837,3 +837,93 @@ Review focus:
 - Error envelope tests assert the full canonical shape and no framework default error body leaks.
 - Snapshot persistence/recovery is bounded to configured workspace task lanes and does not silently accept malformed state.
 - Existing #28 routes remain reachable and unchanged; fallback ordering does not shadow real routes.
+
+## Subagent Workflow Fixture - Issue #30
+
+Fixture level: expanded; repair intensity: high
+Project profile: SHUD-Harness
+
+Expanded-trigger rationale:
+- Core triggers: public REST write endpoint, schema/field contract for IdempotencyRecord/LockRecord/Artifact, persisted workspace files, retry/concurrency/shared-state behavior, digest mismatch rollback, and artifact registry file output.
+- Profile triggers: `workspace`, `artifact`, `idempotency`, `lock`, and evidence-chain correctness.
+
+Change surface:
+- `packages/core/src/domain/services/**` idempotency, lock, and artifact registry services.
+- `packages/backend/src/routes/**` `POST /api/tasks` Idempotency-Key handling and 422 envelope mapping.
+- Backend/core tests proving idempotency replay, mismatch, registry lookup, lock storage, and existing #28/#29 compatibility.
+
+Must preserve:
+- #29 create/list/detail response shapes, snapshot path `workspace/tasks/<task_id>/snapshot.json`, restart recovery, bounded hydration, and full canonical error envelope.
+- Absence of `Idempotency-Key` keeps the #29 create behavior and writes no idempotency record.
+- `POST /api/tasks` remains a change-scoped validation carrier only; this issue must not edit canonical frozen docs or claim the endpoint is in the canonical §4 idempotency applicability list.
+- Runtime workspace assets remain untracked; `zero/` remains source-clean.
+- #33 still owns the shared path safety helper and symlink/traversal matrix; #30 keeps local deterministic workspace-file guards only for the new skeleton surfaces.
+
+Must add/change:
+- `POST /api/tasks` accepts optional `Idempotency-Key`. For this M1 slice only, the backend computes `scope="task"` and `request_digest = sha256(canonical JSON)` where canonical JSON uses sorted object keys over the validated create input, including the M1 defaulted `created_by` when omitted and all business fields.
+- Same `Idempotency-Key` + same digest replays the first completed TaskCard, returns the same object, and does not create an additional TaskCard snapshot.
+- Same `Idempotency-Key` + different digest returns 422 standard envelope with category/evidence that identify `idempotency key mismatch`, and it does not create a new TaskCard or overwrite the existing idempotency result.
+- IdempotencyRecord file skeleton persists completed task records at a deterministic workspace-local path such as `workspace/tasks/_idempotency/task/<sha256(key)>.json`; filenames must be derived from a digest or other safe segment, not the raw header.
+- LockRecord storage skeleton validates `LockRecordSchema`, persists a record under `workspace/locks/<scope>/<lock_id>.json`, and can read it back by id.
+- Artifact registry skeleton validates `ArtifactSchema`, verifies `type` against the existing enum, persists registry metadata under `workspace/artifacts/manifests/<artifact_id>.json`, and can read it back by id. The artifact payload file itself is not created in M1.
+
+Risk packs considered:
+- Public API / CLI / script entry: selected - `POST /api/tasks` write semantics change when `Idempotency-Key` is present.
+- Config / project setup: selected - all skeleton records are rooted in the configured workspace.
+- File IO / path safety / overwrite: selected - idempotency, lock, and artifact registry records are written/read under workspace paths with no raw-header path segments.
+- Schema / columns / units / field names: selected - IdempotencyRecord, LockRecord, Artifact, digest, and error envelope fields are structured contracts.
+- Auth / permissions / secrets: selected - the idempotency key is a caller-supplied token-like header and must not appear as a raw filename or leak absolute workspace paths in envelopes.
+- Concurrency / shared state / ordering: selected - concurrent same-key creates must converge on one completed result, and mismatch must not race into a second task.
+- Resource limits / large input / discovery: selected - digesting and record reads must use bounded already-accepted task request bodies and direct lookup paths, not broad directory scans.
+- Legacy compatibility / examples: selected - all #28/#29 backend API and WebSocket tests must stay green; canonical docs remain frozen.
+- Error handling / rollback / partial outputs: selected - invalid/mismatched/failed creates must not leave accepted task state or a poisoned completed idempotency record.
+- Release / packaging / dependency compatibility: selected - no new non-M1 runtime dependency; Bun workspace checks remain green.
+- Documentation / migration notes: selected - PR evidence states change-scoped carrier status and the canonical-list bug-fix follow-up remains out of scope.
+Domain packs:
+- Scientific governance / PI gate / evidence lineage: selected - Artifact metadata can become future evidence, but #30 must not implement M2 evidence_usable semantics or make scientific claims.
+- Hydrology runtime / SHUD-rSHUD-AutoSHUD compatibility: not selected - no solver/runtime behavior changes.
+- Zero adapter / tool registry / agent role governance: not selected - no Zero/tool governance changes.
+
+Invariant Matrix:
+- Governing invariant: For `POST /api/tasks`, each nonblank Idempotency-Key binds `scope=task` to exactly one canonical request digest and completed TaskCard result; replay returns that same result, mismatch fails with 422, and Artifact/Lock records remain schema-valid workspace-local files retrievable by id.
+- Source-of-truth identity/contract: `Idempotency-Key`, `scope=task`, canonical JSON digest, `IdempotencyRecord.result_ref` task id, TaskCard schema, API error envelope, Artifact/LockRecord schemas, configured workspace root, and deterministic record paths.
+- Producers: backend `POST /api/tasks`, idempotency service create/replay path, task service create path, artifact registry register path, and lock service store path.
+- Validators/preflight: request-body schema validation before digest acceptance, nonblank header validation, canonical JSON stable key sorting, digest comparison, schema validation before record writes, and safe filename derivation from digests/ids.
+- Storage/cache/query: workspace task snapshots plus idempotency records under task-scoped registry paths, lock records under `workspace/locks/`, and artifact metadata under `workspace/artifacts/manifests/`.
+- Public routes/entrypoints: `POST /api/tasks` only; artifact and lock services are core service skeletons with no public REST route in #30.
+- Frontend/downstream consumers: #35 Dashboard keeps using the #29 create/list shape; future retry/UI logic can rely on same-key replay and 422 mismatch.
+- Failure paths/rollback/stale state: missing/blank idempotency key, invalid request body, key digest mismatch, task persistence failure after key reservation, duplicate/concurrent same-key create, invalid artifact/lock schema, unsafe id/key path segment, and service re-instantiation over the same workspace.
+- Evidence/audit/readiness: core service tests, backend route tests, `test:backend-api`, backend/ws compatibility, schema tests/check, root check, OpenSpec validation, diff check, zero diff, and no tracked `workspace`.
+- Regression rows:
+  - Same key + same body, including reordered JSON keys -> first request returns 201 TaskCard, replay returns the same TaskCard, `GET /api/tasks` lists one task, and one completed IdempotencyRecord points at that task.
+  - Same key + request with omitted `created_by` followed by explicit `created_by="pi"` -> replay returns the first TaskCard because the digest includes the defaulted actor value; same key + different `created_by` -> 422 and no new task.
+  - Same key + changed business field -> 422 envelope with all canonical fields and idempotency evidence refs; no second task snapshot or completed result is created.
+  - Absent key -> existing #29 create/list/detail/snapshot behavior, with no idempotency record.
+  - Concurrent same-key same-body requests -> exactly one TaskCard/result_ref wins and every successful replay returns that same object; no duplicate task snapshots.
+  - Task persistence failure after an idempotency attempt -> no completed result is recorded; after workspace repair the same key/body can create one task.
+  - Valid Artifact record -> `registerArtifact` returns schema-valid metadata, `getArtifact(id)` returns the same record, and metadata exists under `workspace/artifacts/manifests/`; invalid type/id/path is rejected without a registry file.
+  - Valid LockRecord -> store/read returns the same schema-valid record under `workspace/locks/<scope>/`; invalid lock schema is rejected without a lock file.
+  - Existing #28/#29 health, workspace init, task recovery, unknown-route, WebSocket, and schema tests remain green.
+
+Boundary-surface checklist:
+- Public entrypoints: `POST /api/tasks`; no artifact/lock REST endpoint in #30.
+- Read surfaces: request JSON body, `Idempotency-Key` header, direct idempotency/lock/artifact record files.
+- Write/delete/overwrite surfaces: idempotency record create/complete update for the current key, lock record store, artifact metadata store, and existing task snapshot create; no delete behavior.
+- Producer/consumer evidence boundaries: request body -> canonical digest -> IdempotencyRecord -> TaskCard snapshot/result_ref -> replayed response; Artifact metadata -> future evidence registry consumers.
+- Stale-state/idempotency boundaries: process-local concurrency plus file-level record replay after service re-instantiation; full cross-process distributed locking is out of scope.
+- Unchanged downstream consumers: #28 workspace/health routes, #29 task list/detail/snapshot recovery, backend WS tool.failed tests, future #31 logs, #33 path helper, and #35 Dashboard.
+
+Required evidence:
+- Backend route tests for same key/same digest replay, key-order-independent digesting, same key/different digest 422 envelope, absent-key compatibility, concurrent same-key create, and failed-create retry without poisoned completed record.
+- Core service tests for IdempotencyRecord read/write/replay lookup, LockRecord store/read schema validation, Artifact registry register/get schema validation, safe deterministic record filenames, invalid record rejection, and direct lookup without broad workspace scans.
+- Compatibility and gate commands: `bun run test:backend-api`; `bun run test:backend-ws`; `bun run test:schemas`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
+
+Non-goals:
+- Expanding the canonical idempotency applicability list in frozen specs; the proposal Impact follow-up remains a separate bug-fix ledger item.
+- Full Artifact manifest semantics, `evidence_usable` upgrade rules, artifact payload serving/download APIs, report evidence lineage, cross-process lock leases/heartbeats, PI gate decisions, structured request logs (#31), path safety helper wiring and symlink/traversal matrix (#33), frontend retry UI (#35), and scientific conclusions.
+
+Review focus:
+- Digest canonicalization is deterministic, includes all validated business fields, and cannot be bypassed by JSON key order or omitted default `created_by`.
+- Idempotency mismatch and failed create paths do not create duplicate TaskCards or poisoned completed records.
+- Workspace record paths use safe derived segments and API error JSON never exposes raw caller headers or absolute workspace paths.
+- Artifact/Lock services stay skeleton-sized but schema-valid, workspace-local, directly queryable, and compatible with later #33 path helper wiring.

--- a/openspec/changes/m1-foundation/specs/task-api/spec.md
+++ b/openspec/changes/m1-foundation/specs/task-api/spec.md
@@ -38,7 +38,7 @@ Hono 后端骨架：workspace init、TaskCard 最小链路、错误 envelope、�
 
 ### Requirement: 幂等与锁 service skeleton
 
-写端点 SHALL 接受 `Idempotency-Key` 头；`packages/core` SHALL 提供 IdempotencyRecord / LockRecord 的存取 service skeleton（文件级实现即可，契约遵 Idempotency_Concurrency_Locking_Spec §2/§3——IdempotencyRecord 含 `request_digest`，key mismatch 按 API_Error_And_Idempotency_Contracts §2 映射 422）。
+M1 变更范围内，`POST /api/tasks` SHALL 接受可选 `Idempotency-Key` 头作为 skeleton 验证载体；`packages/core` SHALL 提供 IdempotencyRecord / LockRecord 的存取 service skeleton（文件级实现即可，契约遵 Idempotency_Concurrency_Locking_Spec §2/§3——IdempotencyRecord 含 `request_digest`，key mismatch 按 API_Error_And_Idempotency_Contracts §2 映射 422）。
 
 M1 以 `POST /api/tasks` 作为 skeleton 的验证载体，属 change-scoped 约定：该端点不在 Idempotency_Concurrency_Locking_Spec §4「必须幂等的操作」表与 API_Error_And_Idempotency_Contracts §3 适用清单内，本 requirement 不以验收断言扩张 canonical 契约——纳入 canonical 适用清单按账本冻结规则以 spec bug 修正单独记录（待办见 proposal Impact）。change-scoped key/digest 配方：`Idempotency-Key` 由客户端提供，`scope=task`（IdempotencyRecord scope 枚举既有值），`request_digest` = 规范化 JSON 请求体（键排序；至少覆盖 title、created_by 与全部业务字段）的 sha256。
 

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -133,6 +133,42 @@
       - #29 does not implement Idempotency-Key handling, shared path helper, structured request logging, PERF-API-001, frontend Dashboard, or Workbench task navigation.
       - `bun run test:backend-api`; `bun run test:backend-ws`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 - [ ] 6.3 幂等/锁 service skeleton（相同 Idempotency-Key + 相同 request_digest 重放返回同一对象；相同 key + 不同 digest → 422 标准 envelope；M1 验证载体 = `POST /api/tasks`，key/digest 配方为 change-scoped，见 task-api spec 与 proposal Impact 账本待办）+ Artifact registry skeleton（注册/按 id 查询/落盘）——依赖: 4.1（IdempotencyRecord/LockRecord schema）
+  - Fixture (#30): expanded / high
+    - Change surface: `packages/core/src/domain/services/**` idempotency/lock/artifact registry services; `packages/backend/src/routes/**` `POST /api/tasks` Idempotency-Key handling; backend/core tests.
+    - Must preserve: #28 workspace/health behavior, #29 task create/list/detail/snapshot/recovery shapes, unknown-route envelope, backend WS tests, frozen canonical docs, untracked `workspace/`, and `zero/` source diff=0.
+    - Must add/change: optional `Idempotency-Key` on `POST /api/tasks`; `scope=task`; `request_digest = sha256(canonical JSON)` over sorted validated create input including defaulted `created_by`; same key+digest replay returns the first TaskCard; same key+different digest returns 422 canonical envelope; core IdempotencyRecord/LockRecord file services; Artifact registry register/get file skeleton.
+    - Risk packs considered:
+      - Public API / CLI / script entry: selected - `POST /api/tasks` write behavior changes when `Idempotency-Key` is present.
+      - Config / project setup: selected - records are rooted in configured workspace.
+      - File IO / path safety / overwrite: selected - idempotency, lock, and artifact metadata files are written/read under workspace paths.
+      - Schema / columns / units / field names: selected - IdempotencyRecord, LockRecord, Artifact, digest, and error envelope fields are structured contracts.
+      - Auth / permissions / secrets: selected - caller-provided key must not become a raw filename or leak as an unsafe path/evidence value.
+      - Concurrency / shared state / ordering: selected - concurrent same-key creates must converge on one completed TaskCard result.
+      - Resource limits / large input / discovery: selected - digesting uses the bounded accepted request body and direct lookup paths; no broad scans.
+      - Legacy compatibility / examples: selected - #28/#29 route contracts and generated schema checks remain compatible.
+      - Error handling / rollback / partial outputs: selected - mismatch/invalid/failed create paths leave no duplicate accepted task or poisoned completed record.
+      - Release / packaging / dependency compatibility: selected - no non-M1 runtime dependency.
+      - Documentation / migration notes: selected - PR evidence states `POST /api/tasks` remains change-scoped, not canonical §4.
+      - Scientific governance / PI gate / evidence lineage: selected - Artifact metadata is future evidence plumbing; no M2 evidence_usable semantics or scientific claims.
+      - Hydrology runtime / SHUD-rSHUD-AutoSHUD compatibility: not selected - no solver/runtime behavior changes.
+      - Zero adapter / tool registry / agent role governance: not selected - no Zero/tool governance changes.
+    - Invariant Matrix:
+      - Governing invariant: a nonblank Idempotency-Key on `POST /api/tasks` binds `scope=task` to one canonical request digest and one completed TaskCard result; replay returns that result, mismatch fails with 422, and Artifact/Lock records remain schema-valid workspace-local files retrievable by id.
+      - Source-of-truth identity/contract: `Idempotency-Key`, `scope=task`, canonical JSON digest, IdempotencyRecord.result_ref, TaskCard schema, API error envelope, Artifact/LockRecord schemas, configured workspace root, and deterministic record paths.
+      - Producers: backend `POST /api/tasks`, idempotency service, task service, artifact registry service, lock service.
+      - Validators/preflight: create-body schema validation, nonblank header validation, sorted canonical JSON digest, digest comparison, schema validation before record writes, safe derived filename/id segments.
+      - Storage/cache/query: task snapshots, idempotency records, lock records, and artifact metadata under configured workspace paths.
+      - Public routes/entrypoints: `POST /api/tasks`; no artifact/lock REST route in #30.
+      - Frontend/downstream consumers: #35 Dashboard keeps the #29 create/list shape; future retry UI consumes replay/422 semantics.
+      - Failure paths/stale state: missing/blank key, invalid body, digest mismatch, task persistence failure after key reservation, concurrent duplicate same-key create, invalid artifact/lock record, service re-instantiation.
+      - Evidence/readiness: backend route tests, core service tests, schema tests, root checks, OpenSpec validation, diff check, zero diff, no tracked workspace assets.
+    - Evidence floor (#30):
+      - Backend route tests cover same key + same body replay, reordered JSON key digest stability, omitted `created_by` followed by explicit `created_by="pi"` replaying the same TaskCard, same key + changed `created_by` returning 422, same key + different body 422 envelope, absent-key #29 compatibility with no idempotency record, concurrent same-key create producing one TaskCard/result_ref, and failed-create retry without a completed poisoned IdempotencyRecord.
+      - 422 tests assert every canonical envelope field under `error`: `error_id`, `category`, `severity`, `message`, `user_message`, `evidence_refs`, `retryable`, `recommended_next_actions`; error JSON must not expose the raw `Idempotency-Key` value or absolute workspace paths.
+      - Core service tests cover IdempotencyRecord store/get/replay lookup, LockRecord store/get, Artifact register/get, schema-invalid rejection without files, safe deterministic filenames that do not use raw `Idempotency-Key`, and direct lookup paths rather than broad workspace scans.
+      - Artifact registry test uses a valid Artifact type from `Artifact_Registry_Spec`, returns the same record by id, and persists metadata under `workspace/artifacts/manifests/`; M1 does not create/serve the payload file or implement full manifest/evidence_usable semantics.
+      - PR evidence states the `POST /api/tasks` idempotency carrier is change-scoped only and does not modify canonical frozen spec applicability lists.
+      - `bun run test:backend-api`; `bun run test:backend-ws`; `bun run test:schemas`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 - [ ] 6.4 结构化 NDJSON API 请求日志中间件（OBS-LOG-001 八字段：ts/level/service/event/request_id/route/status/duration_ms；secret 仅以 ref/[REDACTED] 形式出现，OBS-LOG-002）
 - [ ] 6.5 PERF-API-001 冒烟脚本 `bun run test:perf:api`（fixture = mock workspace + 100 tasks；GET /api/tasks、GET /api/tasks/:id、health ready P95 ≤ 300ms）+ 接入 1.2 的 PR CI——依赖: 1.2
 - [ ] 6.6 路径安全 helper（packages/core 共享 service，遵 Workspace_Conventions §9：resolve 规范化 → workspace 边界校验 → 拒 symlink escape → 记录规范化路径）+ Artifact registry 落盘与 task snapshot 写入两处接线 + 正负例单测（`../` 穿越拒绝、symlink escape 拒绝、合法路径规范化记录；承接 Test_Plan W1 Unit「path normalization」）——依赖: 6.2、6.3（两处落盘写入面在位）

--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
     "test:backend-api": "bun test ./packages/backend/src/routes/*.test.ts",
     "test:backend-ws": "bun test ./packages/backend/src/ws/index.test.ts",
     "test:schemas": "bun test ./packages/core/src/domain/schemas/core-schemas.test.ts",
+    "test:core-services": "bun test ./packages/core/src/domain/services/*.test.ts",
     "schema:generate": "bun scripts/schema/generate.ts",
     "test:schema-generation": "bun scripts/schema/generate.ts --self-test",
     "schema:check": "sh scripts/schema/check.sh",
     "validate:dependency-lock": "node scripts/dependency-lock/validate.mjs",
     "test:dependency-lock": "sh scripts/dependency-lock/self_test.sh",
-    "check": "bun run typecheck && bun run test:policy-gate && bun run test:tool-registry-governance && bun run test:backend-api && bun run test:backend-ws && bun run test:schemas"
+    "check": "bun run typecheck && bun run test:policy-gate && bun run test:tool-registry-governance && bun run test:backend-api && bun run test:backend-ws && bun run test:schemas && bun run test:core-services"
   },
   "devDependencies": {
     "typescript": "5.8.3"

--- a/packages/backend/src/routes/index.test.ts
+++ b/packages/backend/src/routes/index.test.ts
@@ -767,6 +767,71 @@ describe("backend workspace and health routes", () => {
     await expectPathMissing(join(workspaceRoot, "tasks", "TASK-local-unbound", "snapshot.json"));
   });
 
+  test("POST /api/tasks rolls back the local task when authoritative convergence is not request-bound", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:completion-converges-unbound";
+    const taskBody = validTaskCreateBody();
+    const foreignTaskBody = validTaskCreateBody({
+      title: "Foreign authoritative task",
+      question_or_goal: "This task should not satisfy the original request digest"
+    });
+    const requestDigest = sha256Hex(
+      canonicalJson({
+        ...taskBody,
+        created_by: taskBody.created_by ?? DEFAULT_TASK_CREATED_BY
+      })
+    );
+    const foreignTask = await createTaskCardService({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:31.450Z"),
+      taskIdFactory: () => "TASK-foreign-unbound-convergence"
+    }).createTask(foreignTaskBody);
+    let hookCompletions = 0;
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:31.475Z"),
+      taskIdFactory: () => "TASK-local-unbound-convergence",
+      taskSnapshotWriteHooks: {
+        afterSnapshotWrite: async () => {
+          if (hookCompletions > 0) {
+            return;
+          }
+          hookCompletions += 1;
+          await createIdempotencyRecordService({ workspaceRoot }).completeRecord({
+            scope: "task",
+            key: idempotencyKey,
+            requestDigest,
+            resultRef: foreignTask.task_id
+          });
+        }
+      }
+    });
+
+    const response = await postTask(app, taskBody, { "Idempotency-Key": idempotencyKey });
+    const body = (await response.json()) as ApiErrorResponse;
+    const listResponse = await app.request("/api/tasks");
+    const localDetailResponse = await app.request("/api/tasks/TASK-local-unbound-convergence");
+    const localDetailBody = (await localDetailResponse.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(500);
+    expectCanonicalError(body, "workspace_error");
+    expect(body.error.evidence_refs).toEqual([
+      "workspace/tasks/_idempotency/task",
+      "idempotency.result_ref"
+    ]);
+    expectNoAbsoluteWorkspacePath(body, tempRoot, workspaceRoot);
+    expect(hookCompletions).toBe(1);
+    expect(listResponse.status).toBe(200);
+    expect(await listResponse.json()).toEqual({ tasks: [foreignTask] });
+    expect(localDetailResponse.status).toBe(404);
+    expectCanonicalError(localDetailBody, "not_found");
+    expect(await taskIdsWithSnapshots(workspaceRoot)).toEqual([foreignTask.task_id]);
+    await expectPathMissing(
+      join(workspaceRoot, "tasks", "TASK-local-unbound-convergence", "snapshot.json")
+    );
+  });
+
   test("POST /api/tasks evicts local cache when authoritative convergence finds the local snapshot missing", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -1102,7 +1167,7 @@ describe("backend workspace and health routes", () => {
     const recordAfterReplay = await idempotencyService.getRecord("task", idempotencyKey);
 
     expect(seededBegin.status).toBe("acquired");
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(409);
     expectCanonicalError(body, "workspace_error");
     expect(body.error.message).toBe("Idempotency record did not complete before replay timeout.");
     expect(body.error.retryable).toBe(true);
@@ -1492,6 +1557,49 @@ describe("backend workspace and health routes", () => {
     expect(await freshListResponse.json()).toEqual({ tasks: [retryTask] });
   });
 
+  test("POST /api/tasks does not follow a swapped task lane symlink during failed snapshot cleanup", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:after-snapshot-hook-swaps-lane";
+    const outsideLane = join(tempRoot, "outside-lane");
+    const outsideSnapshot = join(outsideLane, "snapshot.json");
+    const outsideSnapshotText = "outside snapshot must survive\n";
+    let swappedLane = false;
+    await mkdir(outsideLane, { recursive: true });
+    await writeFile(outsideSnapshot, outsideSnapshotText, { flag: "wx" });
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:57.610Z"),
+      taskIdFactory: () => "TASK-hook-swaps-lane",
+      taskSnapshotWriteHooks: {
+        afterSnapshotWrite: async ({ taskDirectory }) => {
+          if (swappedLane) {
+            return;
+          }
+          swappedLane = true;
+          await rm(taskDirectory, { recursive: true, force: true });
+          await symlink(outsideLane, taskDirectory);
+          throw new Error("after snapshot publish lane swap");
+        }
+      }
+    });
+
+    const failedResponse = await postTask(app, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const failedBody = (await failedResponse.json()) as ApiErrorResponse;
+    const idempotencyService = createIdempotencyRecordService({ workspaceRoot });
+    const recordAfterFailure = await idempotencyService.getRecord("task", idempotencyKey);
+
+    expect(failedResponse.status).toBe(500);
+    expectCanonicalError(failedBody, "workspace_error");
+    expectNoAbsoluteWorkspacePath(failedBody, tempRoot, workspaceRoot);
+    expect(swappedLane).toBe(true);
+    expect(recordAfterFailure?.status).toBe("failed");
+    expect(recordAfterFailure?.result_ref).toBeUndefined();
+    expect(await readFile(outsideSnapshot, "utf8")).toBe(outsideSnapshotText);
+  });
+
   test("POST /api/tasks rolls back snapshot when idempotency completion fails", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -1693,7 +1801,7 @@ describe("backend workspace and health routes", () => {
     expectNoAbsoluteWorkspacePath(failedBody, tempRoot, workspaceRoot);
     expect(recordAfterFailure?.status).toBe("started");
     expect(recordAfterFailure?.result_ref).toBeUndefined();
-    expect(retryResponse.status).toBe(500);
+    expect(retryResponse.status).toBe(409);
     expectCanonicalError(retryBody, "workspace_error");
     expectNoAbsoluteWorkspacePath(retryBody, tempRoot, workspaceRoot);
     expect(recordAfterRetry?.status).toBe("started");

--- a/packages/backend/src/routes/index.test.ts
+++ b/packages/backend/src/routes/index.test.ts
@@ -23,6 +23,7 @@ import {
   canonicalJson,
   createIdempotencyRecordService,
   createTaskCardService,
+  idempotencyRecordEvidenceRef,
   idempotencyRecordFileName,
   sha256Hex,
   type CreateTaskInput,
@@ -654,6 +655,74 @@ describe("backend workspace and health routes", () => {
     expect(await taskIdsWithSnapshots(workspaceRoot)).toEqual([firstTask.task_id]);
     expect(await staleApp.request("/api/tasks").then((response) => response.json())).toEqual({
       tasks: [firstTask]
+    });
+  });
+
+  test("POST /api/tasks fails closed when idempotency record key does not match the lookup path", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:path-key-a";
+    const storedKey = "task:create:path-key-b-secret";
+    const taskBody = validTaskCreateBody();
+    const requestDigest = sha256Hex(
+      canonicalJson({
+        ...taskBody,
+        created_by: taskBody.created_by ?? DEFAULT_TASK_CREATED_BY
+      })
+    );
+    const existingTask = await createTaskCardService({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:31.500Z"),
+      taskIdFactory: () => "TASK-poisoned-idempotency-result"
+    }).createTask(taskBody);
+    const idempotencyDirectory = join(workspaceRoot, "tasks", "_idempotency", "task");
+    const recordPath = join(idempotencyDirectory, idempotencyRecordFileName(idempotencyKey));
+    let taskIdFactoryCalls = 0;
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:31.750Z"),
+      taskIdFactory: () => {
+        taskIdFactoryCalls += 1;
+        return "TASK-duplicate-should-not-create";
+      }
+    });
+
+    await mkdir(idempotencyDirectory, { recursive: true });
+    await writeFile(
+      recordPath,
+      `${JSON.stringify({
+        key: storedKey,
+        scope: "task",
+        request_digest: requestDigest,
+        status: "completed",
+        result_ref: existingTask.task_id,
+        created_at: "2026-07-07T12:03:31.750Z",
+        updated_at: "2026-07-07T12:03:31.750Z"
+      })}\n`,
+      { flag: "wx" }
+    );
+
+    const response = await postTask(app, taskBody, { "Idempotency-Key": idempotencyKey });
+    const body = (await response.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(500);
+    expectCanonicalError(body, "workspace_error");
+    expect(body.error.message).toBe(
+      "Idempotency record identity does not match its lookup path."
+    );
+    expect(body.error.evidence_refs).toEqual([
+      idempotencyRecordEvidenceRef("task", idempotencyKey),
+      "idempotency.key",
+      "idempotency.scope"
+    ]);
+    expect(JSON.stringify(body)).not.toContain(idempotencyKey);
+    expect(JSON.stringify(body)).not.toContain(storedKey);
+    expect(JSON.stringify(body)).not.toContain(existingTask.task_id);
+    expectNoAbsoluteWorkspacePath(body, tempRoot, workspaceRoot);
+    expect(taskIdFactoryCalls).toBe(0);
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([existingTask.task_id]);
+    expect(await app.request("/api/tasks").then((listResponse) => listResponse.json())).toEqual({
+      tasks: [existingTask]
     });
   });
 

--- a/packages/backend/src/routes/index.test.ts
+++ b/packages/backend/src/routes/index.test.ts
@@ -711,6 +711,132 @@ describe("backend workspace and health routes", () => {
     ]);
   });
 
+  test("POST /api/tasks treats completeRecord convergence as authoritative and rolls back the local task", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:completion-converges-authoritative";
+    const taskBody = validTaskCreateBody();
+    const requestDigest = sha256Hex(
+      canonicalJson({
+        ...taskBody,
+        created_by: taskBody.created_by ?? DEFAULT_TASK_CREATED_BY
+      })
+    );
+    const authoritativeTask = await createTaskCardService({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:31.300Z"),
+      taskIdFactory: () => "TASK-authoritative-completed"
+    }).createTask(taskBody);
+    let hookCompletions = 0;
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:31.400Z"),
+      taskIdFactory: () => "TASK-local-unbound",
+      taskSnapshotWriteHooks: {
+        afterSnapshotWrite: async () => {
+          if (hookCompletions > 0) {
+            return;
+          }
+          hookCompletions += 1;
+          await createIdempotencyRecordService({ workspaceRoot }).completeRecord({
+            scope: "task",
+            key: idempotencyKey,
+            requestDigest,
+            resultRef: authoritativeTask.task_id
+          });
+        }
+      }
+    });
+
+    const firstResponse = await postTask(app, taskBody, { "Idempotency-Key": idempotencyKey });
+    const replayResponse = await postTask(app, taskBody, { "Idempotency-Key": idempotencyKey });
+    const firstTask = (await firstResponse.json()) as TaskCard;
+    const replayTask = (await replayResponse.json()) as TaskCard;
+    const idempotencyRecord = await createIdempotencyRecordService({ workspaceRoot }).getRecord(
+      "task",
+      idempotencyKey
+    );
+
+    expect(firstResponse.status).toBe(200);
+    expect(replayResponse.status).toBe(200);
+    expect(firstTask).toEqual(authoritativeTask);
+    expect(replayTask).toEqual(authoritativeTask);
+    expect(hookCompletions).toBe(1);
+    expect(idempotencyRecord?.result_ref).toBe(authoritativeTask.task_id);
+    expect(await taskIdsWithSnapshots(workspaceRoot)).toEqual([authoritativeTask.task_id]);
+    await expectPathMissing(join(workspaceRoot, "tasks", "TASK-local-unbound", "snapshot.json"));
+  });
+
+  test("POST /api/tasks evicts local cache when authoritative convergence finds the local snapshot missing", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:completion-converges-rollback-fails";
+    const taskBody = validTaskCreateBody();
+    const requestDigest = sha256Hex(
+      canonicalJson({
+        ...taskBody,
+        created_by: taskBody.created_by ?? DEFAULT_TASK_CREATED_BY
+      })
+    );
+    const authoritativeTask = await createTaskCardService({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:31.500Z"),
+      taskIdFactory: () => "TASK-authoritative-rollback-failure"
+    }).createTask(taskBody);
+    let hookCompletions = 0;
+    let removedDuringRollback = false;
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:31.600Z"),
+      taskIdFactory: () => "TASK-local-rollback-failure",
+      taskSnapshotReadHooks: {
+        beforeSnapshotOpen: async ({ snapshotPath: candidatePath, laneTaskId }) => {
+          if (laneTaskId !== "TASK-local-rollback-failure" || removedDuringRollback) {
+            return;
+          }
+          removedDuringRollback = true;
+          await rm(candidatePath);
+        }
+      },
+      taskSnapshotWriteHooks: {
+        afterSnapshotWrite: async () => {
+          if (hookCompletions > 0) {
+            return;
+          }
+          hookCompletions += 1;
+          await createIdempotencyRecordService({ workspaceRoot }).completeRecord({
+            scope: "task",
+            key: idempotencyKey,
+            requestDigest,
+            resultRef: authoritativeTask.task_id
+          });
+        }
+      }
+    });
+
+    const response = await postTask(app, taskBody, { "Idempotency-Key": idempotencyKey });
+    const task = (await response.json()) as TaskCard;
+    const idempotencyRecord = await createIdempotencyRecordService({ workspaceRoot }).getRecord(
+      "task",
+      idempotencyKey
+    );
+    const listResponse = await app.request("/api/tasks");
+    const localDetailResponse = await app.request("/api/tasks/TASK-local-rollback-failure");
+    const localDetailBody = (await localDetailResponse.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(200);
+    expect(task).toEqual(authoritativeTask);
+    expect(hookCompletions).toBe(1);
+    expect(removedDuringRollback).toBe(true);
+    expect(idempotencyRecord?.status).toBe("completed");
+    expect(idempotencyRecord?.result_ref).toBe(authoritativeTask.task_id);
+    expect(listResponse.status).toBe(200);
+    expect(await listResponse.json()).toEqual({ tasks: [authoritativeTask] });
+    expect(localDetailResponse.status).toBe(404);
+    expectCanonicalError(localDetailBody, "not_found");
+    expect(await taskIdsWithSnapshots(workspaceRoot)).toEqual([authoritativeTask.task_id]);
+  });
+
   test("POST /api/tasks fails closed when idempotency record key does not match the lookup path", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -830,6 +956,112 @@ describe("backend workspace and health routes", () => {
     expectNoAbsoluteWorkspacePath(body, tempRoot, workspaceRoot);
     expect(taskIdFactoryCalls).toBe(0);
     await expectPathMissing(join(workspaceRoot, "tasks", "TASK-unsafe-result-ref-duplicate"));
+  });
+
+  test("POST /api/tasks fails closed when completed idempotency result_ref points to a foreign task", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:foreign-result-ref";
+    const taskBody = validTaskCreateBody({ title: "Expected request task" });
+    const foreignTask = await createTaskCardService({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:31.900Z"),
+      taskIdFactory: () => "TASK-foreign-secret-result"
+    }).createTask(validTaskCreateBody({ title: "Foreign task must not replay" }));
+    const requestDigest = sha256Hex(
+      canonicalJson({
+        ...taskBody,
+        created_by: taskBody.created_by ?? DEFAULT_TASK_CREATED_BY
+      })
+    );
+    const idempotencyService = createIdempotencyRecordService({ workspaceRoot });
+    await idempotencyService.beginRecord({
+      scope: "task",
+      key: idempotencyKey,
+      requestDigest
+    });
+    await idempotencyService.completeRecord({
+      scope: "task",
+      key: idempotencyKey,
+      requestDigest,
+      resultRef: foreignTask.task_id
+    });
+    let taskIdFactoryCalls = 0;
+    const app = createBackendApi({
+      workspaceRoot,
+      taskIdFactory: () => {
+        taskIdFactoryCalls += 1;
+        return "TASK-foreign-result-duplicate";
+      }
+    });
+
+    const response = await postTask(app, taskBody, { "Idempotency-Key": idempotencyKey });
+    const body = (await response.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(500);
+    expectCanonicalError(body, "workspace_error");
+    expect(body.error.message).toBe(
+      "Completed idempotency result is not bound to the task create request."
+    );
+    expect(body.error.evidence_refs).toEqual([
+      "workspace/tasks/_idempotency/task",
+      "idempotency.result_ref"
+    ]);
+    expect(JSON.stringify(body)).not.toContain(idempotencyKey);
+    expect(JSON.stringify(body)).not.toContain(foreignTask.task_id);
+    expect(JSON.stringify(body)).not.toContain("Foreign task must not replay");
+    expectNoAbsoluteWorkspacePath(body, tempRoot, workspaceRoot);
+    expect(taskIdFactoryCalls).toBe(0);
+    expect(await taskIdsWithSnapshots(workspaceRoot)).toEqual([foreignTask.task_id]);
+  });
+
+  test("POST /api/tasks fails closed when completed idempotency result_ref points to a missing task", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:missing-result-ref";
+    const missingResultRef = "TASK-missing-secret-result";
+    const taskBody = validTaskCreateBody();
+    const requestDigest = sha256Hex(
+      canonicalJson({
+        ...taskBody,
+        created_by: taskBody.created_by ?? DEFAULT_TASK_CREATED_BY
+      })
+    );
+    const idempotencyService = createIdempotencyRecordService({ workspaceRoot });
+    await idempotencyService.beginRecord({
+      scope: "task",
+      key: idempotencyKey,
+      requestDigest
+    });
+    await idempotencyService.completeRecord({
+      scope: "task",
+      key: idempotencyKey,
+      requestDigest,
+      resultRef: missingResultRef
+    });
+    let taskIdFactoryCalls = 0;
+    const app = createBackendApi({
+      workspaceRoot,
+      taskIdFactory: () => {
+        taskIdFactoryCalls += 1;
+        return "TASK-missing-result-duplicate";
+      }
+    });
+
+    const response = await postTask(app, taskBody, { "Idempotency-Key": idempotencyKey });
+    const body = (await response.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(500);
+    expectCanonicalError(body, "workspace_error");
+    expect(body.error.evidence_refs).toEqual([
+      "workspace/tasks/_idempotency/task",
+      "idempotency.result_ref"
+    ]);
+    expect(JSON.stringify(body)).not.toContain(idempotencyKey);
+    expect(JSON.stringify(body)).not.toContain(missingResultRef);
+    expectNoAbsoluteWorkspacePath(body, tempRoot, workspaceRoot);
+    expect(taskIdFactoryCalls).toBe(0);
+    expect(await taskIdsWithSnapshots(workspaceRoot)).toEqual([]);
   });
 
   test("POST /api/tasks times out a stale started same-digest idempotency claim without creating a task", async () => {
@@ -1209,6 +1441,57 @@ describe("backend workspace and health routes", () => {
     });
   });
 
+  test("POST /api/tasks cleans a published snapshot when afterSnapshotWrite throws before retry", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:after-snapshot-hook-throws";
+    const taskIds = ["TASK-hook-throws-orphan", "TASK-hook-throws-retry"];
+    let shouldThrowAfterPublish = true;
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:57.600Z"),
+      taskIdFactory: () => taskIds.shift() ?? "TASK-unexpected-hook-throws-extra",
+      taskSnapshotWriteHooks: {
+        afterSnapshotWrite: () => {
+          if (!shouldThrowAfterPublish) {
+            return;
+          }
+          shouldThrowAfterPublish = false;
+          throw new Error("after snapshot publish failure");
+        }
+      }
+    });
+
+    const failedResponse = await postTask(app, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const failedBody = (await failedResponse.json()) as ApiErrorResponse;
+    const idempotencyService = createIdempotencyRecordService({ workspaceRoot });
+    const recordAfterFailure = await idempotencyService.getRecord("task", idempotencyKey);
+
+    expect(failedResponse.status).toBe(500);
+    expectCanonicalError(failedBody, "workspace_error");
+    expectNoAbsoluteWorkspacePath(failedBody, tempRoot, workspaceRoot);
+    expect(recordAfterFailure?.status).toBe("failed");
+    expect(recordAfterFailure?.result_ref).toBeUndefined();
+    expect(await taskIdsWithSnapshots(workspaceRoot)).toEqual([]);
+    await expectPathMissing(join(workspaceRoot, "tasks", "TASK-hook-throws-orphan", "snapshot.json"));
+
+    const retryResponse = await postTask(app, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const retryTask = (await retryResponse.json()) as TaskCard;
+    const freshApp = createBackendApi({ workspaceRoot });
+    const freshListResponse = await freshApp.request("/api/tasks");
+
+    expect(retryResponse.status).toBe(201);
+    expect(retryTask.task_id).toBe("TASK-hook-throws-retry");
+    expect(taskIds).toEqual([]);
+    expect(await taskIdsWithSnapshots(workspaceRoot)).toEqual([retryTask.task_id]);
+    expect(freshListResponse.status).toBe(200);
+    expect(await freshListResponse.json()).toEqual({ tasks: [retryTask] });
+  });
+
   test("POST /api/tasks rolls back snapshot when idempotency completion fails", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -1345,7 +1628,7 @@ describe("backend workspace and health routes", () => {
     expect(idempotencyFiles).toEqual([idempotencyRecordFileName(idempotencyKey)]);
   });
 
-  test("POST /api/tasks binds idempotency result when completion and rollback both fail", async () => {
+  test("POST /api/tasks quarantines idempotency state when completion and rollback cannot prove the snapshot", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
     const idempotencyKey = "task:create:rollback-failure-bound";
@@ -1403,17 +1686,20 @@ describe("backend workspace and health routes", () => {
     const recordAfterFailure = await idempotencyService.getRecord("task", idempotencyKey);
     const retryResponse = await postTask(app, taskBody, { "Idempotency-Key": idempotencyKey });
     const retryBody = (await retryResponse.json()) as ApiErrorResponse;
+    const recordAfterRetry = await idempotencyService.getRecord("task", idempotencyKey);
 
     expect(failedResponse.status).toBe(500);
     expectCanonicalError(failedBody, "workspace_error");
     expectNoAbsoluteWorkspacePath(failedBody, tempRoot, workspaceRoot);
-    expect(recordAfterFailure?.status).toBe("completed");
-    expect(recordAfterFailure?.result_ref).toBe("TASK-rollback-failure-original");
+    expect(recordAfterFailure?.status).toBe("started");
+    expect(recordAfterFailure?.result_ref).toBeUndefined();
     expect(retryResponse.status).toBe(500);
     expectCanonicalError(retryBody, "workspace_error");
     expectNoAbsoluteWorkspacePath(retryBody, tempRoot, workspaceRoot);
+    expect(recordAfterRetry?.status).toBe("started");
+    expect(recordAfterRetry?.result_ref).toBeUndefined();
     expect(taskIdFactoryCalls).toBe(1);
-    expect(await taskSnapshotIds(workspaceRoot)).toEqual(["TASK-rollback-failure-original"]);
+    expect(await taskIdsWithSnapshots(workspaceRoot)).toEqual([]);
     await expectPathMissing(join(workspaceRoot, "tasks", "TASK-rollback-failure-duplicate"));
   });
 
@@ -1732,10 +2018,48 @@ describe("backend workspace and health routes", () => {
 
     expect(response.status).toBe(400);
     expectCanonicalError(body, "schema_error");
-    expect(body.error.evidence_refs).toEqual(["request.body.question_or_goal"]);
+    expect(body.error.evidence_refs).toEqual(["request.body"]);
     expect(taskIdFactoryCalls).toBe(0);
     expect(await idempotencyService.getRecord("task", idempotencyKey)).toBeUndefined();
     await expectPathMissing(join(workspaceRoot, "tasks", "TASK-oversized-keyed"));
+  });
+
+  test("POST /api/tasks rejects oversized keyed malformed JSON before parsing body", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:oversized-malformed-before-parse";
+    let taskIdFactoryCalls = 0;
+    const app = createBackendApi({
+      workspaceRoot,
+      taskIdFactory: () => {
+        taskIdFactoryCalls += 1;
+        return "TASK-oversized-malformed-keyed";
+      }
+    });
+    const oversizedMalformedBody = `{"type":"engineering","title":"Oversized","question_or_goal":"${"x".repeat(
+      MAX_TASK_SNAPSHOT_BYTES + 1
+    )}`;
+
+    const response = await app.request("/api/tasks", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "Idempotency-Key": idempotencyKey
+      },
+      body: oversizedMalformedBody
+    });
+    const body = (await response.json()) as ApiErrorResponse;
+    const idempotencyService = createIdempotencyRecordService({ workspaceRoot });
+
+    expect(response.status).toBe(400);
+    expectCanonicalError(body, "schema_error");
+    expect(body.error.message).toBe(
+      "Task create request exceeds the M1 bounded idempotency digest size."
+    );
+    expect(body.error.evidence_refs).toEqual(["request.body"]);
+    expect(taskIdFactoryCalls).toBe(0);
+    expect(await idempotencyService.getRecord("task", idempotencyKey)).toBeUndefined();
+    await expectPathMissing(join(workspaceRoot, "tasks", "TASK-oversized-malformed-keyed"));
   });
 
   test("POST /api/tasks accepts and recovers large snapshots below the M1 byte cap", async () => {

--- a/packages/backend/src/routes/index.test.ts
+++ b/packages/backend/src/routes/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { execFile as execFileWithCallback } from "node:child_process";
+import { writeFileSync } from "node:fs";
 import {
   access,
   readdir,
@@ -16,10 +17,14 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import {
+  DEFAULT_TASK_CREATED_BY,
   MAX_TASK_SNAPSHOT_BYTES,
   TaskServiceError,
+  canonicalJson,
   createIdempotencyRecordService,
   createTaskCardService,
+  idempotencyRecordFileName,
+  sha256Hex,
   type CreateTaskInput,
   type TaskCard,
   type TaskSnapshot
@@ -611,6 +616,56 @@ describe("backend workspace and health routes", () => {
     expect(idempotencyRecord?.result_ref).toBe(firstTask.task_id);
   });
 
+  test("POST /api/tasks times out a stale started same-digest idempotency claim without creating a task", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    let taskIdFactoryCalls = 0;
+    const idempotencyKey = "task:create:stale-started-claim";
+    const taskBody = validTaskCreateBody({ created_by: undefined });
+    const requestDigest = sha256Hex(
+      canonicalJson({
+        ...taskBody,
+        created_by: taskBody.created_by ?? DEFAULT_TASK_CREATED_BY
+      })
+    );
+    const idempotencyService = createIdempotencyRecordService({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:32.000Z")
+    });
+    const seededBegin = await idempotencyService.beginRecord({
+      scope: "task",
+      key: idempotencyKey,
+      requestDigest
+    });
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:33.000Z"),
+      taskIdFactory: () => {
+        taskIdFactoryCalls += 1;
+        return "TASK-should-not-be-created";
+      }
+    });
+
+    const response = await Promise.race([
+      postTask(app, taskBody, { "Idempotency-Key": idempotencyKey }),
+      timeoutAfter(2_000, "POST /api/tasks did not time out a stale idempotency claim")
+    ]);
+    const body = (await response.json()) as ApiErrorResponse;
+    const recordAfterReplay = await idempotencyService.getRecord("task", idempotencyKey);
+
+    expect(seededBegin.status).toBe("acquired");
+    expect(response.status).toBe(500);
+    expectCanonicalError(body, "workspace_error");
+    expect(body.error.message).toBe("Idempotency record did not complete before replay timeout.");
+    expect(body.error.retryable).toBe(true);
+    expect(body.error.evidence_refs).toEqual(["workspace/tasks/_idempotency/task"]);
+    expectNoAbsoluteWorkspacePath(body, tempRoot, workspaceRoot);
+    expect(taskIdFactoryCalls).toBe(0);
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([]);
+    expect(recordAfterReplay).toEqual(seededBegin.record);
+    expect(recordAfterReplay?.status).toBe("started");
+  });
+
   test("POST /api/tasks computes the same digest for reordered JSON keys", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -754,6 +809,28 @@ describe("backend workspace and health routes", () => {
     await expectPathMissing(join(workspaceRoot, "tasks", "_idempotency"));
   });
 
+  test("POST /api/tasks rejects a blank Idempotency-Key without task or idempotency state", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:52.000Z"),
+      taskIdFactory: () => "TASK-blank-idempotency-key"
+    });
+
+    const response = await postTask(app, validTaskCreateBody(), {
+      "Idempotency-Key": "   "
+    });
+    const body = (await response.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(400);
+    expectCanonicalError(body, "schema_error");
+    expect(body.error.evidence_refs).toEqual(["request.headers.Idempotency-Key"]);
+    expectNoAbsoluteWorkspacePath(body, tempRoot, workspaceRoot);
+    await expectPathMissing(join(workspaceRoot, "tasks"));
+    await expectPathMissing(join(workspaceRoot, "tasks", "_idempotency"));
+  });
+
   test("POST /api/tasks concurrent same-key creates converge on one completed result", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -791,6 +868,267 @@ describe("backend workspace and health routes", () => {
     expect(await taskSnapshotIds(workspaceRoot)).toEqual([firstTask.task_id]);
     expect(idempotencyRecord?.status).toBe("completed");
     expect(idempotencyRecord?.result_ref).toBe(firstTask.task_id);
+  });
+
+  test("POST /api/tasks concurrent same-key creates converge across backend app instances", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:cross-app-concurrent";
+    const firstApp = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:56.000Z"),
+      taskIdFactory: () => "TASK-cross-app-a"
+    });
+    const secondApp = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:56.000Z"),
+      taskIdFactory: () => "TASK-cross-app-b"
+    });
+
+    const responses = await Promise.all([
+      postTask(firstApp, validTaskCreateBody(), { "Idempotency-Key": idempotencyKey }),
+      postTask(secondApp, validTaskCreateBody(), { "Idempotency-Key": idempotencyKey })
+    ]);
+    const tasks = (await Promise.all(responses.map((response) => response.json()))) as TaskCard[];
+    const statuses = responses.map((response) => response.status).sort();
+    const idempotencyRecord = await createIdempotencyRecordService({ workspaceRoot }).getRecord(
+      "task",
+      idempotencyKey
+    );
+
+    expect(statuses).toEqual([200, 201]);
+    expect(tasks[1]).toEqual(tasks[0]);
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([tasks[0].task_id]);
+    expect(idempotencyRecord?.status).toBe("completed");
+    expect(idempotencyRecord?.result_ref).toBe(tasks[0].task_id);
+  });
+
+  test("POST /api/tasks blocked idempotency path fails before task state and succeeds after repair", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:blocked-idempotency-path";
+    await mkdir(join(workspaceRoot, "tasks"), { recursive: true });
+    await writeFile(join(workspaceRoot, "tasks", "_idempotency"), "blocked", { flag: "wx" });
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:57.000Z"),
+      taskIdFactory: () => "TASK-after-idempotency-repair"
+    });
+
+    const failedResponse = await postTask(app, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const failedBody = (await failedResponse.json()) as ApiErrorResponse;
+    expect(failedResponse.status).toBe(500);
+    expectCanonicalError(failedBody, "workspace_error");
+    expectNoAbsoluteWorkspacePath(failedBody, tempRoot, workspaceRoot);
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([]);
+
+    await rm(join(workspaceRoot, "tasks", "_idempotency"), { force: true });
+    const repairedResponse = await postTask(app, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const repairedTask = (await repairedResponse.json()) as TaskCard;
+    const idempotencyRecord = await createIdempotencyRecordService({ workspaceRoot }).getRecord(
+      "task",
+      idempotencyKey
+    );
+
+    expect(repairedResponse.status).toBe(201);
+    expect(repairedTask.task_id).toBe("TASK-after-idempotency-repair");
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([repairedTask.task_id]);
+    expect(idempotencyRecord?.status).toBe("completed");
+    expect(idempotencyRecord?.result_ref).toBe(repairedTask.task_id);
+  });
+
+  test("POST /api/tasks failed task persistence marks claim failed and retries after repair", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:claim-succeeds-task-fails";
+    const taskIds = ["TASK-claim-fails", "TASK-claim-retry"];
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:57.500Z"),
+      taskIdFactory: () => taskIds.shift() ?? "TASK-unexpected-extra"
+    });
+
+    expect(await app.request("/api/tasks").then((response) => response.json())).toEqual({
+      tasks: []
+    });
+    await mkdir(join(workspaceRoot, "tasks"), { recursive: true });
+    await writeFile(join(workspaceRoot, "tasks", "TASK-claim-fails"), "blocked lane", {
+      flag: "wx"
+    });
+
+    const failedResponse = await postTask(app, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const failedBody = (await failedResponse.json()) as ApiErrorResponse;
+    const idempotencyService = createIdempotencyRecordService({ workspaceRoot });
+    const recordAfterFailure = await idempotencyService.getRecord("task", idempotencyKey);
+
+    expect(failedResponse.status).toBe(500);
+    expectCanonicalError(failedBody, "workspace_error");
+    expectNoAbsoluteWorkspacePath(failedBody, tempRoot, workspaceRoot);
+    expect(recordAfterFailure?.status).toBe("failed");
+    expect(recordAfterFailure?.result_ref).toBeUndefined();
+    await expectPathMissing(join(workspaceRoot, "tasks", "TASK-claim-fails", "snapshot.json"));
+    await expectPathMissing(join(workspaceRoot, "tasks", "TASK-claim-retry"));
+
+    await rm(join(workspaceRoot, "tasks", "TASK-claim-fails"), { force: true });
+    const repairedResponse = await postTask(app, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const repairedTask = (await repairedResponse.json()) as TaskCard;
+    const recordAfterRepair = await idempotencyService.getRecord("task", idempotencyKey);
+
+    expect(repairedResponse.status).toBe(201);
+    expect(repairedTask.task_id).toBe("TASK-claim-retry");
+    expect(taskIds).toEqual([]);
+    expect(recordAfterRepair?.status).toBe("completed");
+    expect(recordAfterRepair?.result_ref).toBe(repairedTask.task_id);
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([repairedTask.task_id]);
+    expect(await app.request("/api/tasks").then((response) => response.json())).toEqual({
+      tasks: [repairedTask]
+    });
+  });
+
+  test("POST /api/tasks rolls back snapshot when idempotency completion fails", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:complete-fails-after-snapshot";
+    const taskBody = validTaskCreateBody();
+    const requestDigest = sha256Hex(canonicalJson(taskBody));
+    const taskIds = ["TASK-complete-fails", "TASK-complete-retry"];
+    let poisonedCompletion = false;
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:57.625Z"),
+      taskIdFactory: () => {
+        const taskId = taskIds.shift() ?? "TASK-unexpected-complete-extra";
+        if (!poisonedCompletion) {
+          poisonedCompletion = true;
+          writeFileSync(
+            join(
+              workspaceRoot,
+              "tasks",
+              "_idempotency",
+              "task",
+              idempotencyRecordFileName(idempotencyKey)
+            ),
+            `${JSON.stringify(
+              {
+                key: idempotencyKey,
+                scope: "task",
+                request_digest: requestDigest,
+                status: "failed",
+                created_at: "2026-07-07T12:03:57.625Z",
+                updated_at: "2026-07-07T12:03:57.625Z"
+              },
+              null,
+              2
+            )}\n`
+          );
+        }
+        return taskId;
+      }
+    });
+
+    const failedResponse = await postTask(app, taskBody, {
+      "Idempotency-Key": idempotencyKey
+    });
+    const failedBody = (await failedResponse.json()) as ApiErrorResponse;
+    const idempotencyService = createIdempotencyRecordService({ workspaceRoot });
+    const recordAfterFailure = await idempotencyService.getRecord("task", idempotencyKey);
+
+    expect(failedResponse.status).toBe(400);
+    expectCanonicalError(failedBody, "schema_error");
+    expectNoAbsoluteWorkspacePath(failedBody, tempRoot, workspaceRoot);
+    expect(recordAfterFailure?.status).toBe("failed");
+    expect(recordAfterFailure?.result_ref).toBeUndefined();
+    await expectPathMissing(join(workspaceRoot, "tasks", "TASK-complete-fails"));
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([]);
+    expect(await app.request("/api/tasks").then((response) => response.json())).toEqual({
+      tasks: []
+    });
+
+    const repairedResponse = await postTask(app, taskBody, {
+      "Idempotency-Key": idempotencyKey
+    });
+    const repairedTask = (await repairedResponse.json()) as TaskCard;
+    const recordAfterRepair = await idempotencyService.getRecord("task", idempotencyKey);
+    const idempotencyFiles = await readdir(join(workspaceRoot, "tasks", "_idempotency", "task"));
+
+    expect(repairedResponse.status).toBe(201);
+    expect(repairedTask.task_id).toBe("TASK-complete-retry");
+    expect(taskIds).toEqual([]);
+    expect(recordAfterRepair?.status).toBe("completed");
+    expect(recordAfterRepair?.result_ref).toBe(repairedTask.task_id);
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([repairedTask.task_id]);
+    expect(await app.request("/api/tasks").then((response) => response.json())).toEqual({
+      tasks: [repairedTask]
+    });
+    expect(idempotencyFiles).toEqual([idempotencyRecordFileName(idempotencyKey)]);
+  });
+
+  test("POST /api/tasks concurrent failed-claim retries converge across backend app instances", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:failed-concurrent-route-retry";
+    await mkdir(join(workspaceRoot, "tasks"), { recursive: true });
+    await writeFile(join(workspaceRoot, "tasks", "TASK-route-failed-retry"), "blocked lane", {
+      flag: "wx"
+    });
+    const failingApp = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:57.750Z"),
+      taskIdFactory: () => "TASK-route-failed-retry"
+    });
+    const failedResponse = await postTask(failingApp, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const failedBody = (await failedResponse.json()) as ApiErrorResponse;
+    const idempotencyService = createIdempotencyRecordService({ workspaceRoot });
+    const recordAfterFailure = await idempotencyService.getRecord("task", idempotencyKey);
+
+    expect(failedResponse.status).toBe(500);
+    expectCanonicalError(failedBody, "workspace_error");
+    expectNoAbsoluteWorkspacePath(failedBody, tempRoot, workspaceRoot);
+    expect(recordAfterFailure?.status).toBe("failed");
+    await expectPathMissing(
+      join(workspaceRoot, "tasks", "TASK-route-failed-retry", "snapshot.json")
+    );
+
+    await rm(join(workspaceRoot, "tasks", "TASK-route-failed-retry"), { force: true });
+    const firstRetryApp = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:58.000Z"),
+      taskIdFactory: () => "TASK-route-retry-a"
+    });
+    const secondRetryApp = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:58.000Z"),
+      taskIdFactory: () => "TASK-route-retry-b"
+    });
+
+    const retryResponses = await Promise.all([
+      postTask(firstRetryApp, validTaskCreateBody(), { "Idempotency-Key": idempotencyKey }),
+      postTask(secondRetryApp, validTaskCreateBody(), { "Idempotency-Key": idempotencyKey })
+    ]);
+    const retryTasks = (await Promise.all(
+      retryResponses.map((response) => response.json())
+    )) as TaskCard[];
+    const statuses = retryResponses.map((response) => response.status).sort();
+    const uniqueSerializedTasks = Array.from(new Set(retryTasks.map((task) => JSON.stringify(task))));
+    const createdTask = JSON.parse(uniqueSerializedTasks[0] as string) as TaskCard;
+    const recordAfterRetry = await idempotencyService.getRecord("task", idempotencyKey);
+
+    expect(statuses).toEqual([200, 201]);
+    expect(uniqueSerializedTasks).toHaveLength(1);
+    expect(["TASK-route-retry-a", "TASK-route-retry-b"]).toContain(createdTask.task_id);
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([createdTask.task_id]);
+    expect(recordAfterRetry?.status).toBe("completed");
+    expect(recordAfterRetry?.result_ref).toBe(createdTask.task_id);
   });
 
   test("POST /api/tasks failed create retry does not leave a poisoned completed idempotency record", async () => {

--- a/packages/backend/src/routes/index.test.ts
+++ b/packages/backend/src/routes/index.test.ts
@@ -658,6 +658,59 @@ describe("backend workspace and health routes", () => {
     });
   });
 
+  test("POST /api/tasks completed idempotency replay reads only the referenced snapshot lane", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:targeted-replay";
+    const taskBody = validTaskCreateBody();
+    const requestDigest = sha256Hex(
+      canonicalJson({
+        ...taskBody,
+        created_by: taskBody.created_by ?? DEFAULT_TASK_CREATED_BY
+      })
+    );
+    const targetTask = await createTaskCardService({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:31.250Z"),
+      taskIdFactory: () => "TASK-targeted-replay"
+    }).createTask(taskBody);
+    const idempotencyService = createIdempotencyRecordService({ workspaceRoot });
+    await idempotencyService.beginRecord({
+      scope: "task",
+      key: idempotencyKey,
+      requestDigest
+    });
+    await idempotencyService.completeRecord({
+      scope: "task",
+      key: idempotencyKey,
+      requestDigest,
+      resultRef: targetTask.task_id
+    });
+    await mkdir(join(workspaceRoot, "tasks", "TASK-unrelated-malformed"), { recursive: true });
+    await writeFile(join(workspaceRoot, "tasks", "TASK-unrelated-malformed", "snapshot.json"), "{", {
+      flag: "wx"
+    });
+    let taskIdFactoryCalls = 0;
+    const app = createBackendApi({
+      workspaceRoot,
+      taskIdFactory: () => {
+        taskIdFactoryCalls += 1;
+        return "TASK-targeted-replay-duplicate";
+      }
+    });
+
+    const response = await postTask(app, taskBody, { "Idempotency-Key": idempotencyKey });
+    const replayTask = (await response.json()) as TaskCard;
+
+    expect(response.status).toBe(200);
+    expect(replayTask).toEqual(targetTask);
+    expect(taskIdFactoryCalls).toBe(0);
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([
+      "TASK-targeted-replay",
+      "TASK-unrelated-malformed"
+    ]);
+  });
+
   test("POST /api/tasks fails closed when idempotency record key does not match the lookup path", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -724,6 +777,59 @@ describe("backend workspace and health routes", () => {
     expect(await app.request("/api/tasks").then((listResponse) => listResponse.json())).toEqual({
       tasks: [existingTask]
     });
+  });
+
+  test("POST /api/tasks fails closed when completed idempotency result_ref is unsafe", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:unsafe-result-ref";
+    const unsafeResultRef = "../outside/TASK-secret";
+    const taskBody = validTaskCreateBody();
+    const requestDigest = sha256Hex(
+      canonicalJson({
+        ...taskBody,
+        created_by: taskBody.created_by ?? DEFAULT_TASK_CREATED_BY
+      })
+    );
+    const idempotencyDirectory = join(workspaceRoot, "tasks", "_idempotency", "task");
+    const recordPath = join(idempotencyDirectory, idempotencyRecordFileName(idempotencyKey));
+    let taskIdFactoryCalls = 0;
+    const app = createBackendApi({
+      workspaceRoot,
+      taskIdFactory: () => {
+        taskIdFactoryCalls += 1;
+        return "TASK-unsafe-result-ref-duplicate";
+      }
+    });
+
+    await mkdir(idempotencyDirectory, { recursive: true });
+    await writeFile(
+      recordPath,
+      `${JSON.stringify({
+        key: idempotencyKey,
+        scope: "task",
+        request_digest: requestDigest,
+        status: "completed",
+        result_ref: unsafeResultRef,
+        created_at: "2026-07-07T12:03:31.875Z",
+        updated_at: "2026-07-07T12:03:31.875Z"
+      })}\n`,
+      { flag: "wx" }
+    );
+
+    const response = await postTask(app, taskBody, { "Idempotency-Key": idempotencyKey });
+    const body = (await response.json()) as ApiErrorResponse;
+
+    expect(response.status).toBe(500);
+    expectCanonicalError(body, "workspace_error");
+    expect(body.error.evidence_refs).toEqual([
+      idempotencyRecordEvidenceRef("task", idempotencyKey),
+      "idempotency.result_ref"
+    ]);
+    expect(JSON.stringify(body)).not.toContain(unsafeResultRef);
+    expectNoAbsoluteWorkspacePath(body, tempRoot, workspaceRoot);
+    expect(taskIdFactoryCalls).toBe(0);
+    await expectPathMissing(join(workspaceRoot, "tasks", "TASK-unsafe-result-ref-duplicate"));
   });
 
   test("POST /api/tasks times out a stale started same-digest idempotency claim without creating a task", async () => {
@@ -1181,6 +1287,136 @@ describe("backend workspace and health routes", () => {
     expect(idempotencyFiles).toEqual([idempotencyRecordFileName(idempotencyKey)]);
   });
 
+  test("POST /api/tasks recovers a malformed transition guard after completion rollback", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:malformed-guard-route-retry";
+    const taskIds = ["TASK-malformed-guard-first", "TASK-malformed-guard-retry"];
+    let poisonedGuard = false;
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:57.635Z"),
+      taskIdFactory: () => {
+        const taskId = taskIds.shift() ?? "TASK-unexpected-malformed-guard-extra";
+        if (!poisonedGuard) {
+          poisonedGuard = true;
+          writeFileSync(
+            join(
+              workspaceRoot,
+              "tasks",
+              "_idempotency",
+              "task",
+              `${sha256Hex(`transition:${idempotencyKey}`)}.guard.json`
+            ),
+            "{"
+          );
+        }
+        return taskId;
+      }
+    });
+
+    const failedResponse = await postTask(app, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const failedBody = (await failedResponse.json()) as ApiErrorResponse;
+    const idempotencyService = createIdempotencyRecordService({ workspaceRoot });
+    const recordAfterFailure = await idempotencyService.getRecord("task", idempotencyKey);
+
+    expect(failedResponse.status).toBe(500);
+    expectCanonicalError(failedBody, "workspace_error");
+    expectNoAbsoluteWorkspacePath(failedBody, tempRoot, workspaceRoot);
+    expect(recordAfterFailure?.status).toBe("failed");
+    expect(recordAfterFailure?.result_ref).toBeUndefined();
+    expect(await taskIdsWithSnapshots(workspaceRoot)).toEqual([]);
+
+    const repairedResponse = await postTask(app, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const repairedTask = (await repairedResponse.json()) as TaskCard;
+    const recordAfterRepair = await idempotencyService.getRecord("task", idempotencyKey);
+    const idempotencyFiles = await readdir(join(workspaceRoot, "tasks", "_idempotency", "task"));
+
+    expect(repairedResponse.status).toBe(201);
+    expect(repairedTask.task_id).toBe("TASK-malformed-guard-retry");
+    expect(taskIds).toEqual([]);
+    expect(recordAfterRepair?.status).toBe("completed");
+    expect(recordAfterRepair?.result_ref).toBe(repairedTask.task_id);
+    expect(await taskIdsWithSnapshots(workspaceRoot)).toEqual([repairedTask.task_id]);
+    expect(idempotencyFiles).toEqual([idempotencyRecordFileName(idempotencyKey)]);
+  });
+
+  test("POST /api/tasks binds idempotency result when completion and rollback both fail", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:rollback-failure-bound";
+    const taskBody = validTaskCreateBody();
+    const requestDigest = sha256Hex(canonicalJson(taskBody));
+    let taskIdFactoryCalls = 0;
+    let poisonedAfterSnapshot = false;
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:57.640Z"),
+      taskIdFactory: () => {
+        taskIdFactoryCalls += 1;
+        return taskIdFactoryCalls === 1
+          ? "TASK-rollback-failure-original"
+          : "TASK-rollback-failure-duplicate";
+      },
+      taskSnapshotWriteHooks: {
+        afterSnapshotWrite: async ({ taskDirectory }) => {
+          if (poisonedAfterSnapshot) {
+            return;
+          }
+          poisonedAfterSnapshot = true;
+          await writeFile(
+            join(
+              workspaceRoot,
+              "tasks",
+              "_idempotency",
+              "task",
+              idempotencyRecordFileName(idempotencyKey)
+            ),
+            `${JSON.stringify(
+              {
+                key: idempotencyKey,
+                scope: "task",
+                request_digest: requestDigest,
+                status: "failed",
+                created_at: "2026-07-07T12:03:57.640Z",
+                updated_at: "2026-07-07T12:03:57.640Z"
+              },
+              null,
+              2
+            )}\n`
+          );
+          await rm(join(taskDirectory, "snapshot.json"));
+          await mkdir(join(taskDirectory, "snapshot.json"));
+        }
+      }
+    });
+
+    const failedResponse = await postTask(app, taskBody, {
+      "Idempotency-Key": idempotencyKey
+    });
+    const failedBody = (await failedResponse.json()) as ApiErrorResponse;
+    const idempotencyService = createIdempotencyRecordService({ workspaceRoot });
+    const recordAfterFailure = await idempotencyService.getRecord("task", idempotencyKey);
+    const retryResponse = await postTask(app, taskBody, { "Idempotency-Key": idempotencyKey });
+    const retryBody = (await retryResponse.json()) as ApiErrorResponse;
+
+    expect(failedResponse.status).toBe(500);
+    expectCanonicalError(failedBody, "workspace_error");
+    expectNoAbsoluteWorkspacePath(failedBody, tempRoot, workspaceRoot);
+    expect(recordAfterFailure?.status).toBe("completed");
+    expect(recordAfterFailure?.result_ref).toBe("TASK-rollback-failure-original");
+    expect(retryResponse.status).toBe(500);
+    expectCanonicalError(retryBody, "workspace_error");
+    expectNoAbsoluteWorkspacePath(retryBody, tempRoot, workspaceRoot);
+    expect(taskIdFactoryCalls).toBe(1);
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual(["TASK-rollback-failure-original"]);
+    await expectPathMissing(join(workspaceRoot, "tasks", "TASK-rollback-failure-duplicate"));
+  });
+
   test("POST /api/tasks rollback preserves existing lane files and leaves failed claim retryable", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -1469,6 +1705,37 @@ describe("backend workspace and health routes", () => {
     await expectPathMissing(join(workspaceRoot, "tasks"));
     expect(listResponse.status).toBe(200);
     expect(await listResponse.json()).toEqual({ tasks: [] });
+  });
+
+  test("POST /api/tasks rejects oversized keyed requests before digest state", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:oversized-before-digest";
+    let taskIdFactoryCalls = 0;
+    const app = createBackendApi({
+      workspaceRoot,
+      taskIdFactory: () => {
+        taskIdFactoryCalls += 1;
+        return "TASK-oversized-keyed";
+      }
+    });
+
+    const response = await postTask(
+      app,
+      validTaskCreateBody({
+        question_or_goal: "x".repeat(MAX_TASK_SNAPSHOT_BYTES + 1)
+      }),
+      { "Idempotency-Key": idempotencyKey }
+    );
+    const body = (await response.json()) as ApiErrorResponse;
+    const idempotencyService = createIdempotencyRecordService({ workspaceRoot });
+
+    expect(response.status).toBe(400);
+    expectCanonicalError(body, "schema_error");
+    expect(body.error.evidence_refs).toEqual(["request.body.question_or_goal"]);
+    expect(taskIdFactoryCalls).toBe(0);
+    expect(await idempotencyService.getRecord("task", idempotencyKey)).toBeUndefined();
+    await expectPathMissing(join(workspaceRoot, "tasks", "TASK-oversized-keyed"));
   });
 
   test("POST /api/tasks accepts and recovers large snapshots below the M1 byte cap", async () => {

--- a/packages/backend/src/routes/index.test.ts
+++ b/packages/backend/src/routes/index.test.ts
@@ -616,6 +616,47 @@ describe("backend workspace and health routes", () => {
     expect(idempotencyRecord?.result_ref).toBe(firstTask.task_id);
   });
 
+  test("POST /api/tasks completed idempotency replay resolves a stale task cache from durable snapshot", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:stale-cache-replay";
+    let staleAppTaskIdFactoryCalls = 0;
+    const staleApp = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:31.000Z"),
+      taskIdFactory: () => {
+        staleAppTaskIdFactoryCalls += 1;
+        return "TASK-stale-cache-duplicate";
+      }
+    });
+    const creatingApp = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:31.000Z"),
+      taskIdFactory: () => "TASK-stale-cache-original"
+    });
+
+    const emptyListResponse = await staleApp.request("/api/tasks");
+    const firstResponse = await postTask(creatingApp, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const replayResponse = await postTask(staleApp, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const firstTask = (await firstResponse.json()) as TaskCard;
+    const replayTask = (await replayResponse.json()) as TaskCard;
+
+    expect(emptyListResponse.status).toBe(200);
+    expect(await emptyListResponse.json()).toEqual({ tasks: [] });
+    expect(firstResponse.status).toBe(201);
+    expect(replayResponse.status).toBe(200);
+    expect(replayTask).toEqual(firstTask);
+    expect(staleAppTaskIdFactoryCalls).toBe(0);
+    expect(await taskIdsWithSnapshots(workspaceRoot)).toEqual([firstTask.task_id]);
+    expect(await staleApp.request("/api/tasks").then((response) => response.json())).toEqual({
+      tasks: [firstTask]
+    });
+  });
+
   test("POST /api/tasks times out a stale started same-digest idempotency claim without creating a task", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -1069,6 +1110,88 @@ describe("backend workspace and health routes", () => {
       tasks: [repairedTask]
     });
     expect(idempotencyFiles).toEqual([idempotencyRecordFileName(idempotencyKey)]);
+  });
+
+  test("POST /api/tasks rollback preserves existing lane files and leaves failed claim retryable", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "task:create:existing-lane-rollback";
+    const taskBody = validTaskCreateBody();
+    const requestDigest = sha256Hex(canonicalJson(taskBody));
+    const taskIds = ["TASK-existing-lane", "TASK-existing-lane-retry"];
+    const taskLane = join(workspaceRoot, "tasks", "TASK-existing-lane");
+    const sentinelPath = join(taskLane, "sentinel.txt");
+    let poisonedCompletion = false;
+    await mkdir(taskLane, { recursive: true });
+    await writeFile(sentinelPath, "preserve lane sentinel", { flag: "wx" });
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:57.650Z"),
+      taskIdFactory: () => {
+        const taskId = taskIds.shift() ?? "TASK-unexpected-existing-lane-extra";
+        if (!poisonedCompletion) {
+          poisonedCompletion = true;
+          writeFileSync(
+            join(
+              workspaceRoot,
+              "tasks",
+              "_idempotency",
+              "task",
+              idempotencyRecordFileName(idempotencyKey)
+            ),
+            `${JSON.stringify(
+              {
+                key: idempotencyKey,
+                scope: "task",
+                request_digest: requestDigest,
+                status: "failed",
+                created_at: "2026-07-07T12:03:57.650Z",
+                updated_at: "2026-07-07T12:03:57.650Z"
+              },
+              null,
+              2
+            )}\n`
+          );
+        }
+        return taskId;
+      }
+    });
+
+    const failedResponse = await postTask(app, taskBody, {
+      "Idempotency-Key": idempotencyKey
+    });
+    const failedBody = (await failedResponse.json()) as ApiErrorResponse;
+    const idempotencyService = createIdempotencyRecordService({ workspaceRoot });
+    const recordAfterFailure = await idempotencyService.getRecord("task", idempotencyKey);
+
+    expect(failedResponse.status).toBe(400);
+    expectCanonicalError(failedBody, "schema_error");
+    expectNoAbsoluteWorkspacePath(failedBody, tempRoot, workspaceRoot);
+    expect(await readFile(sentinelPath, "utf8")).toBe("preserve lane sentinel");
+    await expectPathMissing(join(taskLane, "snapshot.json"));
+    expect(await taskIdsWithSnapshots(workspaceRoot)).toEqual([]);
+    expect(await app.request("/api/tasks").then((response) => response.json())).toEqual({
+      tasks: []
+    });
+    expect(recordAfterFailure?.status).toBe("failed");
+    expect(recordAfterFailure?.result_ref).toBeUndefined();
+
+    const repairedResponse = await postTask(app, taskBody, {
+      "Idempotency-Key": idempotencyKey
+    });
+    const repairedTask = (await repairedResponse.json()) as TaskCard;
+    const recordAfterRepair = await idempotencyService.getRecord("task", idempotencyKey);
+
+    expect(repairedResponse.status).toBe(201);
+    expect(repairedTask.task_id).toBe("TASK-existing-lane-retry");
+    expect(taskIds).toEqual([]);
+    expect(await readFile(sentinelPath, "utf8")).toBe("preserve lane sentinel");
+    expect(await taskIdsWithSnapshots(workspaceRoot)).toEqual([repairedTask.task_id]);
+    expect(await app.request("/api/tasks").then((response) => response.json())).toEqual({
+      tasks: [repairedTask]
+    });
+    expect(recordAfterRepair?.status).toBe("completed");
+    expect(recordAfterRepair?.result_ref).toBe(repairedTask.task_id);
   });
 
   test("POST /api/tasks concurrent failed-claim retries converge across backend app instances", async () => {
@@ -1927,6 +2050,23 @@ async function taskSnapshotIds(workspaceRoot: string): Promise<string[]> {
   return (await readdir(join(workspaceRoot, "tasks")))
     .filter((entry) => entry.startsWith("TASK-"))
     .sort();
+}
+
+async function taskIdsWithSnapshots(workspaceRoot: string): Promise<string[]> {
+  const taskIds = await taskSnapshotIds(workspaceRoot);
+  const idsWithSnapshots: string[] = [];
+  for (const taskId of taskIds) {
+    try {
+      const snapshot = await stat(join(workspaceRoot, "tasks", taskId, "snapshot.json"));
+      if (snapshot.isFile()) {
+        idsWithSnapshots.push(taskId);
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return idsWithSnapshots.sort();
 }
 
 function expectCanonicalError(body: ApiErrorResponse, category: string): void {

--- a/packages/backend/src/routes/index.test.ts
+++ b/packages/backend/src/routes/index.test.ts
@@ -18,6 +18,7 @@ import { promisify } from "node:util";
 import {
   MAX_TASK_SNAPSHOT_BYTES,
   TaskServiceError,
+  createIdempotencyRecordService,
   createTaskCardService,
   type CreateTaskInput,
   type TaskCard,
@@ -570,6 +571,265 @@ describe("backend workspace and health routes", () => {
     expect(await listResponse.json()).toEqual({ tasks: [createdTask] });
     expect(detailResponse.status).toBe(200);
     expect(await detailResponse.json()).toEqual(createdTask);
+  });
+
+  test("POST /api/tasks replays same Idempotency-Key and body without duplicate snapshots", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    let nextId = 0;
+    const idempotencyKey = "task:create:replay";
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:30.000Z"),
+      taskIdFactory: () => {
+        nextId += 1;
+        return `TASK-idempotent-${nextId}`;
+      }
+    });
+
+    const firstResponse = await postTask(app, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const secondResponse = await postTask(app, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const firstTask = (await firstResponse.json()) as TaskCard;
+    const secondTask = (await secondResponse.json()) as TaskCard;
+    const idempotencyService = createIdempotencyRecordService({ workspaceRoot });
+    const idempotencyRecord = await idempotencyService.getRecord("task", idempotencyKey);
+
+    expect(firstResponse.status).toBe(201);
+    expect(secondResponse.status).toBe(200);
+    expect(secondTask).toEqual(firstTask);
+    expect(nextId).toBe(1);
+    expect(await app.request("/api/tasks").then((response) => response.json())).toEqual({
+      tasks: [firstTask]
+    });
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([firstTask.task_id]);
+    expect((await readdir(join(workspaceRoot, "tasks", "_idempotency", "task")))).toHaveLength(1);
+    expect(idempotencyRecord?.status).toBe("completed");
+    expect(idempotencyRecord?.result_ref).toBe(firstTask.task_id);
+  });
+
+  test("POST /api/tasks computes the same digest for reordered JSON keys", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    let nextId = 0;
+    const idempotencyKey = "task:create:reordered-json";
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:35.000Z"),
+      taskIdFactory: () => {
+        nextId += 1;
+        return `TASK-reordered-${nextId}`;
+      }
+    });
+
+    const firstResponse = await postRawTask(
+      app,
+      {
+        type: "engineering",
+        title: "Add optional event diagnostics",
+        question_or_goal: "Add event_flux output without breaking old rSHUD readers",
+        inference_budget: { mode: "normal" },
+        created_by: "pi"
+      },
+      idempotencyKey
+    );
+    const secondResponse = await app.request("/api/tasks", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "Idempotency-Key": idempotencyKey
+      },
+      body:
+        '{"created_by":"pi","inference_budget":{"mode":"normal"},"question_or_goal":"Add event_flux output without breaking old rSHUD readers","title":"Add optional event diagnostics","type":"engineering"}'
+    });
+    const firstTask = (await firstResponse.json()) as TaskCard;
+    const secondTask = (await secondResponse.json()) as TaskCard;
+
+    expect(firstResponse.status).toBe(201);
+    expect(secondResponse.status).toBe(200);
+    expect(secondTask).toEqual(firstTask);
+    expect(nextId).toBe(1);
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([firstTask.task_id]);
+  });
+
+  test("POST /api/tasks idempotency digest includes defaulted created_by", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    let nextId = 0;
+    const idempotencyKey = "task:create:default-created-by";
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:40.000Z"),
+      taskIdFactory: () => {
+        nextId += 1;
+        return `TASK-default-idempotent-${nextId}`;
+      }
+    });
+
+    const omittedResponse = await postTask(app, validTaskCreateBody({ created_by: undefined }), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const explicitResponse = await postTask(app, validTaskCreateBody({ created_by: "pi" }), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const changedResponse = await postTask(app, validTaskCreateBody({ created_by: "engineer" }), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const omittedTask = (await omittedResponse.json()) as TaskCard;
+    const explicitTask = (await explicitResponse.json()) as TaskCard;
+    const changedBody = (await changedResponse.json()) as ApiErrorResponse;
+
+    expect(omittedResponse.status).toBe(201);
+    expect(explicitResponse.status).toBe(200);
+    expect(changedResponse.status).toBe(422);
+    expect(explicitTask).toEqual(omittedTask);
+    expect(omittedTask.created_by).toBe("pi");
+    expectCanonicalError(changedBody, "idempotency_mismatch");
+    expect(nextId).toBe(1);
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([omittedTask.task_id]);
+  });
+
+  test("POST /api/tasks returns 422 on same Idempotency-Key with different body", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const idempotencyKey = "raw-secret-idempotency-key-should-not-leak";
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:45.000Z"),
+      taskIdFactory: () => "TASK-idempotency-mismatch"
+    });
+
+    const firstResponse = await postTask(app, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const firstTask = (await firstResponse.json()) as TaskCard;
+    const mismatchResponse = await postTask(
+      app,
+      validTaskCreateBody({ title: "Changed task title" }),
+      { "Idempotency-Key": idempotencyKey }
+    );
+    const mismatchBody = (await mismatchResponse.json()) as ApiErrorResponse;
+
+    expect(firstResponse.status).toBe(201);
+    expect(mismatchResponse.status).toBe(422);
+    expectCanonicalError(mismatchBody, "idempotency_mismatch");
+    expect(mismatchBody.error.evidence_refs).toEqual([
+      "request.headers.Idempotency-Key",
+      "idempotency.scope:task",
+      "idempotency.request_digest"
+    ]);
+    expect(JSON.stringify(mismatchBody)).not.toContain(idempotencyKey);
+    expectNoAbsoluteWorkspacePath(mismatchBody, tempRoot, workspaceRoot);
+    expect(await app.request("/api/tasks").then((response) => response.json())).toEqual({
+      tasks: [firstTask]
+    });
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([firstTask.task_id]);
+  });
+
+  test("POST /api/tasks without Idempotency-Key preserves create/list/detail behavior and writes no record", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:50.000Z"),
+      taskIdFactory: () => "TASK-no-idempotency-key"
+    });
+
+    const response = await postTask(app, validTaskCreateBody());
+    const task = (await response.json()) as TaskCard;
+    const listResponse = await app.request("/api/tasks");
+    const detailResponse = await app.request(`/api/tasks/${task.task_id}`);
+
+    expect(response.status).toBe(201);
+    expect(listResponse.status).toBe(200);
+    expect(detailResponse.status).toBe(200);
+    expect(await listResponse.json()).toEqual({ tasks: [task] });
+    expect(await detailResponse.json()).toEqual(task);
+    expect((await stat(join(workspaceRoot, "tasks", task.task_id, "snapshot.json"))).isFile()).toBe(
+      true
+    );
+    await expectPathMissing(join(workspaceRoot, "tasks", "_idempotency"));
+  });
+
+  test("POST /api/tasks concurrent same-key creates converge on one completed result", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    let nextId = 0;
+    const idempotencyKey = "task:create:concurrent";
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:55.000Z"),
+      taskIdFactory: () => {
+        nextId += 1;
+        return `TASK-idempotent-concurrent-${nextId}`;
+      }
+    });
+
+    const responses = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        postTask(app, validTaskCreateBody(), { "Idempotency-Key": idempotencyKey })
+      )
+    );
+    const tasks = (await Promise.all(responses.map((response) => response.json()))) as TaskCard[];
+    const statuses = responses.map((response) => response.status).sort();
+    const uniqueSerializedTasks = Array.from(new Set(tasks.map((task) => JSON.stringify(task))));
+    expect(uniqueSerializedTasks).toHaveLength(1);
+    const firstTask = JSON.parse(uniqueSerializedTasks[0] as string) as TaskCard;
+    const idempotencyRecord = await createIdempotencyRecordService({ workspaceRoot }).getRecord(
+      "task",
+      idempotencyKey
+    );
+
+    expect(statuses).toEqual([200, 200, 200, 200, 200, 200, 200, 201]);
+    expect(nextId).toBe(1);
+    expect(await app.request("/api/tasks").then((response) => response.json())).toEqual({
+      tasks: [firstTask]
+    });
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([firstTask.task_id]);
+    expect(idempotencyRecord?.status).toBe("completed");
+    expect(idempotencyRecord?.result_ref).toBe(firstTask.task_id);
+  });
+
+  test("POST /api/tasks failed create retry does not leave a poisoned completed idempotency record", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const outsideTasksRoot = join(tempRoot, "outside-tasks");
+    const idempotencyKey = "task:create:failed-retry";
+    await mkdir(workspaceRoot, { recursive: true });
+    await mkdir(outsideTasksRoot);
+    await symlink(outsideTasksRoot, join(workspaceRoot, "tasks"), "dir");
+    const app = createBackendApi({
+      workspaceRoot,
+      now: fixedNow("2026-07-07T12:03:58.000Z"),
+      taskIdFactory: () => "TASK-retry-after-repair"
+    });
+
+    const failedResponse = await postTask(app, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const failedBody = (await failedResponse.json()) as ApiErrorResponse;
+    await rm(join(workspaceRoot, "tasks"), { recursive: true, force: true });
+    const idempotencyService = createIdempotencyRecordService({ workspaceRoot });
+    const recordAfterFailure = await idempotencyService.getRecord("task", idempotencyKey);
+    const repairedResponse = await postTask(app, validTaskCreateBody(), {
+      "Idempotency-Key": idempotencyKey
+    });
+    const repairedTask = (await repairedResponse.json()) as TaskCard;
+    const recordAfterRepair = await idempotencyService.getRecord("task", idempotencyKey);
+
+    expect(failedResponse.status).toBe(500);
+    expectCanonicalError(failedBody, "workspace_error");
+    expectNoAbsoluteWorkspacePath(failedBody, tempRoot, workspaceRoot);
+    expect(recordAfterFailure).toBeUndefined();
+    expect(repairedResponse.status).toBe(201);
+    expect(repairedTask.task_id).toBe("TASK-retry-after-repair");
+    expect(recordAfterRepair?.status).toBe("completed");
+    expect(recordAfterRepair?.result_ref).toBe(repairedTask.task_id);
+    expect(await taskSnapshotIds(workspaceRoot)).toEqual([repairedTask.task_id]);
+    await expectPathMissing(join(outsideTasksRoot, "TASK-retry-after-repair"));
   });
 
   test("POST /api/tasks preserves unrelated files in an existing task lane", async () => {
@@ -1300,13 +1560,35 @@ async function writeFillerTaskEntries(tasksRoot: string, count: number): Promise
 
 async function postTask(
   app: ReturnType<typeof createBackendApi>,
-  body: CreateTaskInput
+  body: CreateTaskInput,
+  headers: Record<string, string> = {}
 ): Promise<Response> {
   return await app.request("/api/tasks", {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...headers },
     body: JSON.stringify(body)
   });
+}
+
+async function postRawTask(
+  app: ReturnType<typeof createBackendApi>,
+  body: Record<string, unknown>,
+  idempotencyKey: string
+): Promise<Response> {
+  return await app.request("/api/tasks", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "Idempotency-Key": idempotencyKey
+    },
+    body: JSON.stringify(body)
+  });
+}
+
+async function taskSnapshotIds(workspaceRoot: string): Promise<string[]> {
+  return (await readdir(join(workspaceRoot, "tasks")))
+    .filter((entry) => entry.startsWith("TASK-"))
+    .sort();
 }
 
 function expectCanonicalError(body: ApiErrorResponse, category: string): void {

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -6,6 +6,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import {
   DEFAULT_TASK_CREATED_BY,
   CreateTaskInputSchema,
+  MAX_TASK_SNAPSHOT_BYTES,
   TaskServiceError,
   canonicalJson,
   createIdempotencyMismatchError,
@@ -16,7 +17,8 @@ import {
   type CreateTaskInput,
   type IdempotencyRecordService,
   type TaskCard,
-  type TaskCardService
+  type TaskCardService,
+  type TaskSnapshotWriteHooks
 } from "@shud-harness/core";
 import { Hono, type Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -85,6 +87,7 @@ export interface BackendApiOptions {
   startTimeMs?: number;
   now?: () => Date;
   taskIdFactory?: () => string;
+  taskSnapshotWriteHooks?: TaskSnapshotWriteHooks;
   writableProbe?: WorkspaceWritableProbe;
   snapshotReadableProbe?: WorkspaceSnapshotReadableProbe;
 }
@@ -139,7 +142,8 @@ export function createBackendApi(options: BackendApiOptions = {}): Hono {
   const taskService = createTaskCardService({
     workspaceRoot,
     now: options.now,
-    taskIdFactory: options.taskIdFactory
+    taskIdFactory: options.taskIdFactory,
+    snapshotWriteHooks: options.taskSnapshotWriteHooks
   });
   const idempotencyService = createIdempotencyRecordService({
     workspaceRoot,
@@ -212,8 +216,9 @@ export function createBackendApi(options: BackendApiOptions = {}): Hono {
       }
     }
 
-    const requestDigest = taskCreateRequestDigest(parsedBody.data);
     try {
+      assertKeyedTaskCreateRequestWithinDigestBounds(parsedBody.data);
+      const requestDigest = taskCreateRequestDigest(parsedBody.data);
       const result = await createIdempotentTaskCard({
         input: parsedBody.data,
         idempotencyKey: idempotencyKey.key,
@@ -328,13 +333,11 @@ async function createIdempotentTaskCard(
   try {
     task = await input.taskService.createTask(input.input);
   } catch (error) {
-    await input.idempotencyService
-      .failRecord({
-        scope: "task",
-        key: input.idempotencyKey,
-        requestDigest: input.requestDigest
-      })
-      .catch(() => undefined);
+    await input.idempotencyService.recoverFailedRecordAfterRollback({
+      scope: "task",
+      key: input.idempotencyKey,
+      requestDigest: input.requestDigest
+    });
     throw error;
   }
 
@@ -352,20 +355,73 @@ async function createIdempotentTaskCard(
     } catch (caughtError) {
       rollbackError = caughtError;
     }
-    await input.idempotencyService
-      .failRecord({
+
+    if (rollbackError) {
+      const remainingSnapshot = await inspectRemainingRollbackTaskSnapshot(
+        input.taskService,
+        task
+      );
+      if (remainingSnapshot.status === "matched") {
+        await input.idempotencyService.recoverCompletedRecordAfterRollbackFailure({
+          scope: "task",
+          key: input.idempotencyKey,
+          requestDigest: input.requestDigest,
+          resultRef: task.task_id
+        });
+        return { task: remainingSnapshot.task, created: true };
+      }
+      if (remainingSnapshot.status === "missing") {
+        await input.idempotencyService.recoverFailedRecordAfterRollback({
+          scope: "task",
+          key: input.idempotencyKey,
+          requestDigest: input.requestDigest
+        });
+        throw error;
+      }
+
+      await input.idempotencyService.recoverCompletedRecordAfterRollbackFailure({
         scope: "task",
         key: input.idempotencyKey,
-        requestDigest: input.requestDigest
-      })
-      .catch(() => undefined);
-    if (rollbackError) {
+        requestDigest: input.requestDigest,
+        resultRef: task.task_id
+      });
       throw rollbackError;
     }
+
+    await input.idempotencyService.recoverFailedRecordAfterRollback({
+      scope: "task",
+      key: input.idempotencyKey,
+      requestDigest: input.requestDigest
+    });
     throw error;
   }
 
   return { task, created: true };
+}
+
+type RemainingRollbackTaskSnapshot =
+  | { status: "matched"; task: TaskCard }
+  | { status: "missing" }
+  | { status: "unsafe" };
+
+async function inspectRemainingRollbackTaskSnapshot(
+  taskService: TaskCardService,
+  task: TaskCard
+): Promise<RemainingRollbackTaskSnapshot> {
+  try {
+    const remainingTask = await taskService.getTaskFromSnapshot(task.task_id);
+    if (JSON.stringify(remainingTask) === JSON.stringify(task)) {
+      return { status: "matched", task: remainingTask };
+    }
+
+    return { status: "unsafe" };
+  } catch (error) {
+    if (error instanceof TaskServiceError && error.code === "task_not_found") {
+      return { status: "missing" };
+    }
+
+    return { status: "unsafe" };
+  }
 }
 
 async function waitForIdempotentTaskCompletion(
@@ -411,15 +467,51 @@ async function getIdempotentTaskResult(
   taskService: TaskCardService,
   taskId: string
 ): Promise<TaskCard> {
-  try {
-    return await taskService.getTask(taskId);
-  } catch (error) {
-    if (error instanceof TaskServiceError && error.code === "task_not_found") {
-      return await taskService.getTaskFromSnapshot(taskId);
-    }
-
-    throw error;
+  if (!isSafeTaskId(taskId)) {
+    throw new TaskServiceError({
+      code: "record_malformed",
+      status: 500,
+      category: "workspace_error",
+      message: "Completed task idempotency result_ref is not a safe TaskCard id.",
+      userMessage: "The idempotency result reference cannot be used safely.",
+      evidenceRefs: ["idempotency.result_ref"],
+      retryable: false,
+      recommendedNextActions: ["Inspect and repair the idempotency result reference before retrying."]
+    });
   }
+
+  return await taskService.getTaskFromSnapshot(taskId);
+}
+
+function assertKeyedTaskCreateRequestWithinDigestBounds(input: CreateTaskInput): void {
+  const fields: Array<[string, string | undefined]> = [
+    ["request.body.title", input.title],
+    ["request.body.question_or_goal", input.question_or_goal],
+    ["request.body.created_by", input.created_by]
+  ];
+
+  for (const [evidenceRef, value] of fields) {
+    if (typeof value === "string" && Buffer.byteLength(value, "utf8") > MAX_TASK_SNAPSHOT_BYTES) {
+      throw oversizedTaskCreateRequestError([evidenceRef]);
+    }
+  }
+
+  if (Buffer.byteLength(JSON.stringify(input), "utf8") > MAX_TASK_SNAPSHOT_BYTES) {
+    throw oversizedTaskCreateRequestError(["request.body"]);
+  }
+}
+
+function oversizedTaskCreateRequestError(evidenceRefs: string[]): TaskServiceError {
+  return new TaskServiceError({
+    code: "task_snapshot_too_large",
+    status: 400,
+    category: "schema_error",
+    message: "Task create request exceeds the M1 bounded idempotency digest size.",
+    userMessage: "The task request is too large to process safely.",
+    evidenceRefs,
+    retryable: false,
+    recommendedNextActions: ["Shorten the task title, goal, or creator fields and submit again."]
+  });
 }
 
 function taskCreateRequestDigest(input: CreateTaskInput): string {

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -3,10 +3,19 @@ import { constants } from "node:fs";
 import { access, lstat, mkdir, unlink, writeFile } from "node:fs/promises";
 import { dirname, join, parse, resolve, sep } from "node:path";
 import {
+  DEFAULT_TASK_CREATED_BY,
   CreateTaskInputSchema,
   TaskServiceError,
+  canonicalJson,
+  createIdempotencyMismatchError,
+  createIdempotencyRecordService,
   createTaskCardService,
-  isSafeTaskId
+  isSafeTaskId,
+  sha256Hex,
+  type CreateTaskInput,
+  type IdempotencyRecordService,
+  type TaskCard,
+  type TaskCardService
 } from "@shud-harness/core";
 import { Hono, type Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -131,6 +140,11 @@ export function createBackendApi(options: BackendApiOptions = {}): Hono {
     now: options.now,
     taskIdFactory: options.taskIdFactory
   });
+  const idempotencyService = createIdempotencyRecordService({
+    workspaceRoot,
+    now: options.now
+  });
+  const taskCreateIdempotencyInflight = new Map<string, TaskCreateIdempotencyInflight>();
 
   app.post("/api/workspace/init", async (c) => {
     try {
@@ -184,10 +198,49 @@ export function createBackendApi(options: BackendApiOptions = {}): Hono {
       );
     }
 
+    const idempotencyKey = nonblankIdempotencyKey(c);
+    if (!idempotencyKey) {
+      try {
+        return c.json(await taskService.createTask(parsedBody.data), 201);
+      } catch (error) {
+        return jsonTaskServiceError(c, error);
+      }
+    }
+
+    const requestDigest = taskCreateRequestDigest(parsedBody.data);
+    const inflightKey = `task:${sha256Hex(idempotencyKey)}`;
+    const existingInflight = taskCreateIdempotencyInflight.get(inflightKey);
+    if (existingInflight) {
+      if (existingInflight.requestDigest !== requestDigest) {
+        return jsonTaskServiceError(c, createIdempotencyMismatchError());
+      }
+
+      try {
+        const result = await existingInflight.promise;
+        return c.json(result.task, 200);
+      } catch (error) {
+        return jsonTaskServiceError(c, error);
+      }
+    }
+
+    const promise = createIdempotentTaskCard({
+      input: parsedBody.data,
+      idempotencyKey,
+      requestDigest,
+      taskService,
+      idempotencyService
+    });
+    taskCreateIdempotencyInflight.set(inflightKey, { requestDigest, promise });
+
     try {
-      return c.json(await taskService.createTask(parsedBody.data), 201);
+      const result = await promise;
+      return c.json(result.task, result.created ? 201 : 200);
     } catch (error) {
       return jsonTaskServiceError(c, error);
+    } finally {
+      if (taskCreateIdempotencyInflight.get(inflightKey)?.promise === promise) {
+        taskCreateIdempotencyInflight.delete(inflightKey);
+      }
     }
   });
 
@@ -246,6 +299,73 @@ export function createBackendApi(options: BackendApiOptions = {}): Hono {
   });
 
   return app;
+}
+
+interface TaskCreateIdempotencyInflight {
+  requestDigest: string;
+  promise: Promise<IdempotentTaskCreateResult>;
+}
+
+interface IdempotentTaskCreateResult {
+  task: TaskCard;
+  created: boolean;
+}
+
+interface CreateIdempotentTaskCardInput {
+  input: CreateTaskInput;
+  idempotencyKey: string;
+  requestDigest: string;
+  taskService: TaskCardService;
+  idempotencyService: IdempotencyRecordService;
+}
+
+async function createIdempotentTaskCard(
+  input: CreateIdempotentTaskCardInput
+): Promise<IdempotentTaskCreateResult> {
+  const replay = await input.idempotencyService.lookupReplay({
+    scope: "task",
+    key: input.idempotencyKey,
+    requestDigest: input.requestDigest
+  });
+
+  if (replay.status === "mismatch") {
+    throw createIdempotencyMismatchError();
+  }
+  if (replay.status === "completed") {
+    return {
+      task: await input.taskService.getTask(replay.record.result_ref),
+      created: false
+    };
+  }
+
+  const task = await input.taskService.createTask(input.input);
+  await input.idempotencyService.completeRecord({
+    scope: "task",
+    key: input.idempotencyKey,
+    requestDigest: input.requestDigest,
+    resultRef: task.task_id
+  });
+
+  return { task, created: true };
+}
+
+function taskCreateRequestDigest(input: CreateTaskInput): string {
+  return sha256Hex(
+    canonicalJson({
+      ...input,
+      created_by: input.created_by ?? DEFAULT_TASK_CREATED_BY
+    })
+  );
+}
+
+function nonblankIdempotencyKey(c: Context): string | undefined {
+  const header = c.req.header("Idempotency-Key");
+  if (typeof header !== "string") {
+    return undefined;
+  }
+
+  const trimmedHeader = header.trim();
+  return trimmedHeader.length > 0 ? trimmedHeader : undefined;
 }
 
 function jsonTaskServiceError(c: Context, error: unknown): Response {

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -316,7 +316,7 @@ async function createIdempotentTaskCard(
   }
   if (begin.status === "completed") {
     return {
-      task: await input.taskService.getTask(begin.record.result_ref),
+      task: await getIdempotentTaskResult(input.taskService, begin.record.result_ref),
       created: false
     };
   }
@@ -346,7 +346,12 @@ async function createIdempotentTaskCard(
       resultRef: task.task_id
     });
   } catch (error) {
-    await input.taskService.rollbackTaskForIdempotency(task.task_id);
+    let rollbackError: unknown;
+    try {
+      await input.taskService.rollbackTaskForIdempotency(task.task_id);
+    } catch (caughtError) {
+      rollbackError = caughtError;
+    }
     await input.idempotencyService
       .failRecord({
         scope: "task",
@@ -354,6 +359,9 @@ async function createIdempotentTaskCard(
         requestDigest: input.requestDigest
       })
       .catch(() => undefined);
+    if (rollbackError) {
+      throw rollbackError;
+    }
     throw error;
   }
 
@@ -377,7 +385,7 @@ async function waitForIdempotentTaskCompletion(
     }
     if (replay.status === "completed") {
       return {
-        task: await input.taskService.getTask(replay.record.result_ref),
+        task: await getIdempotentTaskResult(input.taskService, replay.record.result_ref),
         created: false
       };
     }
@@ -396,6 +404,21 @@ async function waitForIdempotentTaskCompletion(
     }
 
     await sleep(IDEMPOTENCY_REPLAY_POLL_INTERVAL_MS);
+  }
+}
+
+async function getIdempotentTaskResult(
+  taskService: TaskCardService,
+  taskId: string
+): Promise<TaskCard> {
+  try {
+    return await taskService.getTask(taskId);
+  } catch (error) {
+    if (error instanceof TaskServiceError && error.code === "task_not_found") {
+      return await taskService.getTaskFromSnapshot(taskId);
+    }
+
+    throw error;
   }
 }
 

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -415,11 +415,6 @@ async function createIdempotentTaskCard(
     throw idempotencyResultBindingError();
   }
   if (completedRecord.result_ref !== task.task_id) {
-    const authoritativeTask = await getIdempotentTaskResult(
-      input.taskService,
-      completedRecord.result_ref,
-      input.requestDigest
-    );
     let convergenceRollbackError: unknown;
     try {
       await input.taskService.rollbackTaskForIdempotency(task.task_id);
@@ -435,6 +430,12 @@ async function createIdempotentTaskCard(
         throw convergenceRollbackError;
       }
     }
+
+    const authoritativeTask = await getIdempotentTaskResult(
+      input.taskService,
+      completedRecord.result_ref,
+      input.requestDigest
+    );
     return { task: authoritativeTask, created: false };
   }
 
@@ -495,7 +496,7 @@ async function waitForIdempotentTaskCompletion(
     if (Date.now() >= deadline) {
       throw new TaskServiceError({
         code: "record_malformed",
-        status: 500,
+        status: 409,
         category: "workspace_error",
         message: "Idempotency record did not complete before replay timeout.",
         userMessage: "The task create request is still pending idempotency completion.",

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -18,6 +18,7 @@ import {
   type IdempotencyRecordService,
   type TaskCard,
   type TaskCardService,
+  type TaskSnapshotReadHooks,
   type TaskSnapshotWriteHooks
 } from "@shud-harness/core";
 import { Hono, type Context } from "hono";
@@ -87,6 +88,7 @@ export interface BackendApiOptions {
   startTimeMs?: number;
   now?: () => Date;
   taskIdFactory?: () => string;
+  taskSnapshotReadHooks?: TaskSnapshotReadHooks;
   taskSnapshotWriteHooks?: TaskSnapshotWriteHooks;
   writableProbe?: WorkspaceWritableProbe;
   snapshotReadableProbe?: WorkspaceSnapshotReadableProbe;
@@ -143,6 +145,7 @@ export function createBackendApi(options: BackendApiOptions = {}): Hono {
     workspaceRoot,
     now: options.now,
     taskIdFactory: options.taskIdFactory,
+    snapshotReadHooks: options.taskSnapshotReadHooks,
     snapshotWriteHooks: options.taskSnapshotWriteHooks
   });
   const idempotencyService = createIdempotencyRecordService({
@@ -166,10 +169,24 @@ export function createBackendApi(options: BackendApiOptions = {}): Hono {
   });
 
   app.post("/api/tasks", async (c) => {
+    let idempotencyKey: ParsedIdempotencyKey;
+    try {
+      idempotencyKey = parseIdempotencyKey(c);
+    } catch (error) {
+      return jsonTaskServiceError(c, error);
+    }
+
     let rawBody: unknown;
     try {
-      rawBody = await c.req.json();
-    } catch {
+      rawBody =
+        idempotencyKey.status === "present"
+          ? parseJsonRequestText(await readBoundedKeyedTaskCreateRequestText(c))
+          : await c.req.json();
+    } catch (error) {
+      if (error instanceof TaskServiceError) {
+        return jsonTaskServiceError(c, error);
+      }
+
       return jsonApiError(
         c,
         {
@@ -202,12 +219,6 @@ export function createBackendApi(options: BackendApiOptions = {}): Hono {
       );
     }
 
-    let idempotencyKey: ParsedIdempotencyKey;
-    try {
-      idempotencyKey = parseIdempotencyKey(c);
-    } catch (error) {
-      return jsonTaskServiceError(c, error);
-    }
     if (idempotencyKey.status === "absent") {
       try {
         return c.json(await taskService.createTask(parsedBody.data), 201);
@@ -321,7 +332,11 @@ async function createIdempotentTaskCard(
   }
   if (begin.status === "completed") {
     return {
-      task: await getIdempotentTaskResult(input.taskService, begin.record.result_ref),
+      task: await getIdempotentTaskResult(
+        input.taskService,
+        begin.record.result_ref,
+        input.requestDigest
+      ),
       created: false
     };
   }
@@ -341,8 +356,9 @@ async function createIdempotentTaskCard(
     throw error;
   }
 
+  let completedRecord: Awaited<ReturnType<IdempotencyRecordService["completeRecord"]>>;
   try {
-    await input.idempotencyService.completeRecord({
+    completedRecord = await input.idempotencyService.completeRecord({
       scope: "task",
       key: input.idempotencyKey,
       requestDigest: input.requestDigest,
@@ -379,11 +395,10 @@ async function createIdempotentTaskCard(
         throw error;
       }
 
-      await input.idempotencyService.recoverCompletedRecordAfterRollbackFailure({
+      await input.idempotencyService.quarantineRecordAfterUnsafeRollback({
         scope: "task",
         key: input.idempotencyKey,
-        requestDigest: input.requestDigest,
-        resultRef: task.task_id
+        requestDigest: input.requestDigest
       });
       throw rollbackError;
     }
@@ -394,6 +409,33 @@ async function createIdempotentTaskCard(
       requestDigest: input.requestDigest
     });
     throw error;
+  }
+
+  if (completedRecord.status !== "completed" || !completedRecord.result_ref) {
+    throw idempotencyResultBindingError();
+  }
+  if (completedRecord.result_ref !== task.task_id) {
+    const authoritativeTask = await getIdempotentTaskResult(
+      input.taskService,
+      completedRecord.result_ref,
+      input.requestDigest
+    );
+    let convergenceRollbackError: unknown;
+    try {
+      await input.taskService.rollbackTaskForIdempotency(task.task_id);
+    } catch (caughtError) {
+      convergenceRollbackError = caughtError;
+    }
+    if (convergenceRollbackError) {
+      const remainingSnapshot = await inspectRemainingRollbackTaskSnapshot(
+        input.taskService,
+        task
+      );
+      if (remainingSnapshot.status !== "missing") {
+        throw convergenceRollbackError;
+      }
+    }
+    return { task: authoritativeTask, created: false };
   }
 
   return { task, created: true };
@@ -441,7 +483,11 @@ async function waitForIdempotentTaskCompletion(
     }
     if (replay.status === "completed") {
       return {
-        task: await getIdempotentTaskResult(input.taskService, replay.record.result_ref),
+        task: await getIdempotentTaskResult(
+          input.taskService,
+          replay.record.result_ref,
+          input.requestDigest
+        ),
         created: false
       };
     }
@@ -465,7 +511,8 @@ async function waitForIdempotentTaskCompletion(
 
 async function getIdempotentTaskResult(
   taskService: TaskCardService,
-  taskId: string
+  taskId: string,
+  requestDigest: string
 ): Promise<TaskCard> {
   if (!isSafeTaskId(taskId)) {
     throw new TaskServiceError({
@@ -480,7 +527,67 @@ async function getIdempotentTaskResult(
     });
   }
 
-  return await taskService.getTaskFromSnapshot(taskId);
+  let task: TaskCard;
+  try {
+    task = await taskService.getTaskFromSnapshot(taskId);
+  } catch (error) {
+    if (error instanceof TaskServiceError) {
+      throw idempotencyResultBindingError();
+    }
+
+    throw error;
+  }
+
+  if (taskCreateRequestDigestFromTask(task) !== requestDigest) {
+    throw idempotencyResultBindingError();
+  }
+
+  return task;
+}
+
+async function readBoundedKeyedTaskCreateRequestText(c: Context): Promise<string> {
+  const contentLength = c.req.header("content-length");
+  if (typeof contentLength === "string" && contentLength.trim().length > 0) {
+    const parsedLength = Number(contentLength);
+    if (Number.isFinite(parsedLength) && parsedLength > MAX_TASK_SNAPSHOT_BYTES) {
+      throw oversizedTaskCreateRequestError(["request.body"]);
+    }
+  }
+
+  const body = c.req.raw.body;
+  if (!body) {
+    return "";
+  }
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let decoded = "";
+  let totalBytes = 0;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_TASK_SNAPSHOT_BYTES) {
+        await reader.cancel().catch(() => undefined);
+        throw oversizedTaskCreateRequestError(["request.body"]);
+      }
+
+      decoded += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    decoded += decoder.decode();
+  }
+
+  return decoded;
+}
+
+function parseJsonRequestText(rawText: string): unknown {
+  return JSON.parse(rawText) as unknown;
 }
 
 function assertKeyedTaskCreateRequestWithinDigestBounds(input: CreateTaskInput): void {
@@ -521,6 +628,31 @@ function taskCreateRequestDigest(input: CreateTaskInput): string {
       created_by: input.created_by ?? DEFAULT_TASK_CREATED_BY
     })
   );
+}
+
+function taskCreateRequestDigestFromTask(task: TaskCard): string {
+  return sha256Hex(
+    canonicalJson({
+      type: task.type,
+      title: task.title,
+      question_or_goal: task.question_or_goal,
+      inference_budget: task.inference_budget,
+      created_by: task.created_by
+    })
+  );
+}
+
+function idempotencyResultBindingError(): TaskServiceError {
+  return new TaskServiceError({
+    code: "record_malformed",
+    status: 500,
+    category: "workspace_error",
+    message: "Completed idempotency result is not bound to the task create request.",
+    userMessage: "The idempotency result cannot be used safely.",
+    evidenceRefs: ["workspace/tasks/_idempotency/task", "idempotency.result_ref"],
+    retryable: false,
+    recommendedNextActions: ["Inspect and repair the idempotency record before retrying."]
+  });
 }
 
 function parseIdempotencyKey(c: Context): ParsedIdempotencyKey {

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import { access, lstat, mkdir, unlink, writeFile } from "node:fs/promises";
 import { dirname, join, parse, resolve, sep } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 import {
   DEFAULT_TASK_CREATED_BY,
   CreateTaskInputSchema,
@@ -144,7 +145,6 @@ export function createBackendApi(options: BackendApiOptions = {}): Hono {
     workspaceRoot,
     now: options.now
   });
-  const taskCreateIdempotencyInflight = new Map<string, TaskCreateIdempotencyInflight>();
 
   app.post("/api/workspace/init", async (c) => {
     try {
@@ -198,8 +198,13 @@ export function createBackendApi(options: BackendApiOptions = {}): Hono {
       );
     }
 
-    const idempotencyKey = nonblankIdempotencyKey(c);
-    if (!idempotencyKey) {
+    let idempotencyKey: ParsedIdempotencyKey;
+    try {
+      idempotencyKey = parseIdempotencyKey(c);
+    } catch (error) {
+      return jsonTaskServiceError(c, error);
+    }
+    if (idempotencyKey.status === "absent") {
       try {
         return c.json(await taskService.createTask(parsedBody.data), 201);
       } catch (error) {
@@ -208,39 +213,17 @@ export function createBackendApi(options: BackendApiOptions = {}): Hono {
     }
 
     const requestDigest = taskCreateRequestDigest(parsedBody.data);
-    const inflightKey = `task:${sha256Hex(idempotencyKey)}`;
-    const existingInflight = taskCreateIdempotencyInflight.get(inflightKey);
-    if (existingInflight) {
-      if (existingInflight.requestDigest !== requestDigest) {
-        return jsonTaskServiceError(c, createIdempotencyMismatchError());
-      }
-
-      try {
-        const result = await existingInflight.promise;
-        return c.json(result.task, 200);
-      } catch (error) {
-        return jsonTaskServiceError(c, error);
-      }
-    }
-
-    const promise = createIdempotentTaskCard({
-      input: parsedBody.data,
-      idempotencyKey,
-      requestDigest,
-      taskService,
-      idempotencyService
-    });
-    taskCreateIdempotencyInflight.set(inflightKey, { requestDigest, promise });
-
     try {
-      const result = await promise;
+      const result = await createIdempotentTaskCard({
+        input: parsedBody.data,
+        idempotencyKey: idempotencyKey.key,
+        requestDigest,
+        taskService,
+        idempotencyService
+      });
       return c.json(result.task, result.created ? 201 : 200);
     } catch (error) {
       return jsonTaskServiceError(c, error);
-    } finally {
-      if (taskCreateIdempotencyInflight.get(inflightKey)?.promise === promise) {
-        taskCreateIdempotencyInflight.delete(inflightKey);
-      }
     }
   });
 
@@ -301,10 +284,10 @@ export function createBackendApi(options: BackendApiOptions = {}): Hono {
   return app;
 }
 
-interface TaskCreateIdempotencyInflight {
-  requestDigest: string;
-  promise: Promise<IdempotentTaskCreateResult>;
-}
+const IDEMPOTENCY_REPLAY_WAIT_TIMEOUT_MS = 1000;
+const IDEMPOTENCY_REPLAY_POLL_INTERVAL_MS = 10;
+
+type ParsedIdempotencyKey = { status: "absent" } | { status: "present"; key: string };
 
 interface IdempotentTaskCreateResult {
   task: TaskCard;
@@ -322,31 +305,98 @@ interface CreateIdempotentTaskCardInput {
 async function createIdempotentTaskCard(
   input: CreateIdempotentTaskCardInput
 ): Promise<IdempotentTaskCreateResult> {
-  const replay = await input.idempotencyService.lookupReplay({
+  const begin = await input.idempotencyService.beginRecord({
     scope: "task",
     key: input.idempotencyKey,
     requestDigest: input.requestDigest
   });
 
-  if (replay.status === "mismatch") {
+  if (begin.status === "mismatch") {
     throw createIdempotencyMismatchError();
   }
-  if (replay.status === "completed") {
+  if (begin.status === "completed") {
     return {
-      task: await input.taskService.getTask(replay.record.result_ref),
+      task: await input.taskService.getTask(begin.record.result_ref),
       created: false
     };
   }
+  if (begin.status === "incomplete") {
+    return await waitForIdempotentTaskCompletion(input);
+  }
 
-  const task = await input.taskService.createTask(input.input);
-  await input.idempotencyService.completeRecord({
-    scope: "task",
-    key: input.idempotencyKey,
-    requestDigest: input.requestDigest,
-    resultRef: task.task_id
-  });
+  let task: TaskCard;
+  try {
+    task = await input.taskService.createTask(input.input);
+  } catch (error) {
+    await input.idempotencyService
+      .failRecord({
+        scope: "task",
+        key: input.idempotencyKey,
+        requestDigest: input.requestDigest
+      })
+      .catch(() => undefined);
+    throw error;
+  }
+
+  try {
+    await input.idempotencyService.completeRecord({
+      scope: "task",
+      key: input.idempotencyKey,
+      requestDigest: input.requestDigest,
+      resultRef: task.task_id
+    });
+  } catch (error) {
+    await input.taskService.rollbackTaskForIdempotency(task.task_id);
+    await input.idempotencyService
+      .failRecord({
+        scope: "task",
+        key: input.idempotencyKey,
+        requestDigest: input.requestDigest
+      })
+      .catch(() => undefined);
+    throw error;
+  }
 
   return { task, created: true };
+}
+
+async function waitForIdempotentTaskCompletion(
+  input: CreateIdempotentTaskCardInput
+): Promise<IdempotentTaskCreateResult> {
+  const deadline = Date.now() + IDEMPOTENCY_REPLAY_WAIT_TIMEOUT_MS;
+
+  for (;;) {
+    const replay = await input.idempotencyService.lookupReplay({
+      scope: "task",
+      key: input.idempotencyKey,
+      requestDigest: input.requestDigest
+    });
+
+    if (replay.status === "mismatch") {
+      throw createIdempotencyMismatchError();
+    }
+    if (replay.status === "completed") {
+      return {
+        task: await input.taskService.getTask(replay.record.result_ref),
+        created: false
+      };
+    }
+
+    if (Date.now() >= deadline) {
+      throw new TaskServiceError({
+        code: "record_malformed",
+        status: 500,
+        category: "workspace_error",
+        message: "Idempotency record did not complete before replay timeout.",
+        userMessage: "The task create request is still pending idempotency completion.",
+        evidenceRefs: ["workspace/tasks/_idempotency/task"],
+        retryable: true,
+        recommendedNextActions: ["Retry after the in-progress task create request finishes."]
+      });
+    }
+
+    await sleep(IDEMPOTENCY_REPLAY_POLL_INTERVAL_MS);
+  }
 }
 
 function taskCreateRequestDigest(input: CreateTaskInput): string {
@@ -358,14 +408,27 @@ function taskCreateRequestDigest(input: CreateTaskInput): string {
   );
 }
 
-function nonblankIdempotencyKey(c: Context): string | undefined {
+function parseIdempotencyKey(c: Context): ParsedIdempotencyKey {
   const header = c.req.header("Idempotency-Key");
   if (typeof header !== "string") {
-    return undefined;
+    return { status: "absent" };
   }
 
   const trimmedHeader = header.trim();
-  return trimmedHeader.length > 0 ? trimmedHeader : undefined;
+  if (trimmedHeader.length > 0) {
+    return { status: "present", key: trimmedHeader };
+  }
+
+  throw new TaskServiceError({
+    code: "schema_error",
+    status: 400,
+    category: "schema_error",
+    message: "Idempotency-Key header must be nonblank when provided.",
+    userMessage: "The idempotency key must be nonblank when provided.",
+    evidenceRefs: ["request.headers.Idempotency-Key"],
+    retryable: false,
+    recommendedNextActions: ["Provide a nonblank idempotency key or omit the header."]
+  });
 }
 
 function jsonTaskServiceError(c: Context, error: unknown): Response {

--- a/packages/core/src/domain/services/artifact-registry-service.ts
+++ b/packages/core/src/domain/services/artifact-registry-service.ts
@@ -1,8 +1,10 @@
 import { join, resolve } from "node:path";
 import { ArtifactSchema, ArtifactTypeSchema, type Artifact } from "../schemas/artifact";
+import { TaskServiceError } from "./task-card-service";
 import {
   assertSafeRecordSegment,
   assertSafeRelativeRecordPath,
+  createJsonRecordIfAbsent,
   readJsonRecord,
   workspaceRecordPath,
   writeJsonRecord
@@ -29,31 +31,44 @@ export function createArtifactRegistryService(
         assertSafeRecordSegment(parsedArtifact.data.artifact_id, "artifact.artifact_id");
         assertSafeRelativeRecordPath(parsedArtifact.data.path, "artifact.path");
         ArtifactTypeSchema.parse(parsedArtifact.data.type);
+
+        const created = await createJsonRecordIfAbsent(
+          workspaceRoot,
+          artifactManifestDirectorySegments(),
+          artifactManifestFileName(parsedArtifact.data.artifact_id),
+          parsedArtifact.data,
+          artifactManifestEvidenceRef(parsedArtifact.data.artifact_id),
+          ArtifactSchema
+        );
+        if (created.status === "created") {
+          return created.record;
+        }
+
+        const existing = await readArtifactManifest(workspaceRoot, parsedArtifact.data.artifact_id);
+        if (existing && canonicalJson(existing) === canonicalJson(parsedArtifact.data)) {
+          return existing;
+        }
+
+        throw artifactManifestImmutableError(parsedArtifact.data.artifact_id);
       }
 
       return await writeJsonRecord(
         workspaceRoot,
         artifactManifestDirectorySegments(),
-        parsedArtifact.success
-          ? artifactManifestFileName(parsedArtifact.data.artifact_id)
-          : "invalid.json",
+        "invalid.json",
         artifact,
-        parsedArtifact.success
-          ? artifactManifestEvidenceRef(parsedArtifact.data.artifact_id)
-          : "workspace/artifacts/manifests",
+        "workspace/artifacts/manifests",
         ArtifactSchema
       );
     },
 
     async getArtifact(artifactId: string): Promise<Artifact | undefined> {
       assertSafeRecordSegment(artifactId, "artifact.artifact_id");
-      const recordPath = workspaceRecordPath(
-        workspaceRoot,
-        [...artifactManifestDirectorySegments(), artifactManifestFileName(artifactId)],
-        artifactManifestEvidenceRef(artifactId)
-      );
-
-      return await readJsonRecord(recordPath, artifactManifestEvidenceRef(artifactId), ArtifactSchema);
+      const artifact = await readArtifactManifest(workspaceRoot, artifactId);
+      if (!artifact) {
+        return undefined;
+      }
+      return artifact;
     }
   };
 }
@@ -69,4 +84,71 @@ export function artifactManifestFileName(artifactId: string): string {
 
 export function artifactManifestEvidenceRef(artifactId: string): string {
   return join("workspace", "artifacts", "manifests", artifactManifestFileName(artifactId));
+}
+
+async function readArtifactManifest(
+  workspaceRoot: string,
+  artifactId: string
+): Promise<Artifact | undefined> {
+  const recordPath = workspaceRecordPath(
+    workspaceRoot,
+    [...artifactManifestDirectorySegments(), artifactManifestFileName(artifactId)],
+    artifactManifestEvidenceRef(artifactId)
+  );
+  const artifact = await readJsonRecord(
+    recordPath,
+    artifactManifestEvidenceRef(artifactId),
+    ArtifactSchema
+  );
+  if (!artifact) {
+    return undefined;
+  }
+  assertArtifactLookupIdentity(artifact, artifactId);
+  return artifact;
+}
+
+function assertArtifactLookupIdentity(artifact: Artifact, artifactId: string): void {
+  if (artifact.artifact_id === artifactId) {
+    return;
+  }
+
+  throw new TaskServiceError({
+    code: "record_malformed",
+    status: 500,
+    category: "workspace_error",
+    message: "Artifact manifest identity does not match its lookup path.",
+    userMessage: "The artifact manifest cannot be used safely.",
+    evidenceRefs: [artifactManifestEvidenceRef(artifactId), "artifact.artifact_id"],
+    retryable: false,
+    recommendedNextActions: ["Inspect and repair the artifact manifest before retrying."]
+  });
+}
+
+function artifactManifestImmutableError(artifactId: string): TaskServiceError {
+  return new TaskServiceError({
+    code: "record_schema_error",
+    status: 400,
+    category: "schema_error",
+    message: "Artifact manifest already exists with different metadata.",
+    userMessage: "An existing artifact manifest cannot be overwritten.",
+    evidenceRefs: [artifactManifestEvidenceRef(artifactId), "artifact.artifact_id"],
+    retryable: false,
+    recommendedNextActions: ["Use the existing artifact manifest or choose a new artifact id."]
+  });
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .filter((key) => record[key] !== undefined)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value);
 }

--- a/packages/core/src/domain/services/artifact-registry-service.ts
+++ b/packages/core/src/domain/services/artifact-registry-service.ts
@@ -1,0 +1,72 @@
+import { join, resolve } from "node:path";
+import { ArtifactSchema, ArtifactTypeSchema, type Artifact } from "../schemas/artifact";
+import {
+  assertSafeRecordSegment,
+  assertSafeRelativeRecordPath,
+  readJsonRecord,
+  workspaceRecordPath,
+  writeJsonRecord
+} from "./workspace-record-store";
+
+export interface ArtifactRegistryServiceOptions {
+  workspaceRoot: string;
+}
+
+export interface ArtifactRegistryService {
+  registerArtifact: (artifact: Artifact) => Promise<Artifact>;
+  getArtifact: (artifactId: string) => Promise<Artifact | undefined>;
+}
+
+export function createArtifactRegistryService(
+  options: ArtifactRegistryServiceOptions
+): ArtifactRegistryService {
+  const workspaceRoot = resolve(options.workspaceRoot);
+
+  return {
+    async registerArtifact(artifact: Artifact): Promise<Artifact> {
+      const parsedArtifact = ArtifactSchema.safeParse(artifact);
+      if (parsedArtifact.success) {
+        assertSafeRecordSegment(parsedArtifact.data.artifact_id, "artifact.artifact_id");
+        assertSafeRelativeRecordPath(parsedArtifact.data.path, "artifact.path");
+        ArtifactTypeSchema.parse(parsedArtifact.data.type);
+      }
+
+      return await writeJsonRecord(
+        workspaceRoot,
+        artifactManifestDirectorySegments(),
+        parsedArtifact.success
+          ? artifactManifestFileName(parsedArtifact.data.artifact_id)
+          : "invalid.json",
+        artifact,
+        parsedArtifact.success
+          ? artifactManifestEvidenceRef(parsedArtifact.data.artifact_id)
+          : "workspace/artifacts/manifests",
+        ArtifactSchema
+      );
+    },
+
+    async getArtifact(artifactId: string): Promise<Artifact | undefined> {
+      assertSafeRecordSegment(artifactId, "artifact.artifact_id");
+      const recordPath = workspaceRecordPath(
+        workspaceRoot,
+        [...artifactManifestDirectorySegments(), artifactManifestFileName(artifactId)],
+        artifactManifestEvidenceRef(artifactId)
+      );
+
+      return await readJsonRecord(recordPath, artifactManifestEvidenceRef(artifactId), ArtifactSchema);
+    }
+  };
+}
+
+export function artifactManifestDirectorySegments(): readonly string[] {
+  return ["artifacts", "manifests"];
+}
+
+export function artifactManifestFileName(artifactId: string): string {
+  assertSafeRecordSegment(artifactId, "artifact.artifact_id");
+  return `${artifactId}.json`;
+}
+
+export function artifactManifestEvidenceRef(artifactId: string): string {
+  return join("workspace", "artifacts", "manifests", artifactManifestFileName(artifactId));
+}

--- a/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
+++ b/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
@@ -681,6 +681,96 @@ describe("idempotency, lock, and artifact services", () => {
     expectErrorNotToLeakRecordContent(error, secret);
   });
 
+  test("IdempotencyRecord lookup fails closed when stored key does not match the lookup path", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createIdempotencyRecordService({ workspaceRoot });
+    const lookupKey = "task:create:path-key-a";
+    const storedKey = "task:create:path-key-b-secret";
+    const requestDigest = "digest-record-key-mismatch";
+    const idempotencyDirectory = join(workspaceRoot, "tasks", "_idempotency", "task");
+    const recordPath = join(idempotencyDirectory, idempotencyRecordFileName(lookupKey));
+
+    await mkdir(idempotencyDirectory, { recursive: true });
+    await writeFile(
+      recordPath,
+      `${JSON.stringify({
+        key: storedKey,
+        scope: "task",
+        request_digest: requestDigest,
+        status: "completed",
+        result_ref: "TASK-wrong-key-replay",
+        created_at: "2026-07-07T13:37:00.000Z",
+        updated_at: "2026-07-07T13:37:00.000Z"
+      })}\n`,
+      { flag: "wx" }
+    );
+
+    const error = await captureTaskServiceError(() =>
+      service.lookupReplay({
+        scope: "task",
+        key: lookupKey,
+        requestDigest
+      })
+    );
+
+    expect(error.code).toBe("record_malformed");
+    expect(error.status).toBe(500);
+    expect(error.category).toBe("workspace_error");
+    expect(error.evidenceRefs).toEqual([
+      idempotencyRecordEvidenceRef("task", lookupKey),
+      "idempotency.key",
+      "idempotency.scope"
+    ]);
+    expectErrorNotToLeakRecordContent(error, lookupKey);
+    expectErrorNotToLeakRecordContent(error, storedKey);
+    expectErrorNotToLeakRecordContent(error, "TASK-wrong-key-replay");
+  });
+
+  test("IdempotencyRecord lookup fails closed when stored scope does not match the lookup path", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createIdempotencyRecordService({ workspaceRoot });
+    const lookupKey = "task:create:path-scope-a";
+    const requestDigest = "digest-record-scope-mismatch";
+    const idempotencyDirectory = join(workspaceRoot, "tasks", "_idempotency", "task");
+    const recordPath = join(idempotencyDirectory, idempotencyRecordFileName(lookupKey));
+
+    await mkdir(idempotencyDirectory, { recursive: true });
+    await writeFile(
+      recordPath,
+      `${JSON.stringify({
+        key: lookupKey,
+        scope: "job",
+        request_digest: requestDigest,
+        status: "completed",
+        result_ref: "TASK-wrong-scope-replay",
+        created_at: "2026-07-07T13:38:00.000Z",
+        updated_at: "2026-07-07T13:38:00.000Z"
+      })}\n`,
+      { flag: "wx" }
+    );
+
+    const error = await captureTaskServiceError(() =>
+      service.lookupReplay({
+        scope: "task",
+        key: lookupKey,
+        requestDigest
+      })
+    );
+
+    expect(error.code).toBe("record_malformed");
+    expect(error.status).toBe(500);
+    expect(error.category).toBe("workspace_error");
+    expect(error.evidenceRefs).toEqual([
+      idempotencyRecordEvidenceRef("task", lookupKey),
+      "idempotency.key",
+      "idempotency.scope"
+    ]);
+    expectErrorNotToLeakRecordContent(error, lookupKey);
+    expectErrorNotToLeakRecordContent(error, "TASK-wrong-scope-replay");
+  });
+
   test("LockRecord store/get validates schema and uses direct lookup paths", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);

--- a/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
+++ b/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
@@ -17,6 +17,7 @@ import {
   TaskServiceError,
   createArtifactRegistryService,
   createIdempotencyRecordService,
+  createTaskCardService,
   createLockRecordService,
   idempotencyRecordEvidenceRef,
   idempotencyRecordFileName,
@@ -711,6 +712,7 @@ describe("idempotency, lock, and artifact services", () => {
 
     expect(begin.status).toBe("acquired");
     expect(error.code).toBe("record_malformed");
+    expect(error.status).toBe(409);
     expect(error.retryable).toBe(true);
     expect(error.evidenceRefs).toEqual([idempotencyRecordEvidenceRef("task", rawKey)]);
     expect(JSON.parse(await readFile(guardPath, "utf8"))).toEqual(guard);
@@ -865,10 +867,37 @@ describe("idempotency, lock, and artifact services", () => {
 
     expect(begin.status).toBe("acquired");
     expect(error.code).toBe("record_malformed");
+    expect(error.status).toBe(409);
     expect(error.retryable).toBe(true);
     expect(error.evidenceRefs).toEqual([idempotencyRecordEvidenceRef("task", rawKey)]);
     expect(JSON.parse(await readFile(cleanupLockPath, "utf8"))).toEqual(liveCleanupLock);
     expect(await service.getRecord("task", rawKey)).toEqual(begin.record);
+  });
+
+  test("TaskCard rollback evicts cached task when the durable lane is missing", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createTaskCardService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:35:58.000Z"),
+      taskIdFactory: () => "TASK-missing-lane-rollback"
+    });
+    const task = await service.createTask({
+      type: "engineering",
+      title: "Rollback missing lane",
+      question_or_goal: "Ensure rollback removes stale in-memory task state.",
+      inference_budget: { mode: "normal" },
+      created_by: "pi"
+    });
+
+    await rm(join(workspaceRoot, "tasks", task.task_id), { recursive: true, force: true });
+    await service.rollbackTaskForIdempotency(task.task_id);
+    const detailError = await captureTaskServiceError(() => service.getTask(task.task_id));
+
+    expect(await service.listTasks()).toEqual([]);
+    expect(detailError.code).toBe("task_not_found");
+    expect(detailError.status).toBe(404);
+    await expectPathMissing(join(workspaceRoot, "tasks", task.task_id));
   });
 
   test("IdempotencyRecord invalid schema is rejected without workspace files", async () => {

--- a/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
+++ b/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
@@ -20,6 +20,7 @@ import {
   createLockRecordService,
   idempotencyRecordEvidenceRef,
   idempotencyRecordFileName,
+  sha256Hex,
   type Artifact,
   type IdempotencyRecord,
   type IdempotencyRecordService,
@@ -449,6 +450,106 @@ describe("idempotency, lock, and artifact services", () => {
     expect(JSON.parse(await readFile(recordPath, "utf8"))).toEqual(completedRecord);
   });
 
+  test("IdempotencyRecord storeRecord preserves same-key digest immutability before completion", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    let currentTime = "2026-07-07T13:32:00.000Z";
+    const service = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date(currentTime)
+    });
+    const rawKey = "task:create:store-digest-immutable";
+    const requestDigest = "digest-original-body";
+    const started = await service.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+
+    const startedMismatch = await captureTaskServiceError(() =>
+      service.storeRecord({
+        ...started.record,
+        request_digest: "digest-different-body",
+        updated_at: "2026-07-07T13:32:01.000Z"
+      })
+    );
+    currentTime = "2026-07-07T13:33:00.000Z";
+    const failed = await service.failRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    const failedMismatch = await captureTaskServiceError(() =>
+      service.storeRecord({
+        ...failed,
+        request_digest: "digest-other-after-failure",
+        updated_at: "2026-07-07T13:33:01.000Z"
+      })
+    );
+    const retryStarted = await service.storeRecord({
+      ...failed,
+      status: "started",
+      created_at: "2026-07-07T13:34:00.000Z",
+      updated_at: "2026-07-07T13:34:00.000Z"
+    });
+
+    expect(started.status).toBe("acquired");
+    expect(startedMismatch.code).toBe("idempotency_mismatch");
+    expect(startedMismatch.status).toBe(422);
+    expect(failed.status).toBe("failed");
+    expect(failedMismatch.code).toBe("idempotency_mismatch");
+    expect(failedMismatch.status).toBe(422);
+    expect(retryStarted).toEqual({
+      ...failed,
+      status: "started",
+      created_at: "2026-07-07T13:34:00.000Z",
+      updated_at: "2026-07-07T13:34:00.000Z"
+    });
+    expect(await service.getRecord("task", rawKey)).toEqual(retryStarted);
+  });
+
+  test("IdempotencyRecord malformed transition guard fails bounded without completing", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:35:00.000Z")
+    });
+    const rawKey = "task:create:malformed-transition-guard";
+    const requestDigest = "digest-guard-body";
+    const begin = await service.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    const guardPath = join(
+      workspaceRoot,
+      "tasks",
+      "_idempotency",
+      "task",
+      `${sha256Hex(`transition:${rawKey}`)}.guard.json`
+    );
+    await writeFile(guardPath, "{", { flag: "wx" });
+
+    const error = await captureTaskServiceError(() =>
+      Promise.race([
+        service.completeRecord({
+          scope: "task",
+          key: rawKey,
+          requestDigest,
+          resultRef: "TASK-guard-should-not-complete"
+        }),
+        timeoutAfter(1_000, "completeRecord hung on malformed transition guard")
+      ])
+    );
+
+    expect(begin.status).toBe("acquired");
+    expect(error.code).toBe("record_malformed");
+    expect(error.category).toBe("workspace_error");
+    expect(error.evidenceRefs).toEqual([idempotencyRecordEvidenceRef("task", rawKey)]);
+    expect(await service.getRecord("task", rawKey)).toEqual(begin.record);
+  });
+
   test("IdempotencyRecord invalid schema is rejected without workspace files", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -506,6 +607,47 @@ describe("idempotency, lock, and artifact services", () => {
     expect(error.category).toBe("workspace_error");
     expect(error.evidenceRefs).toEqual([idempotencyRecordEvidenceRef("task", rawKey)]);
     expectErrorNotToLeakRecordContent(error, secret);
+  });
+
+  test("small IdempotencyRecord reads allocate by record size instead of the full service cap", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:36:00.000Z")
+    });
+    const rawKey = "task:create:small-record-allocation";
+    const requestDigest = "digest-small-record";
+    await service.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    const completed = await service.completeRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest,
+      resultRef: "TASK-small-record"
+    });
+    const allocations: number[] = [];
+    const mutableBuffer = Buffer as typeof Buffer & {
+      allocUnsafe: typeof Buffer.allocUnsafe;
+    };
+    const originalAllocUnsafe = mutableBuffer.allocUnsafe;
+    mutableBuffer.allocUnsafe = ((size: number) => {
+      allocations.push(size);
+      return originalAllocUnsafe(size);
+    }) as typeof Buffer.allocUnsafe;
+
+    try {
+      expect(await service.getRecord("task", rawKey)).toEqual(completed);
+    } finally {
+      mutableBuffer.allocUnsafe = originalAllocUnsafe;
+    }
+
+    expect(allocations.length).toBeGreaterThan(0);
+    expect(allocations).not.toContain(MAX_SERVICE_RECORD_BYTES + 1);
+    expect(Math.max(...allocations)).toBeLessThan(4096);
   });
 
   test("symlinked IdempotencyRecord leaf fails closed without hydrating outside record", async () => {
@@ -732,6 +874,11 @@ async function expectPathMissing(path: string): Promise<void> {
   }
 
   throw new Error(`Expected path to be missing: ${path}`);
+}
+
+async function timeoutAfter(milliseconds: number, message: string): Promise<never> {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
+  throw new Error(message);
 }
 
 function validIdempotencyRecord(): IdempotencyRecord {

--- a/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
+++ b/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
@@ -423,10 +423,12 @@ describe("idempotency, lock, and artifact services", () => {
       idempotencyRecordFileName(rawKey)
     );
 
-    const sameRecord = await service.storeRecord({
-      ...completedRecord,
-      updated_at: "2026-07-07T13:31:00.000Z"
-    });
+    const sameRecordError = await captureTaskServiceError(() =>
+      service.storeRecord({
+        ...completedRecord,
+        updated_at: "2026-07-07T13:31:00.000Z"
+      })
+    );
     const overwriteError = await captureTaskServiceError(() =>
       service.storeRecord({
         ...completedRecord,
@@ -442,7 +444,8 @@ describe("idempotency, lock, and artifact services", () => {
     });
 
     expect(begin.status).toBe("acquired");
-    expect(sameRecord).toEqual(completedRecord);
+    expect(sameRecordError.code).toBe("record_schema_error");
+    expect(sameRecordError.category).toBe("schema_error");
     expect(overwriteError.code).toBe("record_schema_error");
     expect(overwriteError.category).toBe("schema_error");
     expect(completedAgain).toEqual(completedRecord);
@@ -539,7 +542,7 @@ describe("idempotency, lock, and artifact services", () => {
     expect(completed.result_ref).toBe("TASK-guarded-complete");
   });
 
-  test("IdempotencyRecord storeRecord preserves same-key digest immutability before completion", async () => {
+  test("IdempotencyRecord storeRecord rejects direct nonterminal transitions and preserves records", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
     let currentTime = "2026-07-07T13:32:00.000Z";
@@ -555,6 +558,12 @@ describe("idempotency, lock, and artifact services", () => {
       requestDigest
     });
 
+    const sameDigestStartedOverwrite = await captureTaskServiceError(() =>
+      service.storeRecord({
+        ...started.record,
+        updated_at: "2026-07-07T13:32:01.000Z"
+      })
+    );
     const startedMismatch = await captureTaskServiceError(() =>
       service.storeRecord({
         ...started.record,
@@ -562,6 +571,15 @@ describe("idempotency, lock, and artifact services", () => {
         updated_at: "2026-07-07T13:32:01.000Z"
       })
     );
+    const startedToFailed = await captureTaskServiceError(() =>
+      service.storeRecord({
+        ...started.record,
+        status: "failed",
+        updated_at: "2026-07-07T13:32:02.000Z"
+      })
+    );
+    expect(await service.getRecord("task", rawKey)).toEqual(started.record);
+
     currentTime = "2026-07-07T13:33:00.000Z";
     const failed = await service.failRecord({
       scope: "task",
@@ -575,26 +593,38 @@ describe("idempotency, lock, and artifact services", () => {
         updated_at: "2026-07-07T13:33:01.000Z"
       })
     );
-    const retryStarted = await service.storeRecord({
-      ...failed,
+    const failedToStarted = await captureTaskServiceError(() =>
+      service.storeRecord({
+        ...failed,
+        status: "started",
+        created_at: "2026-07-07T13:34:00.000Z",
+        updated_at: "2026-07-07T13:34:00.000Z"
+      })
+    );
+
+    const seedService = createIdempotencyRecordService({ workspaceRoot });
+    const seeded = await seedService.storeRecord({
+      key: "task:create:seed-started",
+      scope: "task",
+      request_digest: "digest-seeded",
       status: "started",
-      created_at: "2026-07-07T13:34:00.000Z",
-      updated_at: "2026-07-07T13:34:00.000Z"
+      created_at: "2026-07-07T13:35:00.000Z",
+      updated_at: "2026-07-07T13:35:00.000Z"
     });
 
     expect(started.status).toBe("acquired");
+    expect(sameDigestStartedOverwrite.code).toBe("record_schema_error");
+    expect(sameDigestStartedOverwrite.status).toBe(400);
     expect(startedMismatch.code).toBe("idempotency_mismatch");
     expect(startedMismatch.status).toBe(422);
+    expect(startedToFailed.code).toBe("record_schema_error");
     expect(failed.status).toBe("failed");
     expect(failedMismatch.code).toBe("idempotency_mismatch");
     expect(failedMismatch.status).toBe(422);
-    expect(retryStarted).toEqual({
-      ...failed,
-      status: "started",
-      created_at: "2026-07-07T13:34:00.000Z",
-      updated_at: "2026-07-07T13:34:00.000Z"
-    });
-    expect(await service.getRecord("task", rawKey)).toEqual(retryStarted);
+    expect(failedToStarted.code).toBe("record_schema_error");
+    expect(await service.getRecord("task", rawKey)).toEqual(failed);
+    expect(seeded.status).toBe("started");
+    expect(await seedService.getRecord("task", "task:create:seed-started")).toEqual(seeded);
   });
 
   test("IdempotencyRecord malformed transition guard fails bounded without completing", async () => {
@@ -684,6 +714,160 @@ describe("idempotency, lock, and artifact services", () => {
     expect(error.retryable).toBe(true);
     expect(error.evidenceRefs).toEqual([idempotencyRecordEvidenceRef("task", rawKey)]);
     expect(JSON.parse(await readFile(guardPath, "utf8"))).toEqual(guard);
+    expect(await service.getRecord("task", rawKey)).toEqual(begin.record);
+  });
+
+  test("IdempotencyRecord stale transition guard cleanup preserves a fresh replacement guard", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const rawKey = "task:create:stale-guard-fresh-replacement";
+    const requestDigest = "digest-stale-guard-fresh";
+    const seedService = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:35:40.000Z")
+    });
+    const begin = await seedService.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    const failed = await seedService.failRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    const guardPath = join(
+      workspaceRoot,
+      "tasks",
+      "_idempotency",
+      "task",
+      `${sha256Hex(`transition:${rawKey}`)}.guard.json`
+    );
+    const staleGuard = {
+      guard_id: "stale-observed-guard",
+      owner_pid: 9_999_999,
+      acquired_at_ms: Date.now() - 31_000,
+      acquired_at: "2026-07-07T13:34:00.000Z"
+    };
+    const freshGuard = {
+      guard_id: "fresh-replacement-guard",
+      owner_pid: process.pid,
+      acquired_at_ms: Date.now(),
+      acquired_at: new Date().toISOString()
+    };
+    await writeFile(guardPath, `${JSON.stringify(staleGuard)}\n`, { flag: "wx" });
+    let cleanupHookCalls = 0;
+    const retryService = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:35:41.000Z"),
+      transitionGuardHooks: {
+        beforeStaleGuardCleanup: async ({ guardPath: observedPath, observedGuard }) => {
+          cleanupHookCalls += 1;
+          expect(observedPath).toBe(guardPath);
+          expect(observedGuard).toEqual(staleGuard);
+          await rm(observedPath, { force: true });
+          await writeFile(observedPath, `${JSON.stringify(freshGuard)}\n`, { flag: "wx" });
+        }
+      }
+    });
+
+    const retry = await Promise.race([
+      retryService.beginRecord({
+        scope: "task",
+        key: rawKey,
+        requestDigest
+      }),
+      timeoutAfter(1_000, "beginRecord hung while preserving a fresh replacement guard")
+    ]);
+
+    expect(begin.status).toBe("acquired");
+    expect(failed.status).toBe("failed");
+    expect(cleanupHookCalls).toBe(1);
+    expect(retry).toEqual({ status: "incomplete", record: failed });
+    expect(JSON.parse(await readFile(guardPath, "utf8"))).toEqual(freshGuard);
+    expect(await seedService.getRecord("task", rawKey)).toEqual(failed);
+  });
+
+  test("IdempotencyRecord stale transition cleanup lock is recoverable before completion", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const rawKey = "task:create:stale-cleanup-lock-complete";
+    const requestDigest = "digest-stale-cleanup-lock";
+    const service = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:35:50.000Z")
+    });
+    const begin = await service.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    const cleanupLockPath = idempotencyTransitionCleanupLockPath(workspaceRoot, rawKey);
+    const staleCleanupLock = {
+      guard_id: "stale-cleanup-lock",
+      owner_pid: 9_999_999,
+      acquired_at_ms: Date.now() - 31_000,
+      acquired_at: "2026-07-07T13:34:30.000Z"
+    };
+    await writeFile(cleanupLockPath, `${JSON.stringify(staleCleanupLock)}\n`, { flag: "wx" });
+
+    const completed = await Promise.race([
+      service.completeRecord({
+        scope: "task",
+        key: rawKey,
+        requestDigest,
+        resultRef: "TASK-cleanup-lock-recovered"
+      }),
+      timeoutAfter(1_000, "completeRecord hung on stale transition cleanup lock")
+    ]);
+
+    expect(begin.status).toBe("acquired");
+    expect(completed.status).toBe("completed");
+    expect(completed.result_ref).toBe("TASK-cleanup-lock-recovered");
+    await expectPathMissing(cleanupLockPath);
+    expect(await service.getRecord("task", rawKey)).toEqual(completed);
+  });
+
+  test("IdempotencyRecord live transition cleanup lock stays busy and is not deleted", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const rawKey = "task:create:live-cleanup-lock-complete";
+    const requestDigest = "digest-live-cleanup-lock";
+    const service = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:35:55.000Z")
+    });
+    const begin = await service.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    const cleanupLockPath = idempotencyTransitionCleanupLockPath(workspaceRoot, rawKey);
+    const liveCleanupLock = {
+      guard_id: "live-cleanup-lock",
+      owner_pid: process.pid,
+      acquired_at_ms: Date.now(),
+      acquired_at: new Date().toISOString()
+    };
+    await writeFile(cleanupLockPath, `${JSON.stringify(liveCleanupLock)}\n`, { flag: "wx" });
+
+    const error = await captureTaskServiceError(() =>
+      Promise.race([
+        service.completeRecord({
+          scope: "task",
+          key: rawKey,
+          requestDigest,
+          resultRef: "TASK-cleanup-lock-live"
+        }),
+        timeoutAfter(1_000, "completeRecord hung on live transition cleanup lock")
+      ])
+    );
+
+    expect(begin.status).toBe("acquired");
+    expect(error.code).toBe("record_malformed");
+    expect(error.retryable).toBe(true);
+    expect(error.evidenceRefs).toEqual([idempotencyRecordEvidenceRef("task", rawKey)]);
+    expect(JSON.parse(await readFile(cleanupLockPath, "utf8"))).toEqual(liveCleanupLock);
     expect(await service.getRecord("task", rawKey)).toEqual(begin.record);
   });
 
@@ -1013,6 +1197,21 @@ describe("idempotency, lock, and artifact services", () => {
 
     expect(pathError.code).toBe("record_id_not_safe");
     await expectPathMissing(join(invalidPath.workspaceRoot, "artifacts"));
+
+    const interiorTraversal = await createTempWorkspacePath();
+    tempRoots.push(interiorTraversal.tempRoot);
+    const interiorPathService = createArtifactRegistryService({
+      workspaceRoot: interiorTraversal.workspaceRoot
+    });
+    const interiorPathError = await captureTaskServiceError(() =>
+      interiorPathService.registerArtifact({
+        ...validArtifact(),
+        path: "artifacts/reports/TASK-0001/../report.md"
+      })
+    );
+
+    expect(interiorPathError.code).toBe("record_id_not_safe");
+    await expectPathMissing(join(interiorTraversal.workspaceRoot, "artifacts"));
   });
 
   test("LockRecord and Artifact lookups fail closed on stored identity mismatch", async () => {
@@ -1196,6 +1395,16 @@ async function expectPathMissing(path: string): Promise<void> {
   }
 
   throw new Error(`Expected path to be missing: ${path}`);
+}
+
+function idempotencyTransitionCleanupLockPath(workspaceRoot: string, key: string): string {
+  return join(
+    workspaceRoot,
+    "tasks",
+    "_idempotency",
+    "task",
+    `${sha256Hex(`transition-cleanup:${key}`)}.guard-cleanup`
+  );
 }
 
 async function timeoutAfter(milliseconds: number, message: string): Promise<never> {

--- a/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
+++ b/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
@@ -450,6 +450,95 @@ describe("idempotency, lock, and artifact services", () => {
     expect(JSON.parse(await readFile(recordPath, "utf8"))).toEqual(completedRecord);
   });
 
+  test("IdempotencyRecord storeRecord rejects public completed bypasses", async () => {
+    const fresh = await createTempWorkspacePath();
+    tempRoots.push(fresh.tempRoot);
+    const freshService = createIdempotencyRecordService({ workspaceRoot: fresh.workspaceRoot });
+    const freshError = await captureTaskServiceError(() =>
+      freshService.storeRecord(validIdempotencyRecord())
+    );
+
+    expect(freshError.code).toBe("record_schema_error");
+    expect(freshError.category).toBe("schema_error");
+    await expectPathMissing(join(fresh.workspaceRoot, "tasks"));
+
+    const started = await createTempWorkspacePath();
+    tempRoots.push(started.tempRoot);
+    const startedService = createIdempotencyRecordService({
+      workspaceRoot: started.workspaceRoot,
+      now: () => new Date("2026-07-07T13:31:10.000Z")
+    });
+    const startedBegin = await startedService.beginRecord({
+      scope: "task",
+      key: "task:create:started-bypass",
+      requestDigest: "digest-started-bypass"
+    });
+    const startedError = await captureTaskServiceError(() =>
+      startedService.storeRecord({
+        ...startedBegin.record,
+        status: "completed",
+        result_ref: "TASK-started-bypass"
+      })
+    );
+
+    expect(startedBegin.status).toBe("acquired");
+    expect(startedError.code).toBe("record_schema_error");
+    expect(await startedService.getRecord("task", "task:create:started-bypass")).toEqual(
+      startedBegin.record
+    );
+
+    const failed = await createTempWorkspacePath();
+    tempRoots.push(failed.tempRoot);
+    const failedService = createIdempotencyRecordService({
+      workspaceRoot: failed.workspaceRoot,
+      now: () => new Date("2026-07-07T13:31:20.000Z")
+    });
+    const failedBegin = await failedService.beginRecord({
+      scope: "task",
+      key: "task:create:failed-bypass",
+      requestDigest: "digest-failed-bypass"
+    });
+    const failedRecord = await failedService.failRecord({
+      scope: "task",
+      key: "task:create:failed-bypass",
+      requestDigest: "digest-failed-bypass"
+    });
+    const failedError = await captureTaskServiceError(() =>
+      failedService.storeRecord({
+        ...failedRecord,
+        status: "completed",
+        result_ref: "TASK-failed-bypass"
+      })
+    );
+
+    expect(failedBegin.status).toBe("acquired");
+    expect(failedError.code).toBe("record_schema_error");
+    expect(await failedService.getRecord("task", "task:create:failed-bypass")).toEqual(
+      failedRecord
+    );
+
+    const guarded = await createTempWorkspacePath();
+    tempRoots.push(guarded.tempRoot);
+    const guardedService = createIdempotencyRecordService({
+      workspaceRoot: guarded.workspaceRoot,
+      now: () => new Date("2026-07-07T13:31:30.000Z")
+    });
+    await guardedService.beginRecord({
+      scope: "task",
+      key: "task:create:guarded-complete",
+      requestDigest: "digest-guarded-complete"
+    });
+    const completed = await guardedService.completeRecord({
+      scope: "task",
+      key: "task:create:guarded-complete",
+      requestDigest: "digest-guarded-complete",
+      resultRef: "TASK-guarded-complete"
+    });
+
+    expect(completed.status).toBe("completed");
+    expect(completed.result_ref).toBe("TASK-guarded-complete");
+  });
+
   test("IdempotencyRecord storeRecord preserves same-key digest immutability before completion", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -547,6 +636,54 @@ describe("idempotency, lock, and artifact services", () => {
     expect(error.code).toBe("record_malformed");
     expect(error.category).toBe("workspace_error");
     expect(error.evidenceRefs).toEqual([idempotencyRecordEvidenceRef("task", rawKey)]);
+    expect(await service.getRecord("task", rawKey)).toEqual(begin.record);
+  });
+
+  test("IdempotencyRecord rollback recovery preserves a valid busy transition guard", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:35:30.000Z")
+    });
+    const rawKey = "task:create:busy-guard-rollback-recovery";
+    const requestDigest = "digest-busy-guard-rollback";
+    const begin = await service.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    const guardPath = join(
+      workspaceRoot,
+      "tasks",
+      "_idempotency",
+      "task",
+      `${sha256Hex(`transition:${rawKey}`)}.guard.json`
+    );
+    const guard = {
+      guard_id: "rollback-recovery-busy-guard",
+      owner_pid: process.pid,
+      acquired_at_ms: Date.now(),
+      acquired_at: new Date().toISOString()
+    };
+    await writeFile(guardPath, `${JSON.stringify(guard)}\n`, { flag: "wx" });
+
+    const error = await captureTaskServiceError(() =>
+      Promise.race([
+        service.recoverFailedRecordAfterRollback({
+          scope: "task",
+          key: rawKey,
+          requestDigest
+        }),
+        timeoutAfter(1_000, "recoverFailedRecordAfterRollback hung on valid busy guard")
+      ])
+    );
+
+    expect(begin.status).toBe("acquired");
+    expect(error.code).toBe("record_malformed");
+    expect(error.retryable).toBe(true);
+    expect(error.evidenceRefs).toEqual([idempotencyRecordEvidenceRef("task", rawKey)]);
+    expect(JSON.parse(await readFile(guardPath, "utf8"))).toEqual(guard);
     expect(await service.getRecord("task", rawKey)).toEqual(begin.record);
   });
 
@@ -876,6 +1013,101 @@ describe("idempotency, lock, and artifact services", () => {
 
     expect(pathError.code).toBe("record_id_not_safe");
     await expectPathMissing(join(invalidPath.workspaceRoot, "artifacts"));
+  });
+
+  test("LockRecord and Artifact lookups fail closed on stored identity mismatch", async () => {
+    const lockCase = await createTempWorkspacePath();
+    tempRoots.push(lockCase.tempRoot);
+    const lockService = createLockRecordService({ workspaceRoot: lockCase.workspaceRoot });
+    const lookupLock = validLockRecord();
+    const storedLock = {
+      ...lookupLock,
+      lock_id: "LOCK-secret-foreign",
+      scope: "job"
+    } satisfies LockRecord;
+    const lockPath = join(
+      lockCase.workspaceRoot,
+      "locks",
+      "task",
+      `${lookupLock.lock_id}.json`
+    );
+    await mkdir(join(lockCase.workspaceRoot, "locks", "task"), { recursive: true });
+    await writeFile(lockPath, `${JSON.stringify(storedLock)}\n`, { flag: "wx" });
+
+    const lockError = await captureTaskServiceError(() =>
+      lockService.getLock("task", lookupLock.lock_id)
+    );
+
+    expect(lockError.code).toBe("record_malformed");
+    expect(lockError.category).toBe("workspace_error");
+    expect(lockError.evidenceRefs).toEqual([
+      "workspace/locks/task/LOCK-0001.json",
+      "lock.scope",
+      "lock.lock_id"
+    ]);
+    expectErrorNotToLeakRecordContent(lockError, storedLock.lock_id);
+    expect(await readFile(lockPath, "utf8")).toBe(`${JSON.stringify(storedLock)}\n`);
+
+    const artifactCase = await createTempWorkspacePath();
+    tempRoots.push(artifactCase.tempRoot);
+    const artifactService = createArtifactRegistryService({
+      workspaceRoot: artifactCase.workspaceRoot
+    });
+    const lookupArtifact = validArtifact();
+    const storedArtifact = {
+      ...lookupArtifact,
+      artifact_id: "ART-secret-foreign"
+    } satisfies Artifact;
+    const artifactPath = join(
+      artifactCase.workspaceRoot,
+      "artifacts",
+      "manifests",
+      `${lookupArtifact.artifact_id}.json`
+    );
+    await mkdir(join(artifactCase.workspaceRoot, "artifacts", "manifests"), {
+      recursive: true
+    });
+    await writeFile(artifactPath, `${JSON.stringify(storedArtifact)}\n`, { flag: "wx" });
+
+    const artifactError = await captureTaskServiceError(() =>
+      artifactService.getArtifact(lookupArtifact.artifact_id)
+    );
+
+    expect(artifactError.code).toBe("record_malformed");
+    expect(artifactError.category).toBe("workspace_error");
+    expect(artifactError.evidenceRefs).toEqual([
+      "workspace/artifacts/manifests/ART-0001.json",
+      "artifact.artifact_id"
+    ]);
+    expectErrorNotToLeakRecordContent(artifactError, storedArtifact.artifact_id);
+    expect(await readFile(artifactPath, "utf8")).toBe(`${JSON.stringify(storedArtifact)}\n`);
+  });
+
+  test("Artifact registry rejects divergent duplicate manifests and preserves the first", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createArtifactRegistryService({ workspaceRoot });
+    const artifact = validArtifact();
+    const manifestPath = join(
+      workspaceRoot,
+      "artifacts",
+      "manifests",
+      `${artifact.artifact_id}.json`
+    );
+
+    await expect(service.registerArtifact(artifact)).resolves.toEqual(artifact);
+    await expect(service.registerArtifact({ ...artifact })).resolves.toEqual(artifact);
+    const divergentError = await captureTaskServiceError(() =>
+      service.registerArtifact({
+        ...artifact,
+        media_type: "application/json"
+      })
+    );
+
+    expect(divergentError.code).toBe("record_schema_error");
+    expect(divergentError.category).toBe("schema_error");
+    expect(await service.getArtifact(artifact.artifact_id)).toEqual(artifact);
+    expect(JSON.parse(await readFile(manifestPath, "utf8"))).toEqual(artifact);
   });
 });
 

--- a/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
+++ b/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
@@ -3,6 +3,7 @@ import {
   access,
   mkdir,
   mkdtemp,
+  readFile,
   readdir,
   realpath,
   rm,
@@ -21,6 +22,7 @@ import {
   idempotencyRecordFileName,
   type Artifact,
   type IdempotencyRecord,
+  type IdempotencyRecordService,
   type LockRecord
 } from "./index";
 import { MAX_SERVICE_RECORD_BYTES } from "./workspace-record-store";
@@ -44,6 +46,11 @@ describe("idempotency, lock, and artifact services", () => {
     const rawKey = "raw/secret:idempotency key";
     const requestDigest = "digest-same-body";
 
+    const begin = await service.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
     const record = await service.completeRecord({
       scope: "task",
       key: rawKey,
@@ -62,6 +69,7 @@ describe("idempotency, lock, and artifact services", () => {
       created_at: "2026-07-07T13:00:00.000Z",
       updated_at: "2026-07-07T13:00:00.000Z"
     });
+    expect(begin.status).toBe("acquired");
     expect(files).toHaveLength(1);
     expect(files[0]).toMatch(/^[a-f0-9]{64}\.json$/);
     expect(files[0]).not.toContain("raw");
@@ -89,6 +97,358 @@ describe("idempotency, lock, and artifact services", () => {
     expect(await service.getRecord("task", rawKey)).toEqual(record);
   });
 
+  test("IdempotencyRecord completeRecord rejects a missing record without writing files", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:05:00.000Z")
+    });
+    const rawKey = "task:create:missing-complete";
+
+    const error = await captureTaskServiceError(() =>
+      service.completeRecord({
+        scope: "task",
+        key: rawKey,
+        requestDigest: "digest-missing-complete",
+        resultRef: "TASK-missing-complete"
+      })
+    );
+
+    expect(error.code).toBe("record_malformed");
+    expect(error.category).toBe("workspace_error");
+    await expectPathMissing(join(workspaceRoot, "tasks"));
+    expect(await service.getRecord("task", rawKey)).toBeUndefined();
+  });
+
+  test("IdempotencyRecord beginRecord preserves started, mismatch, and completed states", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    let currentTime = "2026-07-07T13:10:00.000Z";
+    const service = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date(currentTime)
+    });
+    const rawKey = "raw/secret:started idempotency key";
+    const requestDigest = "digest-started-body";
+    const startedRecord = {
+      key: rawKey,
+      scope: "task",
+      request_digest: requestDigest,
+      status: "started",
+      created_at: "2026-07-07T13:10:00.000Z",
+      updated_at: "2026-07-07T13:10:00.000Z"
+    };
+
+    const firstBegin = await service.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    const idempotencyDirectory = join(workspaceRoot, "tasks", "_idempotency", "task");
+    const files = await readdir(idempotencyDirectory);
+
+    expect(firstBegin).toEqual({ status: "acquired", record: startedRecord });
+    expect(await service.getRecord("task", rawKey)).toEqual(startedRecord);
+    expect(files).toEqual([idempotencyRecordFileName(rawKey)]);
+    expect(files[0]).toMatch(/^[a-f0-9]{64}\.json$/);
+    expect(files[0]).not.toContain("raw");
+    expect(files[0]).not.toContain("secret");
+
+    currentTime = "2026-07-07T13:11:00.000Z";
+    const secondBegin = await service.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    const mismatchBegin = await service.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest: "digest-different-body"
+    });
+
+    expect(secondBegin).toEqual({ status: "incomplete", record: startedRecord });
+    expect(mismatchBegin).toEqual({ status: "mismatch", record: startedRecord });
+    expect(await service.getRecord("task", rawKey)).toEqual(startedRecord);
+
+    currentTime = "2026-07-07T13:12:00.000Z";
+    const completedRecord = await service.completeRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest,
+      resultRef: "TASK-begin-record-completed"
+    });
+    const completedBegin = await service.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+
+    expect(completedRecord).toEqual({
+      ...startedRecord,
+      status: "completed",
+      result_ref: "TASK-begin-record-completed",
+      updated_at: "2026-07-07T13:12:00.000Z"
+    });
+    expect(completedBegin).toEqual({ status: "completed", record: completedRecord });
+  });
+
+  test("IdempotencyRecord failed same-digest beginRecord reacquires while different digest mismatches", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    let currentTime = "2026-07-07T13:20:00.000Z";
+    const service = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date(currentTime)
+    });
+    const rawKey = "task:create:failed-retry";
+    const requestDigest = "digest-retry-body";
+    const firstBegin = await service.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+
+    currentTime = "2026-07-07T13:21:00.000Z";
+    const failedRecord = await service.failRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    const mismatchBegin = await service.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest: "digest-different-body"
+    });
+
+    currentTime = "2026-07-07T13:22:00.000Z";
+    const retryBegin = await service.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+
+    expect(firstBegin.status).toBe("acquired");
+    expect(failedRecord).toEqual({
+      ...firstBegin.record,
+      status: "failed",
+      updated_at: "2026-07-07T13:21:00.000Z"
+    });
+    expect(failedRecord.result_ref).toBeUndefined();
+    expect(mismatchBegin).toEqual({ status: "mismatch", record: failedRecord });
+    expect(retryBegin).toEqual({
+      status: "acquired",
+      record: {
+        key: rawKey,
+        scope: "task",
+        request_digest: requestDigest,
+        status: "started",
+        created_at: "2026-07-07T13:22:00.000Z",
+        updated_at: "2026-07-07T13:22:00.000Z"
+      }
+    });
+    expect(await service.getRecord("task", rawKey)).toEqual(retryBegin.record);
+  });
+
+  test("IdempotencyRecord failed retry acquisition is atomic across service instances", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const rawKey = "task:create:failed-concurrent-retry";
+    const requestDigest = "digest-concurrent-retry-body";
+    const seedService = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:25:00.000Z")
+    });
+    const firstBegin = await seedService.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    const failedRecord = await createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:26:00.000Z")
+    }).failRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    const firstRetryService = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:27:00.000Z")
+    });
+    const secondRetryService = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:27:01.000Z")
+    });
+    let failedObservationCount = 0;
+    let releaseFailedObservations = () => undefined;
+    const bothRetryServicesObservedFailed = new Promise<void>((resolve) => {
+      releaseFailedObservations = resolve;
+    });
+    for (const service of [firstRetryService, secondRetryService]) {
+      holdFailedLookupUntilBothRetryServicesObserveIt(
+        service,
+        () => {
+          failedObservationCount += 1;
+          if (failedObservationCount === 2) {
+            releaseFailedObservations();
+          }
+        },
+        bothRetryServicesObservedFailed
+      );
+    }
+
+    const results = await Promise.all([
+      firstRetryService.beginRecord({
+        scope: "task",
+        key: rawKey,
+        requestDigest
+      }),
+      secondRetryService.beginRecord({
+        scope: "task",
+        key: rawKey,
+        requestDigest
+      })
+    ]);
+    const acquiredResults = results.filter((result) => result.status === "acquired");
+    const incompleteResults = results.filter((result) => result.status === "incomplete");
+    const finalRecord = await seedService.getRecord("task", rawKey);
+    const idempotencyDirectory = join(workspaceRoot, "tasks", "_idempotency", "task");
+    const files = (await readdir(idempotencyDirectory)).sort();
+
+    expect(firstBegin.status).toBe("acquired");
+    expect(failedRecord.status).toBe("failed");
+    expect(failedObservationCount).toBe(2);
+    expect(acquiredResults).toHaveLength(1);
+    expect(incompleteResults).toHaveLength(1);
+    expect(incompleteResults[0]?.record).toEqual(acquiredResults[0]?.record);
+    expect(incompleteResults[0]?.record.status).toBe("started");
+    expect(finalRecord).toEqual(acquiredResults[0]?.record);
+    expect(finalRecord?.status).toBe("started");
+    expect(finalRecord?.request_digest).toBe(requestDigest);
+    expect(files).toEqual([idempotencyRecordFileName(rawKey)]);
+  });
+
+  test("IdempotencyRecord concurrent divergent completions converge without overwrite", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const rawKey = "task:create:divergent-complete";
+    const requestDigest = "digest-divergent-complete";
+    const seedService = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:28:00.000Z")
+    });
+    const started = await seedService.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    const firstCompleteService = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:28:01.000Z")
+    });
+    const secondCompleteService = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:28:02.000Z")
+    });
+    let startedObservationCount = 0;
+    let releaseStartedObservations = () => undefined;
+    const bothCompleteServicesObservedStarted = new Promise<void>((resolve) => {
+      releaseStartedObservations = resolve;
+    });
+    for (const service of [firstCompleteService, secondCompleteService]) {
+      holdStartedLookupUntilBothCompleteServicesObserveIt(
+        service,
+        () => {
+          startedObservationCount += 1;
+          if (startedObservationCount === 2) {
+            releaseStartedObservations();
+          }
+        },
+        bothCompleteServicesObservedStarted
+      );
+    }
+
+    const results = await Promise.all([
+      firstCompleteService.completeRecord({
+        scope: "task",
+        key: rawKey,
+        requestDigest,
+        resultRef: "TASK-divergent-a"
+      }),
+      secondCompleteService.completeRecord({
+        scope: "task",
+        key: rawKey,
+        requestDigest,
+        resultRef: "TASK-divergent-b"
+      })
+    ]);
+    const finalRecord = await seedService.getRecord("task", rawKey);
+    const resultRefs = results.map((result) => result.result_ref);
+
+    expect(started.status).toBe("acquired");
+    expect(startedObservationCount).toBe(2);
+    expect(new Set(resultRefs).size).toBe(1);
+    expect(finalRecord?.status).toBe("completed");
+    expect(finalRecord?.result_ref).toBe(resultRefs[0]);
+    expect(["TASK-divergent-a", "TASK-divergent-b"]).toContain(finalRecord?.result_ref);
+  });
+
+  test("IdempotencyRecord storeRecord cannot overwrite completed result_ref", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:30:00.000Z")
+    });
+    const rawKey = "task:create:completed-immutable";
+    const requestDigest = "digest-completed-body";
+    const begin = await service.beginRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    const completedRecord = await service.completeRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest,
+      resultRef: "TASK-original-result"
+    });
+    const recordPath = join(
+      workspaceRoot,
+      "tasks",
+      "_idempotency",
+      "task",
+      idempotencyRecordFileName(rawKey)
+    );
+
+    const sameRecord = await service.storeRecord({
+      ...completedRecord,
+      updated_at: "2026-07-07T13:31:00.000Z"
+    });
+    const overwriteError = await captureTaskServiceError(() =>
+      service.storeRecord({
+        ...completedRecord,
+        result_ref: "TASK-overwritten-result",
+        updated_at: "2026-07-07T13:32:00.000Z"
+      })
+    );
+    const completedAgain = await service.completeRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest,
+      resultRef: "TASK-overwritten-result"
+    });
+
+    expect(begin.status).toBe("acquired");
+    expect(sameRecord).toEqual(completedRecord);
+    expect(overwriteError.code).toBe("record_schema_error");
+    expect(overwriteError.category).toBe("schema_error");
+    expect(completedAgain).toEqual(completedRecord);
+    expect(await service.getRecord("task", rawKey)).toEqual(completedRecord);
+    expect(JSON.parse(await readFile(recordPath, "utf8"))).toEqual(completedRecord);
+  });
+
   test("IdempotencyRecord invalid schema is rejected without workspace files", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -102,6 +462,20 @@ describe("idempotency, lock, and artifact services", () => {
     );
 
     expect(error.code).toBe("record_schema_error");
+    await expectPathMissing(join(workspaceRoot, "tasks"));
+  });
+
+  test("IdempotencyRecord completed status without result_ref is rejected without workspace files", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createIdempotencyRecordService({ workspaceRoot });
+    const record = validIdempotencyRecord();
+    delete record.result_ref;
+
+    const error = await captureTaskServiceError(() => service.storeRecord(record));
+
+    expect(error.code).toBe("record_schema_error");
+    expect(error.category).toBe("schema_error");
     await expectPathMissing(join(workspaceRoot, "tasks"));
   });
 
@@ -272,6 +646,52 @@ describe("idempotency, lock, and artifact services", () => {
     await expectPathMissing(join(invalidPath.workspaceRoot, "artifacts"));
   });
 });
+
+function holdFailedLookupUntilBothRetryServicesObserveIt(
+  service: IdempotencyRecordService,
+  onFailedObserved: () => void,
+  bothRetryServicesObservedFailed: Promise<void>
+): void {
+  const originalLookupReplay = service.lookupReplay;
+  let hasHeldFailedLookup = false;
+  service.lookupReplay = async (input) => {
+    const result = await originalLookupReplay(input);
+    if (
+      !hasHeldFailedLookup &&
+      result.status === "incomplete" &&
+      result.record.status === "failed"
+    ) {
+      hasHeldFailedLookup = true;
+      onFailedObserved();
+      await bothRetryServicesObservedFailed;
+    }
+
+    return result;
+  };
+}
+
+function holdStartedLookupUntilBothCompleteServicesObserveIt(
+  service: IdempotencyRecordService,
+  onStartedObserved: () => void,
+  bothCompleteServicesObservedStarted: Promise<void>
+): void {
+  const originalLookupReplay = service.lookupReplay;
+  let hasHeldStartedLookup = false;
+  service.lookupReplay = async (input) => {
+    const result = await originalLookupReplay(input);
+    if (
+      !hasHeldStartedLookup &&
+      result.status === "incomplete" &&
+      result.record.status === "started"
+    ) {
+      hasHeldStartedLookup = true;
+      onStartedObserved();
+      await bothCompleteServicesObservedStarted;
+    }
+
+    return result;
+  };
+}
 
 async function createTempWorkspacePath(): Promise<{ tempRoot: string; workspaceRoot: string }> {
   const tempRoot = await realpath(await mkdtemp(join(tmpdir(), "shud-harness-core-services-")));

--- a/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
+++ b/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readdir,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  writeFile
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  TaskServiceError,
+  createArtifactRegistryService,
+  createIdempotencyRecordService,
+  createLockRecordService,
+  idempotencyRecordEvidenceRef,
+  idempotencyRecordFileName,
+  type Artifact,
+  type IdempotencyRecord,
+  type LockRecord
+} from "./index";
+import { MAX_SERVICE_RECORD_BYTES } from "./workspace-record-store";
+
+const tempRoots: string[] = [];
+
+describe("idempotency, lock, and artifact services", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempRoots.splice(0).map((tempRoot) => rm(tempRoot, { recursive: true, force: true }))
+    );
+  });
+
+  test("IdempotencyRecord store/get/replay uses safe deterministic direct paths", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createIdempotencyRecordService({
+      workspaceRoot,
+      now: () => new Date("2026-07-07T13:00:00.000Z")
+    });
+    const rawKey = "raw/secret:idempotency key";
+    const requestDigest = "digest-same-body";
+
+    const record = await service.completeRecord({
+      scope: "task",
+      key: rawKey,
+      requestDigest,
+      resultRef: "TASK-idempotent"
+    });
+    const idempotencyDirectory = join(workspaceRoot, "tasks", "_idempotency", "task");
+    const files = await readdir(idempotencyDirectory);
+
+    expect(record).toEqual({
+      key: rawKey,
+      scope: "task",
+      request_digest: requestDigest,
+      status: "completed",
+      result_ref: "TASK-idempotent",
+      created_at: "2026-07-07T13:00:00.000Z",
+      updated_at: "2026-07-07T13:00:00.000Z"
+    });
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^[a-f0-9]{64}\.json$/);
+    expect(files[0]).not.toContain("raw");
+    expect(files[0]).not.toContain("secret");
+    expect(await service.getRecord("task", rawKey)).toEqual(record);
+
+    const replay = await service.lookupReplay({
+      scope: "task",
+      key: rawKey,
+      requestDigest
+    });
+    expect(replay.status).toBe("completed");
+    if (replay.status === "completed") {
+      expect(replay.record.result_ref).toBe("TASK-idempotent");
+    }
+
+    const mismatch = await service.lookupReplay({
+      scope: "task",
+      key: rawKey,
+      requestDigest: "digest-different-body"
+    });
+    expect(mismatch.status).toBe("mismatch");
+
+    await writeFile(join(idempotencyDirectory, `${"0".repeat(64)}.json`), "{", { flag: "wx" });
+    expect(await service.getRecord("task", rawKey)).toEqual(record);
+  });
+
+  test("IdempotencyRecord invalid schema is rejected without workspace files", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createIdempotencyRecordService({ workspaceRoot });
+
+    const error = await captureTaskServiceError(() =>
+      service.storeRecord({
+        ...validIdempotencyRecord(),
+        status: "running"
+      } as unknown as IdempotencyRecord)
+    );
+
+    expect(error.code).toBe("record_schema_error");
+    await expectPathMissing(join(workspaceRoot, "tasks"));
+  });
+
+  test("oversized existing IdempotencyRecord fails closed without leaking record content", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createIdempotencyRecordService({ workspaceRoot });
+    const rawKey = "oversized existing idempotency key";
+    const secret = "oversized-record-secret";
+    const idempotencyDirectory = join(workspaceRoot, "tasks", "_idempotency", "task");
+    const recordPath = join(idempotencyDirectory, idempotencyRecordFileName(rawKey));
+    const oversizedRecordText = JSON.stringify({
+      ...validIdempotencyRecord(),
+      key: rawKey,
+      result_ref: `TASK-${secret}`,
+      payload: "x".repeat(MAX_SERVICE_RECORD_BYTES)
+    });
+    expect(Buffer.byteLength(oversizedRecordText, "utf8")).toBeGreaterThan(
+      MAX_SERVICE_RECORD_BYTES
+    );
+
+    await mkdir(idempotencyDirectory, { recursive: true });
+    await writeFile(recordPath, oversizedRecordText, { flag: "wx" });
+
+    const error = await captureTaskServiceError(() => service.getRecord("task", rawKey));
+
+    expect(error.code).toBe("record_malformed");
+    expect(error.category).toBe("workspace_error");
+    expect(error.evidenceRefs).toEqual([idempotencyRecordEvidenceRef("task", rawKey)]);
+    expectErrorNotToLeakRecordContent(error, secret);
+  });
+
+  test("symlinked IdempotencyRecord leaf fails closed without hydrating outside record", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createIdempotencyRecordService({ workspaceRoot });
+    const rawKey = "symlinked idempotency key";
+    const secret = "outside-record-secret";
+    const idempotencyDirectory = join(workspaceRoot, "tasks", "_idempotency", "task");
+    const recordPath = join(idempotencyDirectory, idempotencyRecordFileName(rawKey));
+    const outsideRecordPath = join(tempRoot, "outside-idempotency-record.json");
+
+    await mkdir(idempotencyDirectory, { recursive: true });
+    await writeFile(
+      outsideRecordPath,
+      `${JSON.stringify({
+        ...validIdempotencyRecord(),
+        key: rawKey,
+        request_digest: "outside-digest",
+        result_ref: `TASK-${secret}`
+      })}\n`,
+      { flag: "wx" }
+    );
+    await symlink(outsideRecordPath, recordPath);
+
+    const error = await captureTaskServiceError(() => service.getRecord("task", rawKey));
+
+    expect(error.code).toBe("record_malformed");
+    expect(error.category).toBe("workspace_error");
+    expect(error.evidenceRefs).toEqual([idempotencyRecordEvidenceRef("task", rawKey)]);
+    expectErrorNotToLeakRecordContent(error, secret);
+  });
+
+  test("LockRecord store/get validates schema and uses direct lookup paths", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createLockRecordService({ workspaceRoot });
+    const lock = validLockRecord();
+
+    await expect(service.storeLock(lock)).resolves.toEqual(lock);
+    expect(await service.getLock("task", lock.lock_id)).toEqual(lock);
+    expect((await stat(join(workspaceRoot, "locks", "task", `${lock.lock_id}.json`))).isFile()).toBe(
+      true
+    );
+
+    await writeFile(join(workspaceRoot, "locks", "task", "LOCK-bad-sibling.json"), "{", {
+      flag: "wx"
+    });
+    expect(await service.getLock("task", lock.lock_id)).toEqual(lock);
+  });
+
+  test("LockRecord invalid schema or id is rejected without lock files", async () => {
+    const invalidSchema = await createTempWorkspacePath();
+    tempRoots.push(invalidSchema.tempRoot);
+    const schemaService = createLockRecordService({ workspaceRoot: invalidSchema.workspaceRoot });
+
+    const schemaError = await captureTaskServiceError(() =>
+      schemaService.storeLock({
+        ...validLockRecord(),
+        status: "open"
+      } as unknown as LockRecord)
+    );
+
+    expect(schemaError.code).toBe("record_schema_error");
+    await expectPathMissing(join(invalidSchema.workspaceRoot, "locks"));
+
+    const invalidId = await createTempWorkspacePath();
+    tempRoots.push(invalidId.tempRoot);
+    const idService = createLockRecordService({ workspaceRoot: invalidId.workspaceRoot });
+    const idError = await captureTaskServiceError(() =>
+      idService.storeLock({
+        ...validLockRecord(),
+        lock_id: "../LOCK-unsafe"
+      })
+    );
+
+    expect(idError.code).toBe("record_id_not_safe");
+    await expectPathMissing(join(invalidId.workspaceRoot, "locks"));
+  });
+
+  test("Artifact registry register/get persists metadata under manifests only", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createArtifactRegistryService({ workspaceRoot });
+    const artifact = validArtifact();
+
+    await expect(service.registerArtifact(artifact)).resolves.toEqual(artifact);
+    expect(await service.getArtifact(artifact.artifact_id)).toEqual(artifact);
+    expect(
+      (await stat(join(workspaceRoot, "artifacts", "manifests", `${artifact.artifact_id}.json`))).isFile()
+    ).toBe(true);
+    await expectPathMissing(join(workspaceRoot, artifact.path));
+
+    await writeFile(join(workspaceRoot, "artifacts", "manifests", "ART-bad-sibling.json"), "{", {
+      flag: "wx"
+    });
+    expect(await service.getArtifact(artifact.artifact_id)).toEqual(artifact);
+  });
+
+  test("Artifact registry rejects invalid type, id, and path without manifest files", async () => {
+    const invalidType = await createTempWorkspacePath();
+    tempRoots.push(invalidType.tempRoot);
+    const typeService = createArtifactRegistryService({ workspaceRoot: invalidType.workspaceRoot });
+    const typeError = await captureTaskServiceError(() =>
+      typeService.registerArtifact({
+        ...validArtifact(),
+        type: "unsupported"
+      } as unknown as Artifact)
+    );
+
+    expect(typeError.code).toBe("record_schema_error");
+    await expectPathMissing(join(invalidType.workspaceRoot, "artifacts"));
+
+    const invalidId = await createTempWorkspacePath();
+    tempRoots.push(invalidId.tempRoot);
+    const idService = createArtifactRegistryService({ workspaceRoot: invalidId.workspaceRoot });
+    const idError = await captureTaskServiceError(() =>
+      idService.registerArtifact({
+        ...validArtifact(),
+        artifact_id: "../ART-unsafe"
+      })
+    );
+
+    expect(idError.code).toBe("record_id_not_safe");
+    await expectPathMissing(join(invalidId.workspaceRoot, "artifacts"));
+
+    const invalidPath = await createTempWorkspacePath();
+    tempRoots.push(invalidPath.tempRoot);
+    const pathService = createArtifactRegistryService({ workspaceRoot: invalidPath.workspaceRoot });
+    const pathError = await captureTaskServiceError(() =>
+      pathService.registerArtifact({
+        ...validArtifact(),
+        path: "../outside/report.md"
+      })
+    );
+
+    expect(pathError.code).toBe("record_id_not_safe");
+    await expectPathMissing(join(invalidPath.workspaceRoot, "artifacts"));
+  });
+});
+
+async function createTempWorkspacePath(): Promise<{ tempRoot: string; workspaceRoot: string }> {
+  const tempRoot = await realpath(await mkdtemp(join(tmpdir(), "shud-harness-core-services-")));
+  return {
+    tempRoot,
+    workspaceRoot: join(tempRoot, "workspace")
+  };
+}
+
+async function captureTaskServiceError(action: () => Promise<unknown>): Promise<TaskServiceError> {
+  try {
+    await action();
+  } catch (error) {
+    expect(error).toBeInstanceOf(TaskServiceError);
+    return error as TaskServiceError;
+  }
+
+  throw new Error("Expected TaskServiceError.");
+}
+
+function expectErrorNotToLeakRecordContent(error: TaskServiceError, content: string): void {
+  const cause = (error as Error & { cause?: unknown }).cause;
+  const exposedError = JSON.stringify({
+    message: error.message,
+    userMessage: error.userMessage,
+    evidenceRefs: error.evidenceRefs,
+    recommendedNextActions: error.recommendedNextActions,
+    causeMessage: cause instanceof Error ? cause.message : cause
+  });
+  expect(exposedError).not.toContain(content);
+}
+
+async function expectPathMissing(path: string): Promise<void> {
+  try {
+    await access(path);
+  } catch {
+    return;
+  }
+
+  throw new Error(`Expected path to be missing: ${path}`);
+}
+
+function validIdempotencyRecord(): IdempotencyRecord {
+  return {
+    key: "task:create:1",
+    scope: "task",
+    request_digest: "digest",
+    status: "completed",
+    result_ref: "TASK-0001",
+    created_at: "2026-07-07T13:00:00.000Z",
+    updated_at: "2026-07-07T13:00:00.000Z"
+  };
+}
+
+function validLockRecord(): LockRecord {
+  return {
+    lock_id: "LOCK-0001",
+    scope: "task",
+    target_id: "TASK-0001",
+    holder: "worker-1",
+    acquired_at: "2026-07-07T13:00:00.000Z",
+    expires_at: "2026-07-07T13:01:00.000Z",
+    status: "held",
+    reason: "task snapshot write"
+  };
+}
+
+function validArtifact(): Artifact {
+  return {
+    artifact_id: "ART-0001",
+    task_id: "TASK-0001",
+    type: "report_markdown",
+    path: "artifacts/reports/TASK-0001/report.md",
+    media_type: "text/markdown",
+    created_at: "2026-07-07T13:00:00.000Z",
+    created_by: "agent",
+    evidence_usable: false,
+    retention_class: "debug",
+    source_refs: [],
+    redaction_status: "not_needed"
+  };
+}

--- a/packages/core/src/domain/services/idempotency-service.ts
+++ b/packages/core/src/domain/services/idempotency-service.ts
@@ -1,5 +1,8 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
+import { unlink } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { z } from "zod";
 import {
   IdempotencyRecordSchema,
   IdempotencyScopeSchema,
@@ -8,10 +11,28 @@ import {
 } from "../schemas/idempotency";
 import { TaskServiceError } from "./task-card-service";
 import {
+  createJsonRecordIfAbsent,
   readJsonRecord,
   workspaceRecordPath,
   writeJsonRecord
 } from "./workspace-record-store";
+
+const IDEMPOTENCY_TRANSITION_GUARD_STALE_MS = 30_000;
+const IDEMPOTENCY_TRANSITION_GUARD_WAIT_MS = 250;
+const IDEMPOTENCY_TRANSITION_GUARD_POLL_MS = 5;
+
+const IdempotencyTransitionGuardSchema = z.object({
+  guard_id: z.string().min(1),
+  owner_pid: z.number().int().nonnegative(),
+  acquired_at_ms: z.number().int().nonnegative(),
+  acquired_at: z.string().min(1)
+});
+
+type IdempotencyTransitionGuard = z.infer<typeof IdempotencyTransitionGuardSchema>;
+
+type IdempotencyTransitionGuardAcquire =
+  | { status: "acquired"; release: () => Promise<void> }
+  | { status: "busy" };
 
 export interface IdempotencyRecordServiceOptions {
   workspaceRoot: string;
@@ -30,15 +51,25 @@ export type IdempotencyReplayLookup =
   | { status: "incomplete"; record: IdempotencyRecord }
   | { status: "completed"; record: IdempotencyRecord & { result_ref: string } };
 
+export type BeginIdempotencyRecordResult =
+  | { status: "acquired"; record: IdempotencyRecord }
+  | { status: "mismatch"; record: IdempotencyRecord }
+  | { status: "incomplete"; record: IdempotencyRecord }
+  | { status: "completed"; record: IdempotencyRecord & { result_ref: string } };
+
 export interface CompleteIdempotencyRecordInput extends IdempotencyRecordLookupInput {
   resultRef: string;
 }
 
+export type FailIdempotencyRecordInput = IdempotencyRecordLookupInput;
+
 export interface IdempotencyRecordService {
   storeRecord: (record: IdempotencyRecord) => Promise<IdempotencyRecord>;
   getRecord: (scope: IdempotencyScope, key: string) => Promise<IdempotencyRecord | undefined>;
+  beginRecord: (input: IdempotencyRecordLookupInput) => Promise<BeginIdempotencyRecordResult>;
   lookupReplay: (input: IdempotencyRecordLookupInput) => Promise<IdempotencyReplayLookup>;
   completeRecord: (input: CompleteIdempotencyRecordInput) => Promise<IdempotencyRecord>;
+  failRecord: (input: FailIdempotencyRecordInput) => Promise<IdempotencyRecord>;
 }
 
 export function createIdempotencyRecordService(
@@ -58,6 +89,18 @@ export function createIdempotencyRecordService(
           record,
           "workspace/tasks/_idempotency",
           IdempotencyRecordSchema
+        );
+      }
+      assertPersistableIdempotencyRecord(
+        parsedRecord.data,
+        idempotencyRecordEvidenceRef(parsedRecord.data.scope, parsedRecord.data.key)
+      );
+      const existing = await service.getRecord(parsedRecord.data.scope, parsedRecord.data.key);
+      if (existing?.status === "completed") {
+        return assertCompletedRecordStoreAllowed(
+          existing,
+          parsedRecord.data,
+          idempotencyRecordEvidenceRef(parsedRecord.data.scope, parsedRecord.data.key)
         );
       }
 
@@ -90,6 +133,85 @@ export function createIdempotencyRecordService(
       );
     },
 
+    async beginRecord(
+      input: IdempotencyRecordLookupInput
+    ): Promise<BeginIdempotencyRecordResult> {
+      const parsedScope = assertIdempotencyScope(input.scope);
+      assertNonblankIdempotencyKey(input.key);
+      const timestamp = now().toISOString();
+      const record: IdempotencyRecord = {
+        key: input.key,
+        scope: parsedScope,
+        request_digest: input.requestDigest,
+        status: "started",
+        created_at: timestamp,
+        updated_at: timestamp
+      };
+      const evidenceRef = idempotencyRecordEvidenceRef(parsedScope, input.key);
+      const created = await createJsonRecordIfAbsent(
+        workspaceRoot,
+        idempotencyRecordDirectorySegments(parsedScope),
+        idempotencyRecordFileName(input.key),
+        record,
+        evidenceRef,
+        IdempotencyRecordSchema
+      );
+
+      if (created.status === "created") {
+        return { status: "acquired", record: created.record };
+      }
+
+      const existing = await service.lookupReplay({ ...input, scope: parsedScope });
+      if (existing.status === "missing") {
+        throw new TaskServiceError({
+          code: "record_malformed",
+          status: 500,
+          category: "workspace_error",
+          message: "Idempotency record claim was not readable after an existing-record race.",
+          userMessage: "The idempotency record could not be read safely.",
+          evidenceRefs: [evidenceRef],
+          recommendedNextActions: ["Inspect the idempotency record state before retrying."]
+        });
+      }
+      if (existing.status === "incomplete" && existing.record.status === "failed") {
+        const guard = await acquireIdempotencyTransitionGuard(
+          workspaceRoot,
+          parsedScope,
+          input.key,
+          evidenceRef
+        );
+        if (guard.status === "busy") {
+          return beginResultFromReplayLookup(
+            await lookupExistingRecordForBegin(service, { ...input, scope: parsedScope }, evidenceRef)
+          );
+        }
+        try {
+          const retryExisting = await service.lookupReplay({ ...input, scope: parsedScope });
+          if (retryExisting.status === "missing") {
+            throw new TaskServiceError({
+              code: "record_malformed",
+              status: 500,
+              category: "workspace_error",
+              message: "Idempotency record was not readable during failed retry acquisition.",
+              userMessage: "The idempotency record could not be updated safely.",
+              evidenceRefs: [evidenceRef],
+              recommendedNextActions: ["Inspect the idempotency record state before retrying."]
+            });
+          }
+          if (retryExisting.status !== "incomplete" || retryExisting.record.status !== "failed") {
+            return beginResultFromReplayLookup(retryExisting);
+          }
+
+          const stored = await service.storeRecord(record);
+          return beginResultFromStoredRecord(stored, input.requestDigest, parsedScope, input.key);
+        } finally {
+          await guard.release();
+        }
+      }
+
+      return existing;
+    },
+
     async lookupReplay(input: IdempotencyRecordLookupInput): Promise<IdempotencyReplayLookup> {
       const parsedScope = assertIdempotencyScope(input.scope);
       assertNonblankIdempotencyKey(input.key);
@@ -102,18 +224,7 @@ export function createIdempotencyRecordService(
       }
       if (record.status === "completed") {
         if (!record.result_ref) {
-          throw new TaskServiceError({
-            code: "record_malformed",
-            status: 500,
-            category: "workspace_error",
-            message: "Completed idempotency record is missing result_ref.",
-            userMessage: "A completed idempotency record is missing its result reference.",
-            evidenceRefs: [
-              idempotencyRecordEvidenceRef(parsedScope, input.key),
-              "idempotency.result_ref"
-            ],
-            recommendedNextActions: ["Inspect and repair the idempotency record before retrying."]
-          });
+          throw completedRecordMissingResultRefError(parsedScope, input.key);
         }
 
         return { status: "completed", record: record as IdempotencyRecord & { result_ref: string } };
@@ -125,24 +236,147 @@ export function createIdempotencyRecordService(
     async completeRecord(input: CompleteIdempotencyRecordInput): Promise<IdempotencyRecord> {
       const parsedScope = assertIdempotencyScope(input.scope);
       assertNonblankIdempotencyKey(input.key);
-      const existing = await service.lookupReplay({ ...input, scope: parsedScope });
-      if (existing.status === "mismatch") {
+      const evidenceRef = idempotencyRecordEvidenceRef(parsedScope, input.key);
+      const observed = await service.lookupReplay({ ...input, scope: parsedScope });
+      if (observed.status === "mismatch") {
         throw createIdempotencyMismatchError();
       }
-      if (existing.status === "completed") {
-        return existing.record;
+      if (observed.status === "missing") {
+        throw missingTransitionRecordError(
+          parsedScope,
+          input.key,
+          "Idempotency record was missing when completing the claim."
+        );
+      }
+      if (observed.status === "completed") {
+        return observed.record;
       }
 
-      const timestamp = now().toISOString();
-      return await service.storeRecord({
-        key: input.key,
-        scope: parsedScope,
-        request_digest: input.requestDigest,
-        status: "completed",
-        result_ref: input.resultRef,
-        created_at: existing.status === "incomplete" ? existing.record.created_at : timestamp,
-        updated_at: timestamp
-      });
+      const guard = await acquireIdempotencyTransitionGuard(
+        workspaceRoot,
+        parsedScope,
+        input.key,
+        evidenceRef
+      );
+      if (guard.status === "busy") {
+        const current = await service.lookupReplay({ ...input, scope: parsedScope });
+        if (current.status === "completed") {
+          return current.record;
+        }
+        throw transitionGuardBusyError(parsedScope, input.key, "complete");
+      }
+
+      try {
+        const existing = await service.lookupReplay({ ...input, scope: parsedScope });
+        if (existing.status === "mismatch") {
+          throw createIdempotencyMismatchError();
+        }
+        if (existing.status === "missing") {
+          throw missingTransitionRecordError(
+            parsedScope,
+            input.key,
+            "Idempotency record was missing when completing the claim."
+          );
+        }
+        if (existing.status === "completed") {
+          return existing.record;
+        }
+        if (existing.record.status !== "started") {
+          throw invalidTransitionStateError(
+            parsedScope,
+            input.key,
+            "completed",
+            "Only a started idempotency record can be completed.",
+            "The idempotency record is not in a completable state."
+          );
+        }
+
+        const timestamp = now().toISOString();
+        return await service.storeRecord({
+          key: input.key,
+          scope: parsedScope,
+          request_digest: input.requestDigest,
+          status: "completed",
+          result_ref: input.resultRef,
+          created_at: existing.record.created_at,
+          updated_at: timestamp
+        });
+      } finally {
+        await guard.release();
+      }
+    },
+
+    async failRecord(input: FailIdempotencyRecordInput): Promise<IdempotencyRecord> {
+      const parsedScope = assertIdempotencyScope(input.scope);
+      assertNonblankIdempotencyKey(input.key);
+      const evidenceRef = idempotencyRecordEvidenceRef(parsedScope, input.key);
+      const observed = await service.lookupReplay({ ...input, scope: parsedScope });
+      if (observed.status === "mismatch") {
+        throw createIdempotencyMismatchError();
+      }
+      if (observed.status === "missing") {
+        throw missingTransitionRecordError(
+          parsedScope,
+          input.key,
+          "Idempotency record was missing when marking the claim failed."
+        );
+      }
+      if (observed.status === "completed" || observed.record.status === "failed") {
+        return observed.record;
+      }
+
+      const guard = await acquireIdempotencyTransitionGuard(
+        workspaceRoot,
+        parsedScope,
+        input.key,
+        evidenceRef
+      );
+      if (guard.status === "busy") {
+        const current = await service.lookupReplay({ ...input, scope: parsedScope });
+        if (
+          current.status === "completed" ||
+          (current.status === "incomplete" && current.record.status === "failed")
+        ) {
+          return current.record;
+        }
+        throw transitionGuardBusyError(parsedScope, input.key, "fail");
+      }
+
+      try {
+        const existing = await service.lookupReplay({ ...input, scope: parsedScope });
+        if (existing.status === "mismatch") {
+          throw createIdempotencyMismatchError();
+        }
+        if (existing.status === "missing") {
+          throw missingTransitionRecordError(
+            parsedScope,
+            input.key,
+            "Idempotency record was missing when marking the claim failed."
+          );
+        }
+        if (existing.status === "completed" || existing.record.status === "failed") {
+          return existing.record;
+        }
+        if (existing.record.status !== "started") {
+          throw invalidTransitionStateError(
+            parsedScope,
+            input.key,
+            "failed",
+            "Only a started idempotency record can be marked failed.",
+            "The idempotency record is not in a failable state."
+          );
+        }
+
+        const recordWithoutResultRef = { ...existing.record };
+        delete recordWithoutResultRef.result_ref;
+        return await service.storeRecord({
+          ...recordWithoutResultRef,
+          status: "failed",
+          updated_at: now().toISOString()
+        });
+      } finally {
+        await guard.release();
+      }
     }
   };
 
@@ -152,6 +386,11 @@ export function createIdempotencyRecordService(
 export function idempotencyRecordFileName(key: string): string {
   assertNonblankIdempotencyKey(key);
   return `${sha256Hex(key)}.json`;
+}
+
+function idempotencyTransitionGuardFileName(key: string): string {
+  assertNonblankIdempotencyKey(key);
+  return `${sha256Hex(`transition:${key}`)}.guard.json`;
 }
 
 export function idempotencyRecordEvidenceRef(scope: IdempotencyScope, key: string): string {
@@ -164,6 +403,95 @@ export function idempotencyRecordDirectorySegments(
   scope: IdempotencyScope
 ): readonly string[] {
   return ["tasks", "_idempotency", assertIdempotencyScope(scope)];
+}
+
+async function acquireIdempotencyTransitionGuard(
+  workspaceRoot: string,
+  scope: IdempotencyScope,
+  key: string,
+  evidenceRef: string
+): Promise<IdempotencyTransitionGuardAcquire> {
+  const directorySegments = idempotencyRecordDirectorySegments(scope);
+  const guardFileName = idempotencyTransitionGuardFileName(key);
+  const guardPath = workspaceRecordPath(
+    workspaceRoot,
+    [...directorySegments, guardFileName],
+    evidenceRef
+  );
+  const deadline = Date.now() + IDEMPOTENCY_TRANSITION_GUARD_WAIT_MS;
+
+  for (;;) {
+    const guard: IdempotencyTransitionGuard = {
+      guard_id: randomUUID(),
+      owner_pid: process.pid,
+      acquired_at_ms: Date.now(),
+      acquired_at: new Date().toISOString()
+    };
+    const created = await createJsonRecordIfAbsent(
+      workspaceRoot,
+      directorySegments,
+      guardFileName,
+      guard,
+      evidenceRef,
+      IdempotencyTransitionGuardSchema
+    );
+    if (created.status === "created") {
+      return {
+        status: "acquired",
+        release: async () => {
+          const current = await readJsonRecord(
+            guardPath,
+            evidenceRef,
+            IdempotencyTransitionGuardSchema
+          ).catch(() => undefined);
+          if (current?.guard_id === guard.guard_id) {
+            await unlink(guardPath).catch(() => undefined);
+          }
+        }
+      };
+    }
+
+    if (await removeStaleIdempotencyTransitionGuard(guardPath, evidenceRef)) {
+      continue;
+    }
+    if (Date.now() >= deadline) {
+      return { status: "busy" };
+    }
+
+    await sleep(IDEMPOTENCY_TRANSITION_GUARD_POLL_MS);
+  }
+}
+
+async function removeStaleIdempotencyTransitionGuard(
+  guardPath: string,
+  evidenceRef: string
+): Promise<boolean> {
+  const existing = await readJsonRecord(
+    guardPath,
+    evidenceRef,
+    IdempotencyTransitionGuardSchema
+  ).catch(() => undefined);
+  if (!existing) {
+    return true;
+  }
+
+  const ageMs = Date.now() - existing.acquired_at_ms;
+  const ownerIsGone = existing.owner_pid !== process.pid && !isProcessLikelyAlive(existing.owner_pid);
+  if (ageMs < IDEMPOTENCY_TRANSITION_GUARD_STALE_MS && !ownerIsGone) {
+    return false;
+  }
+
+  await unlink(guardPath).catch(() => undefined);
+  return true;
+}
+
+function isProcessLikelyAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return hasErrorCode(error, "EPERM");
+  }
 }
 
 export function createIdempotencyMismatchError(): TaskServiceError {
@@ -181,6 +509,183 @@ export function createIdempotencyMismatchError(): TaskServiceError {
     retryable: false,
     recommendedNextActions: ["Use the original request body or choose a new idempotency key."]
   });
+}
+
+function assertPersistableIdempotencyRecord(
+  record: IdempotencyRecord,
+  evidenceRef: string
+): void {
+  if (record.status !== "completed" || typeof record.result_ref === "string") {
+    return;
+  }
+
+  throw new TaskServiceError({
+    code: "record_schema_error",
+    status: 400,
+    category: "schema_error",
+    message: "Completed idempotency record is missing result_ref.",
+    userMessage: "A completed idempotency record must include its result reference.",
+    evidenceRefs: [evidenceRef, "idempotency.result_ref"],
+    recommendedNextActions: ["Set result_ref before storing a completed idempotency record."]
+  });
+}
+
+function assertCompletedRecordStoreAllowed(
+  existing: IdempotencyRecord,
+  incoming: IdempotencyRecord,
+  evidenceRef: string
+): IdempotencyRecord {
+  if (!existing.result_ref) {
+    throw completedRecordMissingResultRefError(existing.scope, existing.key);
+  }
+  if (
+    incoming.status === "completed" &&
+    incoming.request_digest === existing.request_digest &&
+    incoming.result_ref === existing.result_ref
+  ) {
+    return existing;
+  }
+  if (incoming.request_digest !== existing.request_digest) {
+    throw createIdempotencyMismatchError();
+  }
+
+  throw new TaskServiceError({
+    code: "record_schema_error",
+    status: 400,
+    category: "schema_error",
+    message: "Completed idempotency record is immutable.",
+    userMessage: "A completed idempotency record cannot be overwritten.",
+    evidenceRefs: [evidenceRef, "idempotency.result_ref"],
+    recommendedNextActions: ["Use the existing idempotency result or choose a new key."]
+  });
+}
+
+function completedRecordMissingResultRefError(
+  scope: IdempotencyScope,
+  key: string
+): TaskServiceError {
+  return new TaskServiceError({
+    code: "record_malformed",
+    status: 500,
+    category: "workspace_error",
+    message: "Completed idempotency record is missing result_ref.",
+    userMessage: "A completed idempotency record is missing its result reference.",
+    evidenceRefs: [idempotencyRecordEvidenceRef(scope, key), "idempotency.result_ref"],
+    recommendedNextActions: ["Inspect and repair the idempotency record before retrying."]
+  });
+}
+
+function missingTransitionRecordError(
+  scope: IdempotencyScope,
+  key: string,
+  message: string
+): TaskServiceError {
+  return new TaskServiceError({
+    code: "record_malformed",
+    status: 500,
+    category: "workspace_error",
+    message,
+    userMessage: "The idempotency record could not be updated safely.",
+    evidenceRefs: [idempotencyRecordEvidenceRef(scope, key)],
+    recommendedNextActions: ["Inspect the idempotency record state before retrying."]
+  });
+}
+
+function invalidTransitionStateError(
+  scope: IdempotencyScope,
+  key: string,
+  targetStatus: "completed" | "failed",
+  message: string,
+  userMessage: string
+): TaskServiceError {
+  return new TaskServiceError({
+    code: "record_schema_error",
+    status: 400,
+    category: "schema_error",
+    message,
+    userMessage,
+    evidenceRefs: [idempotencyRecordEvidenceRef(scope, key), "idempotency.status"],
+    recommendedNextActions: [
+      `Repair the idempotency record before marking it ${targetStatus}.`
+    ]
+  });
+}
+
+function transitionGuardBusyError(
+  scope: IdempotencyScope,
+  key: string,
+  transition: "complete" | "fail"
+): TaskServiceError {
+  return new TaskServiceError({
+    code: "record_malformed",
+    status: 500,
+    category: "workspace_error",
+    message: `Idempotency record ${transition} transition is already in progress.`,
+    userMessage: "The idempotency record is being updated by another request.",
+    evidenceRefs: [idempotencyRecordEvidenceRef(scope, key)],
+    retryable: true,
+    recommendedNextActions: ["Retry after the in-progress idempotency transition finishes."]
+  });
+}
+
+async function lookupExistingRecordForBegin(
+  service: IdempotencyRecordService,
+  input: IdempotencyRecordLookupInput,
+  evidenceRef: string
+): Promise<Exclude<IdempotencyReplayLookup, { status: "missing" }>> {
+  const existing = await service.lookupReplay(input);
+  if (existing.status === "missing") {
+    throw new TaskServiceError({
+      code: "record_malformed",
+      status: 500,
+      category: "workspace_error",
+      message: "Idempotency record was not readable during transition acquisition.",
+      userMessage: "The idempotency record could not be updated safely.",
+      evidenceRefs: [evidenceRef],
+      recommendedNextActions: ["Inspect the idempotency record state before retrying."]
+    });
+  }
+
+  return existing;
+}
+
+function beginResultFromReplayLookup(
+  lookup: Exclude<IdempotencyReplayLookup, { status: "missing" }>
+): BeginIdempotencyRecordResult {
+  if (lookup.status === "mismatch") {
+    return { status: "mismatch", record: lookup.record };
+  }
+  if (lookup.status === "completed") {
+    return { status: "completed", record: lookup.record };
+  }
+
+  return { status: "incomplete", record: lookup.record };
+}
+
+function beginResultFromStoredRecord(
+  record: IdempotencyRecord,
+  requestDigest: string,
+  scope: IdempotencyScope,
+  key: string
+): BeginIdempotencyRecordResult {
+  if (record.request_digest !== requestDigest) {
+    return { status: "mismatch", record };
+  }
+  if (record.status === "completed") {
+    if (!record.result_ref) {
+      throw completedRecordMissingResultRefError(scope, key);
+    }
+
+    return {
+      status: "completed",
+      record: record as IdempotencyRecord & { result_ref: string }
+    };
+  }
+  if (record.status === "started") {
+    return { status: "acquired", record };
+  }
+
+  return { status: "incomplete", record };
 }
 
 export function canonicalJson(value: unknown): string {
@@ -234,4 +739,13 @@ function assertIdempotencyScope(scope: IdempotencyScope): IdempotencyScope {
     evidenceRefs: ["idempotency.scope"],
     recommendedNextActions: ["Use a supported idempotency scope."]
   });
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === code
+  );
 }

--- a/packages/core/src/domain/services/idempotency-service.ts
+++ b/packages/core/src/domain/services/idempotency-service.ts
@@ -1,0 +1,237 @@
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import {
+  IdempotencyRecordSchema,
+  IdempotencyScopeSchema,
+  type IdempotencyRecord,
+  type IdempotencyScope
+} from "../schemas/idempotency";
+import { TaskServiceError } from "./task-card-service";
+import {
+  readJsonRecord,
+  workspaceRecordPath,
+  writeJsonRecord
+} from "./workspace-record-store";
+
+export interface IdempotencyRecordServiceOptions {
+  workspaceRoot: string;
+  now?: () => Date;
+}
+
+export interface IdempotencyRecordLookupInput {
+  scope: IdempotencyScope;
+  key: string;
+  requestDigest: string;
+}
+
+export type IdempotencyReplayLookup =
+  | { status: "missing" }
+  | { status: "mismatch"; record: IdempotencyRecord }
+  | { status: "incomplete"; record: IdempotencyRecord }
+  | { status: "completed"; record: IdempotencyRecord & { result_ref: string } };
+
+export interface CompleteIdempotencyRecordInput extends IdempotencyRecordLookupInput {
+  resultRef: string;
+}
+
+export interface IdempotencyRecordService {
+  storeRecord: (record: IdempotencyRecord) => Promise<IdempotencyRecord>;
+  getRecord: (scope: IdempotencyScope, key: string) => Promise<IdempotencyRecord | undefined>;
+  lookupReplay: (input: IdempotencyRecordLookupInput) => Promise<IdempotencyReplayLookup>;
+  completeRecord: (input: CompleteIdempotencyRecordInput) => Promise<IdempotencyRecord>;
+}
+
+export function createIdempotencyRecordService(
+  options: IdempotencyRecordServiceOptions
+): IdempotencyRecordService {
+  const workspaceRoot = resolve(options.workspaceRoot);
+  const now = options.now ?? (() => new Date());
+
+  const service: IdempotencyRecordService = {
+    async storeRecord(record: IdempotencyRecord): Promise<IdempotencyRecord> {
+      const parsedRecord = IdempotencyRecordSchema.safeParse(record);
+      if (!parsedRecord.success) {
+        return await writeJsonRecord(
+          workspaceRoot,
+          idempotencyRecordDirectorySegments("task"),
+          "invalid.json",
+          record,
+          "workspace/tasks/_idempotency",
+          IdempotencyRecordSchema
+        );
+      }
+
+      return await writeJsonRecord(
+        workspaceRoot,
+        idempotencyRecordDirectorySegments(parsedRecord.data.scope),
+        idempotencyRecordFileName(parsedRecord.data.key),
+        parsedRecord.data,
+        idempotencyRecordEvidenceRef(parsedRecord.data.scope, parsedRecord.data.key),
+        IdempotencyRecordSchema
+      );
+    },
+
+    async getRecord(
+      scope: IdempotencyScope,
+      key: string
+    ): Promise<IdempotencyRecord | undefined> {
+      const parsedScope = assertIdempotencyScope(scope);
+      assertNonblankIdempotencyKey(key);
+      const recordPath = workspaceRecordPath(
+        workspaceRoot,
+        [...idempotencyRecordDirectorySegments(parsedScope), idempotencyRecordFileName(key)],
+        idempotencyRecordEvidenceRef(parsedScope, key)
+      );
+
+      return await readJsonRecord(
+        recordPath,
+        idempotencyRecordEvidenceRef(parsedScope, key),
+        IdempotencyRecordSchema
+      );
+    },
+
+    async lookupReplay(input: IdempotencyRecordLookupInput): Promise<IdempotencyReplayLookup> {
+      const parsedScope = assertIdempotencyScope(input.scope);
+      assertNonblankIdempotencyKey(input.key);
+      const record = await service.getRecord(parsedScope, input.key);
+      if (!record) {
+        return { status: "missing" };
+      }
+      if (record.request_digest !== input.requestDigest) {
+        return { status: "mismatch", record };
+      }
+      if (record.status === "completed") {
+        if (!record.result_ref) {
+          throw new TaskServiceError({
+            code: "record_malformed",
+            status: 500,
+            category: "workspace_error",
+            message: "Completed idempotency record is missing result_ref.",
+            userMessage: "A completed idempotency record is missing its result reference.",
+            evidenceRefs: [
+              idempotencyRecordEvidenceRef(parsedScope, input.key),
+              "idempotency.result_ref"
+            ],
+            recommendedNextActions: ["Inspect and repair the idempotency record before retrying."]
+          });
+        }
+
+        return { status: "completed", record: record as IdempotencyRecord & { result_ref: string } };
+      }
+
+      return { status: "incomplete", record };
+    },
+
+    async completeRecord(input: CompleteIdempotencyRecordInput): Promise<IdempotencyRecord> {
+      const parsedScope = assertIdempotencyScope(input.scope);
+      assertNonblankIdempotencyKey(input.key);
+      const existing = await service.lookupReplay({ ...input, scope: parsedScope });
+      if (existing.status === "mismatch") {
+        throw createIdempotencyMismatchError();
+      }
+      if (existing.status === "completed") {
+        return existing.record;
+      }
+
+      const timestamp = now().toISOString();
+      return await service.storeRecord({
+        key: input.key,
+        scope: parsedScope,
+        request_digest: input.requestDigest,
+        status: "completed",
+        result_ref: input.resultRef,
+        created_at: existing.status === "incomplete" ? existing.record.created_at : timestamp,
+        updated_at: timestamp
+      });
+    }
+  };
+
+  return service;
+}
+
+export function idempotencyRecordFileName(key: string): string {
+  assertNonblankIdempotencyKey(key);
+  return `${sha256Hex(key)}.json`;
+}
+
+export function idempotencyRecordEvidenceRef(scope: IdempotencyScope, key: string): string {
+  const parsedScope = assertIdempotencyScope(scope);
+  assertNonblankIdempotencyKey(key);
+  return join("workspace", "tasks", "_idempotency", parsedScope, idempotencyRecordFileName(key));
+}
+
+export function idempotencyRecordDirectorySegments(
+  scope: IdempotencyScope
+): readonly string[] {
+  return ["tasks", "_idempotency", assertIdempotencyScope(scope)];
+}
+
+export function createIdempotencyMismatchError(): TaskServiceError {
+  return new TaskServiceError({
+    code: "idempotency_mismatch",
+    status: 422,
+    category: "idempotency_mismatch",
+    message: "Idempotency key mismatch for task create request.",
+    userMessage: "This idempotency key was already used with different request content.",
+    evidenceRefs: [
+      "request.headers.Idempotency-Key",
+      "idempotency.scope:task",
+      "idempotency.request_digest"
+    ],
+    retryable: false,
+    recommendedNextActions: ["Use the original request body or choose a new idempotency key."]
+  });
+}
+
+export function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  }
+
+  if (value !== null && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const keys = Object.keys(record).filter((key) => record[key] !== undefined).sort();
+    return `{${keys
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+export function sha256Hex(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function assertNonblankIdempotencyKey(key: string): void {
+  if (typeof key === "string" && key.trim().length > 0) {
+    return;
+  }
+
+  throw new TaskServiceError({
+    code: "record_id_not_safe",
+    status: 400,
+    category: "schema_error",
+    message: "Idempotency key must be nonblank.",
+    userMessage: "The idempotency key must be nonblank when provided.",
+    evidenceRefs: ["request.headers.Idempotency-Key"],
+    recommendedNextActions: ["Provide a nonblank idempotency key or omit the header."]
+  });
+}
+
+function assertIdempotencyScope(scope: IdempotencyScope): IdempotencyScope {
+  const parsedScope = IdempotencyScopeSchema.safeParse(scope);
+  if (parsedScope.success) {
+    return parsedScope.data;
+  }
+
+  throw new TaskServiceError({
+    code: "record_id_not_safe",
+    status: 400,
+    category: "schema_error",
+    message: "Idempotency scope is not supported.",
+    userMessage: "The idempotency scope is not supported.",
+    evidenceRefs: ["idempotency.scope"],
+    recommendedNextActions: ["Use a supported idempotency scope."]
+  });
+}

--- a/packages/core/src/domain/services/idempotency-service.ts
+++ b/packages/core/src/domain/services/idempotency-service.ts
@@ -9,7 +9,7 @@ import {
   type IdempotencyRecord,
   type IdempotencyScope
 } from "../schemas/idempotency";
-import { TaskServiceError } from "./task-card-service";
+import { TaskServiceError, isSafeTaskId } from "./task-card-service";
 import {
   createJsonRecordIfAbsent,
   readJsonRecord,
@@ -70,6 +70,12 @@ export interface IdempotencyRecordService {
   lookupReplay: (input: IdempotencyRecordLookupInput) => Promise<IdempotencyReplayLookup>;
   completeRecord: (input: CompleteIdempotencyRecordInput) => Promise<IdempotencyRecord>;
   failRecord: (input: FailIdempotencyRecordInput) => Promise<IdempotencyRecord>;
+  recoverFailedRecordAfterRollback: (
+    input: FailIdempotencyRecordInput
+  ) => Promise<IdempotencyRecord>;
+  recoverCompletedRecordAfterRollbackFailure: (
+    input: CompleteIdempotencyRecordInput
+  ) => Promise<IdempotencyRecord>;
 }
 
 export function createIdempotencyRecordService(
@@ -78,43 +84,97 @@ export function createIdempotencyRecordService(
   const workspaceRoot = resolve(options.workspaceRoot);
   const now = options.now ?? (() => new Date());
 
-  const service: IdempotencyRecordService = {
-    async storeRecord(record: IdempotencyRecord): Promise<IdempotencyRecord> {
-      const parsedRecord = IdempotencyRecordSchema.safeParse(record);
-      if (!parsedRecord.success) {
-        return await writeJsonRecord(
-          workspaceRoot,
-          idempotencyRecordDirectorySegments("task"),
-          "invalid.json",
-          record,
-          "workspace/tasks/_idempotency",
-          IdempotencyRecordSchema
-        );
-      }
-      assertPersistableIdempotencyRecord(
-        parsedRecord.data,
-        idempotencyRecordEvidenceRef(parsedRecord.data.scope, parsedRecord.data.key)
-      );
-      const existing = await service.getRecord(parsedRecord.data.scope, parsedRecord.data.key);
-      if (existing && existing.request_digest !== parsedRecord.data.request_digest) {
-        throw createIdempotencyMismatchError();
-      }
-      if (existing?.status === "completed") {
-        return assertCompletedRecordStoreAllowed(
-          existing,
-          parsedRecord.data,
-          idempotencyRecordEvidenceRef(parsedRecord.data.scope, parsedRecord.data.key)
-        );
-      }
-
+  async function storeRecordInternal(
+    record: IdempotencyRecord,
+    options: { allowCompletedWrite: boolean }
+  ): Promise<IdempotencyRecord> {
+    const parsedRecord = IdempotencyRecordSchema.safeParse(record);
+    if (!parsedRecord.success) {
       return await writeJsonRecord(
         workspaceRoot,
-        idempotencyRecordDirectorySegments(parsedRecord.data.scope),
-        idempotencyRecordFileName(parsedRecord.data.key),
-        parsedRecord.data,
-        idempotencyRecordEvidenceRef(parsedRecord.data.scope, parsedRecord.data.key),
+        idempotencyRecordDirectorySegments("task"),
+        "invalid.json",
+        record,
+        "workspace/tasks/_idempotency",
         IdempotencyRecordSchema
       );
+    }
+    const evidenceRef = idempotencyRecordEvidenceRef(
+      parsedRecord.data.scope,
+      parsedRecord.data.key
+    );
+    assertPersistableIdempotencyRecord(parsedRecord.data, evidenceRef);
+    assertTaskScopeResultRef(parsedRecord.data, evidenceRef);
+    const existing = await service.getRecord(parsedRecord.data.scope, parsedRecord.data.key);
+    if (existing && existing.request_digest !== parsedRecord.data.request_digest) {
+      throw createIdempotencyMismatchError();
+    }
+    if (parsedRecord.data.status === "completed" && !options.allowCompletedWrite) {
+      if (existing?.status === "completed") {
+        return assertCompletedRecordStoreAllowed(existing, parsedRecord.data, evidenceRef);
+      }
+      throw completedRecordStoreBypassError(evidenceRef);
+    }
+    if (existing?.status === "completed") {
+      return assertCompletedRecordStoreAllowed(existing, parsedRecord.data, evidenceRef);
+    }
+
+    return await writeJsonRecord(
+      workspaceRoot,
+      idempotencyRecordDirectorySegments(parsedRecord.data.scope),
+      idempotencyRecordFileName(parsedRecord.data.key),
+      parsedRecord.data,
+      evidenceRef,
+      IdempotencyRecordSchema
+    );
+  }
+
+  async function recoverRecordAfterRollback(
+    input: IdempotencyRecordLookupInput,
+    transition: () => Promise<IdempotencyRecord>
+  ): Promise<IdempotencyRecord> {
+    try {
+      return await transition();
+    } catch (error) {
+      if (!(error instanceof TaskServiceError) || error.code !== "record_malformed") {
+        throw error;
+      }
+    }
+
+    const parsedScope = assertIdempotencyScope(input.scope);
+    assertNonblankIdempotencyKey(input.key);
+    const evidenceRef = idempotencyRecordEvidenceRef(parsedScope, input.key);
+    const current = await lookupExistingRecordForBegin(
+      service,
+      { ...input, scope: parsedScope },
+      evidenceRef
+    );
+    if (current.status === "mismatch") {
+      throw createIdempotencyMismatchError();
+    }
+    if (current.status === "completed") {
+      return current.record;
+    }
+    if (current.record.status === "failed") {
+      return current.record;
+    }
+    if (current.record.request_digest !== input.requestDigest) {
+      throw createIdempotencyMismatchError();
+    }
+
+    await removeRecoverableIdempotencyTransitionGuardForRollbackRecovery(
+      workspaceRoot,
+      parsedScope,
+      input.key,
+      evidenceRef,
+      "fail"
+    );
+    return await transition();
+  }
+
+  const service: IdempotencyRecordService = {
+    async storeRecord(record: IdempotencyRecord): Promise<IdempotencyRecord> {
+      return await storeRecordInternal(record, { allowCompletedWrite: false });
     },
 
     async getRecord(
@@ -216,7 +276,7 @@ export function createIdempotencyRecordService(
             return beginResultFromReplayLookup(retryExisting);
           }
 
-          const stored = await service.storeRecord(record);
+          const stored = await storeRecordInternal(record, { allowCompletedWrite: false });
           return beginResultFromStoredRecord(stored, input.requestDigest, parsedScope, input.key);
         } finally {
           await guard.release();
@@ -240,6 +300,11 @@ export function createIdempotencyRecordService(
         if (!record.result_ref) {
           throw completedRecordMissingResultRefError(parsedScope, input.key);
         }
+        assertTaskScopeCompletedResultRef(
+          record as IdempotencyRecord & { result_ref: string },
+          parsedScope,
+          input.key
+        );
 
         return { status: "completed", record: record as IdempotencyRecord & { result_ref: string } };
       }
@@ -250,6 +315,7 @@ export function createIdempotencyRecordService(
     async completeRecord(input: CompleteIdempotencyRecordInput): Promise<IdempotencyRecord> {
       const parsedScope = assertIdempotencyScope(input.scope);
       assertNonblankIdempotencyKey(input.key);
+      assertTaskScopeInputResultRef(parsedScope, input.key, input.resultRef);
       const evidenceRef = idempotencyRecordEvidenceRef(parsedScope, input.key);
       const observed = await service.lookupReplay({ ...input, scope: parsedScope });
       if (observed.status === "mismatch") {
@@ -306,7 +372,7 @@ export function createIdempotencyRecordService(
         }
 
         const timestamp = now().toISOString();
-        return await service.storeRecord({
+        return await storeRecordInternal({
           key: input.key,
           scope: parsedScope,
           request_digest: input.requestDigest,
@@ -314,7 +380,7 @@ export function createIdempotencyRecordService(
           result_ref: input.resultRef,
           created_at: existing.record.created_at,
           updated_at: timestamp
-        });
+        }, { allowCompletedWrite: true });
       } finally {
         await guard.release();
       }
@@ -383,14 +449,57 @@ export function createIdempotencyRecordService(
 
         const recordWithoutResultRef = { ...existing.record };
         delete recordWithoutResultRef.result_ref;
-        return await service.storeRecord({
+        return await storeRecordInternal({
           ...recordWithoutResultRef,
           status: "failed",
           updated_at: now().toISOString()
-        });
+        }, { allowCompletedWrite: false });
       } finally {
         await guard.release();
       }
+    },
+
+    async recoverFailedRecordAfterRollback(
+      input: FailIdempotencyRecordInput
+    ): Promise<IdempotencyRecord> {
+      return await recoverRecordAfterRollback(input, async () => service.failRecord(input));
+    },
+
+    async recoverCompletedRecordAfterRollbackFailure(
+      input: CompleteIdempotencyRecordInput
+    ): Promise<IdempotencyRecord> {
+      const parsedScope = assertIdempotencyScope(input.scope);
+      assertNonblankIdempotencyKey(input.key);
+      assertTaskScopeInputResultRef(parsedScope, input.key, input.resultRef);
+      const evidenceRef = idempotencyRecordEvidenceRef(parsedScope, input.key);
+      const current = await lookupExistingRecordForBegin(
+        service,
+        { ...input, scope: parsedScope },
+        evidenceRef
+      );
+      if (current.status === "mismatch") {
+        throw createIdempotencyMismatchError();
+      }
+      if (current.status === "completed") {
+        return current.record;
+      }
+      if (current.record.request_digest !== input.requestDigest) {
+        throw createIdempotencyMismatchError();
+      }
+
+      await removeRecoverableIdempotencyTransitionGuardForRollbackRecovery(
+        workspaceRoot,
+        parsedScope,
+        input.key,
+        evidenceRef,
+        "complete"
+      );
+      return await storeRecordInternal({
+        ...current.record,
+        status: "completed",
+        result_ref: input.resultRef,
+        updated_at: now().toISOString()
+      }, { allowCompletedWrite: true });
     }
   };
 
@@ -499,6 +608,84 @@ async function removeStaleIdempotencyTransitionGuard(
   return true;
 }
 
+async function removeRecoverableIdempotencyTransitionGuardForRollbackRecovery(
+  workspaceRoot: string,
+  scope: IdempotencyScope,
+  key: string,
+  evidenceRef: string,
+  transition: "complete" | "fail"
+): Promise<void> {
+  const guardPath = workspaceRecordPath(
+    workspaceRoot,
+    [...idempotencyRecordDirectorySegments(scope), idempotencyTransitionGuardFileName(key)],
+    evidenceRef
+  );
+
+  let guard: IdempotencyTransitionGuard | undefined;
+  try {
+    guard = await readJsonRecord(
+      guardPath,
+      evidenceRef,
+      IdempotencyTransitionGuardSchema
+    );
+  } catch (error) {
+    if (!isRecoverableTransitionGuardRecordError(error)) {
+      throw error;
+    }
+
+    await unlinkIdempotencyTransitionGuardForRollbackRecovery(guardPath, evidenceRef);
+    return;
+  }
+
+  if (!guard) {
+    return;
+  }
+
+  if (isIdempotencyTransitionGuardStale(guard)) {
+    await unlinkIdempotencyTransitionGuardForRollbackRecovery(guardPath, evidenceRef);
+    return;
+  }
+
+  throw transitionGuardBusyError(scope, key, transition);
+}
+
+async function unlinkIdempotencyTransitionGuardForRollbackRecovery(
+  guardPath: string,
+  evidenceRef: string
+): Promise<void> {
+  try {
+    await unlink(guardPath);
+  } catch (error) {
+    if (hasErrorCode(error, "ENOENT")) {
+      return;
+    }
+
+    throw new TaskServiceError({
+      code: "workspace_path_not_safe",
+      status: 500,
+      category: "workspace_error",
+      message: "Failed to remove idempotency transition guard during rollback recovery.",
+      userMessage: "The idempotency record could not be recovered safely.",
+      evidenceRefs: [evidenceRef],
+      retryable: false,
+      recommendedNextActions: ["Inspect the idempotency transition guard before retrying."]
+    });
+  }
+}
+
+function isIdempotencyTransitionGuardStale(guard: IdempotencyTransitionGuard): boolean {
+  const ageMs = Date.now() - guard.acquired_at_ms;
+  const ownerIsGone = guard.owner_pid !== process.pid && !isProcessLikelyAlive(guard.owner_pid);
+  return ageMs >= IDEMPOTENCY_TRANSITION_GUARD_STALE_MS || ownerIsGone;
+}
+
+function isRecoverableTransitionGuardRecordError(error: unknown): boolean {
+  return (
+    error instanceof TaskServiceError &&
+    (error.code === "record_malformed" || error.code === "record_schema_error")
+  );
+}
+
 function isProcessLikelyAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -541,6 +728,69 @@ function assertPersistableIdempotencyRecord(
     userMessage: "A completed idempotency record must include its result reference.",
     evidenceRefs: [evidenceRef, "idempotency.result_ref"],
     recommendedNextActions: ["Set result_ref before storing a completed idempotency record."]
+  });
+}
+
+function assertTaskScopeResultRef(record: IdempotencyRecord, evidenceRef: string): void {
+  if (
+    record.scope !== "task" ||
+    record.status !== "completed" ||
+    typeof record.result_ref !== "string" ||
+    isSafeTaskId(record.result_ref)
+  ) {
+    return;
+  }
+
+  throw unsafeTaskResultRefError(evidenceRef);
+}
+
+function assertTaskScopeInputResultRef(
+  scope: IdempotencyScope,
+  key: string,
+  resultRef: string
+): void {
+  if (scope !== "task" || isSafeTaskId(resultRef)) {
+    return;
+  }
+
+  throw unsafeTaskResultRefError(idempotencyRecordEvidenceRef(scope, key));
+}
+
+function assertTaskScopeCompletedResultRef(
+  record: IdempotencyRecord & { result_ref: string },
+  scope: IdempotencyScope,
+  key: string
+): void {
+  if (scope !== "task" || isSafeTaskId(record.result_ref)) {
+    return;
+  }
+
+  throw unsafeTaskResultRefError(idempotencyRecordEvidenceRef(scope, key));
+}
+
+function unsafeTaskResultRefError(evidenceRef: string): TaskServiceError {
+  return new TaskServiceError({
+    code: "record_malformed",
+    status: 500,
+    category: "workspace_error",
+    message: "Completed task idempotency result_ref is not a safe TaskCard id.",
+    userMessage: "The idempotency result reference cannot be used safely.",
+    evidenceRefs: [evidenceRef, "idempotency.result_ref"],
+    retryable: false,
+    recommendedNextActions: ["Inspect and repair the idempotency result reference before retrying."]
+  });
+}
+
+function completedRecordStoreBypassError(evidenceRef: string): TaskServiceError {
+  return new TaskServiceError({
+    code: "record_schema_error",
+    status: 400,
+    category: "schema_error",
+    message: "Completed idempotency records must be written through completeRecord.",
+    userMessage: "A completed idempotency record cannot be stored directly.",
+    evidenceRefs: [evidenceRef, "idempotency.status"],
+    retryable: false,
+    recommendedNextActions: ["Use beginRecord and completeRecord to finish an idempotency claim."]
   });
 }
 
@@ -711,6 +961,11 @@ function beginResultFromStoredRecord(
     if (!record.result_ref) {
       throw completedRecordMissingResultRefError(scope, key);
     }
+    assertTaskScopeCompletedResultRef(
+      record as IdempotencyRecord & { result_ref: string },
+      scope,
+      key
+    );
 
     return {
       status: "completed",

--- a/packages/core/src/domain/services/idempotency-service.ts
+++ b/packages/core/src/domain/services/idempotency-service.ts
@@ -96,6 +96,9 @@ export function createIdempotencyRecordService(
         idempotencyRecordEvidenceRef(parsedRecord.data.scope, parsedRecord.data.key)
       );
       const existing = await service.getRecord(parsedRecord.data.scope, parsedRecord.data.key);
+      if (existing && existing.request_digest !== parsedRecord.data.request_digest) {
+        throw createIdempotencyMismatchError();
+      }
       if (existing?.status === "completed") {
         return assertCompletedRecordStoreAllowed(
           existing,
@@ -470,7 +473,7 @@ async function removeStaleIdempotencyTransitionGuard(
     guardPath,
     evidenceRef,
     IdempotencyTransitionGuardSchema
-  ).catch(() => undefined);
+  );
   if (!existing) {
     return true;
   }

--- a/packages/core/src/domain/services/idempotency-service.ts
+++ b/packages/core/src/domain/services/idempotency-service.ts
@@ -1263,7 +1263,7 @@ function transitionGuardBusyError(
 ): TaskServiceError {
   return new TaskServiceError({
     code: "record_malformed",
-    status: 500,
+    status: 409,
     category: "workspace_error",
     message: `Idempotency record ${transition} transition is already in progress.`,
     userMessage: "The idempotency record is being updated by another request.",

--- a/packages/core/src/domain/services/idempotency-service.ts
+++ b/packages/core/src/domain/services/idempotency-service.ts
@@ -129,11 +129,22 @@ export function createIdempotencyRecordService(
         idempotencyRecordEvidenceRef(parsedScope, key)
       );
 
-      return await readJsonRecord(
+      const record = await readJsonRecord(
         recordPath,
         idempotencyRecordEvidenceRef(parsedScope, key),
         IdempotencyRecordSchema
       );
+      if (!record) {
+        return undefined;
+      }
+
+      assertIdempotencyRecordLookupIdentity(
+        record,
+        parsedScope,
+        key,
+        idempotencyRecordEvidenceRef(parsedScope, key)
+      );
+      return record;
     },
 
     async beginRecord(
@@ -574,6 +585,28 @@ function completedRecordMissingResultRefError(
     message: "Completed idempotency record is missing result_ref.",
     userMessage: "A completed idempotency record is missing its result reference.",
     evidenceRefs: [idempotencyRecordEvidenceRef(scope, key), "idempotency.result_ref"],
+    recommendedNextActions: ["Inspect and repair the idempotency record before retrying."]
+  });
+}
+
+function assertIdempotencyRecordLookupIdentity(
+  record: IdempotencyRecord,
+  scope: IdempotencyScope,
+  key: string,
+  evidenceRef: string
+): void {
+  if (record.scope === scope && record.key === key) {
+    return;
+  }
+
+  throw new TaskServiceError({
+    code: "record_malformed",
+    status: 500,
+    category: "workspace_error",
+    message: "Idempotency record identity does not match its lookup path.",
+    userMessage: "The idempotency record cannot be used safely.",
+    evidenceRefs: [evidenceRef, "idempotency.key", "idempotency.scope"],
+    retryable: false,
     recommendedNextActions: ["Inspect and repair the idempotency record before retrying."]
   });
 }

--- a/packages/core/src/domain/services/idempotency-service.ts
+++ b/packages/core/src/domain/services/idempotency-service.ts
@@ -37,6 +37,19 @@ type IdempotencyTransitionGuardAcquire =
 export interface IdempotencyRecordServiceOptions {
   workspaceRoot: string;
   now?: () => Date;
+  transitionGuardHooks?: IdempotencyTransitionGuardHooks;
+}
+
+export interface IdempotencyTransitionGuardCleanupHookInput {
+  guardPath: string;
+  evidenceRef: string;
+  observedGuard: IdempotencyTransitionGuard;
+}
+
+export interface IdempotencyTransitionGuardHooks {
+  beforeStaleGuardCleanup?: (
+    input: IdempotencyTransitionGuardCleanupHookInput
+  ) => Promise<void> | void;
 }
 
 export interface IdempotencyRecordLookupInput {
@@ -76,6 +89,9 @@ export interface IdempotencyRecordService {
   recoverCompletedRecordAfterRollbackFailure: (
     input: CompleteIdempotencyRecordInput
   ) => Promise<IdempotencyRecord>;
+  quarantineRecordAfterUnsafeRollback: (
+    input: FailIdempotencyRecordInput
+  ) => Promise<IdempotencyRecord>;
 }
 
 export function createIdempotencyRecordService(
@@ -83,10 +99,11 @@ export function createIdempotencyRecordService(
 ): IdempotencyRecordService {
   const workspaceRoot = resolve(options.workspaceRoot);
   const now = options.now ?? (() => new Date());
+  const transitionGuardHooks = options.transitionGuardHooks;
 
   async function storeRecordInternal(
     record: IdempotencyRecord,
-    options: { allowCompletedWrite: boolean }
+    options: { allowCompletedWrite: boolean; allowExistingMutation: boolean }
   ): Promise<IdempotencyRecord> {
     const parsedRecord = IdempotencyRecordSchema.safeParse(record);
     if (!parsedRecord.success) {
@@ -110,13 +127,29 @@ export function createIdempotencyRecordService(
       throw createIdempotencyMismatchError();
     }
     if (parsedRecord.data.status === "completed" && !options.allowCompletedWrite) {
-      if (existing?.status === "completed") {
-        return assertCompletedRecordStoreAllowed(existing, parsedRecord.data, evidenceRef);
-      }
       throw completedRecordStoreBypassError(evidenceRef);
     }
     if (existing?.status === "completed") {
       return assertCompletedRecordStoreAllowed(existing, parsedRecord.data, evidenceRef);
+    }
+    if (existing && !options.allowExistingMutation) {
+      throw idempotencyRecordStoreExistingError(evidenceRef);
+    }
+
+    if (!options.allowExistingMutation) {
+      const created = await createJsonRecordIfAbsent(
+        workspaceRoot,
+        idempotencyRecordDirectorySegments(parsedRecord.data.scope),
+        idempotencyRecordFileName(parsedRecord.data.key),
+        parsedRecord.data,
+        evidenceRef,
+        IdempotencyRecordSchema
+      );
+      if (created.status === "created") {
+        return created.record;
+      }
+
+      throw idempotencyRecordStoreExistingError(evidenceRef);
     }
 
     return await writeJsonRecord(
@@ -174,7 +207,10 @@ export function createIdempotencyRecordService(
 
   const service: IdempotencyRecordService = {
     async storeRecord(record: IdempotencyRecord): Promise<IdempotencyRecord> {
-      return await storeRecordInternal(record, { allowCompletedWrite: false });
+      return await storeRecordInternal(record, {
+        allowCompletedWrite: false,
+        allowExistingMutation: false
+      });
     },
 
     async getRecord(
@@ -252,7 +288,8 @@ export function createIdempotencyRecordService(
           workspaceRoot,
           parsedScope,
           input.key,
-          evidenceRef
+          evidenceRef,
+          transitionGuardHooks
         );
         if (guard.status === "busy") {
           return beginResultFromReplayLookup(
@@ -276,7 +313,10 @@ export function createIdempotencyRecordService(
             return beginResultFromReplayLookup(retryExisting);
           }
 
-          const stored = await storeRecordInternal(record, { allowCompletedWrite: false });
+          const stored = await storeRecordInternal(record, {
+            allowCompletedWrite: false,
+            allowExistingMutation: true
+          });
           return beginResultFromStoredRecord(stored, input.requestDigest, parsedScope, input.key);
         } finally {
           await guard.release();
@@ -336,7 +376,8 @@ export function createIdempotencyRecordService(
         workspaceRoot,
         parsedScope,
         input.key,
-        evidenceRef
+        evidenceRef,
+        transitionGuardHooks
       );
       if (guard.status === "busy") {
         const current = await service.lookupReplay({ ...input, scope: parsedScope });
@@ -380,7 +421,7 @@ export function createIdempotencyRecordService(
           result_ref: input.resultRef,
           created_at: existing.record.created_at,
           updated_at: timestamp
-        }, { allowCompletedWrite: true });
+        }, { allowCompletedWrite: true, allowExistingMutation: true });
       } finally {
         await guard.release();
       }
@@ -409,7 +450,8 @@ export function createIdempotencyRecordService(
         workspaceRoot,
         parsedScope,
         input.key,
-        evidenceRef
+        evidenceRef,
+        transitionGuardHooks
       );
       if (guard.status === "busy") {
         const current = await service.lookupReplay({ ...input, scope: parsedScope });
@@ -453,7 +495,7 @@ export function createIdempotencyRecordService(
           ...recordWithoutResultRef,
           status: "failed",
           updated_at: now().toISOString()
-        }, { allowCompletedWrite: false });
+        }, { allowCompletedWrite: false, allowExistingMutation: true });
       } finally {
         await guard.release();
       }
@@ -499,7 +541,37 @@ export function createIdempotencyRecordService(
         status: "completed",
         result_ref: input.resultRef,
         updated_at: now().toISOString()
-      }, { allowCompletedWrite: true });
+      }, { allowCompletedWrite: true, allowExistingMutation: true });
+    },
+
+    async quarantineRecordAfterUnsafeRollback(
+      input: FailIdempotencyRecordInput
+    ): Promise<IdempotencyRecord> {
+      const parsedScope = assertIdempotencyScope(input.scope);
+      assertNonblankIdempotencyKey(input.key);
+      const evidenceRef = idempotencyRecordEvidenceRef(parsedScope, input.key);
+      const current = await lookupExistingRecordForBegin(
+        service,
+        { ...input, scope: parsedScope },
+        evidenceRef
+      );
+      if (current.status === "mismatch") {
+        throw createIdempotencyMismatchError();
+      }
+      if (current.status === "completed") {
+        return current.record;
+      }
+      if (current.record.request_digest !== input.requestDigest) {
+        throw createIdempotencyMismatchError();
+      }
+
+      const recordWithoutResultRef = { ...current.record };
+      delete recordWithoutResultRef.result_ref;
+      return await storeRecordInternal({
+        ...recordWithoutResultRef,
+        status: "started",
+        updated_at: now().toISOString()
+      }, { allowCompletedWrite: false, allowExistingMutation: true });
     }
   };
 
@@ -532,7 +604,8 @@ async function acquireIdempotencyTransitionGuard(
   workspaceRoot: string,
   scope: IdempotencyScope,
   key: string,
-  evidenceRef: string
+  evidenceRef: string,
+  transitionGuardHooks?: IdempotencyTransitionGuardHooks
 ): Promise<IdempotencyTransitionGuardAcquire> {
   const directorySegments = idempotencyRecordDirectorySegments(scope);
   const guardFileName = idempotencyTransitionGuardFileName(key);
@@ -550,14 +623,33 @@ async function acquireIdempotencyTransitionGuard(
       acquired_at_ms: Date.now(),
       acquired_at: new Date().toISOString()
     };
-    const created = await createJsonRecordIfAbsent(
+    const publishLock = await acquireIdempotencyTransitionCleanupLock(
       workspaceRoot,
-      directorySegments,
-      guardFileName,
-      guard,
-      evidenceRef,
-      IdempotencyTransitionGuardSchema
+      scope,
+      key,
+      evidenceRef
     );
+    if (publishLock.status === "busy") {
+      if (Date.now() >= deadline) {
+        return { status: "busy" };
+      }
+      await sleep(IDEMPOTENCY_TRANSITION_GUARD_POLL_MS);
+      continue;
+    }
+
+    let created: Awaited<ReturnType<typeof createJsonRecordIfAbsent<IdempotencyTransitionGuard>>>;
+    try {
+      created = await createJsonRecordIfAbsent(
+        workspaceRoot,
+        directorySegments,
+        guardFileName,
+        guard,
+        evidenceRef,
+        IdempotencyTransitionGuardSchema
+      );
+    } finally {
+      await publishLock.release();
+    }
     if (created.status === "created") {
       return {
         status: "acquired",
@@ -574,7 +666,16 @@ async function acquireIdempotencyTransitionGuard(
       };
     }
 
-    if (await removeStaleIdempotencyTransitionGuard(guardPath, evidenceRef)) {
+    if (
+      await removeStaleIdempotencyTransitionGuard(
+        workspaceRoot,
+        scope,
+        key,
+        guardPath,
+        evidenceRef,
+        transitionGuardHooks
+      )
+    ) {
       continue;
     }
     if (Date.now() >= deadline) {
@@ -586,8 +687,12 @@ async function acquireIdempotencyTransitionGuard(
 }
 
 async function removeStaleIdempotencyTransitionGuard(
+  workspaceRoot: string,
+  scope: IdempotencyScope,
+  key: string,
   guardPath: string,
-  evidenceRef: string
+  evidenceRef: string,
+  transitionGuardHooks?: IdempotencyTransitionGuardHooks
 ): Promise<boolean> {
   const existing = await readJsonRecord(
     guardPath,
@@ -598,14 +703,31 @@ async function removeStaleIdempotencyTransitionGuard(
     return true;
   }
 
-  const ageMs = Date.now() - existing.acquired_at_ms;
-  const ownerIsGone = existing.owner_pid !== process.pid && !isProcessLikelyAlive(existing.owner_pid);
-  if (ageMs < IDEMPOTENCY_TRANSITION_GUARD_STALE_MS && !ownerIsGone) {
+  if (!isIdempotencyTransitionGuardStale(existing)) {
     return false;
   }
 
-  await unlink(guardPath).catch(() => undefined);
-  return true;
+  const cleanupLock = await acquireIdempotencyTransitionCleanupLock(
+    workspaceRoot,
+    scope,
+    key,
+    evidenceRef
+  );
+  if (cleanupLock.status === "busy") {
+    return false;
+  }
+
+  try {
+    await transitionGuardHooks?.beforeStaleGuardCleanup?.({
+      guardPath,
+      evidenceRef,
+      observedGuard: existing
+    });
+
+    return await unlinkObservedIdempotencyTransitionGuard(guardPath, evidenceRef, existing);
+  } finally {
+    await cleanupLock.release();
+  }
 }
 
 async function removeRecoverableIdempotencyTransitionGuardForRollbackRecovery(
@@ -633,7 +755,14 @@ async function removeRecoverableIdempotencyTransitionGuardForRollbackRecovery(
       throw error;
     }
 
-    await unlinkIdempotencyTransitionGuardForRollbackRecovery(guardPath, evidenceRef);
+    await unlinkRecoverableMalformedIdempotencyTransitionGuardForRollbackRecovery(
+      workspaceRoot,
+      scope,
+      key,
+      guardPath,
+      evidenceRef,
+      transition
+    );
     return;
   }
 
@@ -642,7 +771,15 @@ async function removeRecoverableIdempotencyTransitionGuardForRollbackRecovery(
   }
 
   if (isIdempotencyTransitionGuardStale(guard)) {
-    await unlinkIdempotencyTransitionGuardForRollbackRecovery(guardPath, evidenceRef);
+    await unlinkObservedIdempotencyTransitionGuardForRollbackRecovery(
+      workspaceRoot,
+      scope,
+      key,
+      guardPath,
+      evidenceRef,
+      guard,
+      transition
+    );
     return;
   }
 
@@ -671,6 +808,215 @@ async function unlinkIdempotencyTransitionGuardForRollbackRecovery(
       recommendedNextActions: ["Inspect the idempotency transition guard before retrying."]
     });
   }
+}
+
+async function unlinkObservedIdempotencyTransitionGuardForRollbackRecovery(
+  workspaceRoot: string,
+  scope: IdempotencyScope,
+  key: string,
+  guardPath: string,
+  evidenceRef: string,
+  observed: IdempotencyTransitionGuard,
+  transition: "complete" | "fail"
+): Promise<void> {
+  const cleanupLock = await acquireIdempotencyTransitionCleanupLock(
+    workspaceRoot,
+    scope,
+    key,
+    evidenceRef
+  );
+  if (cleanupLock.status === "busy") {
+    throw transitionGuardBusyError(scope, key, transition);
+  }
+
+  try {
+    if (await unlinkObservedIdempotencyTransitionGuard(guardPath, evidenceRef, observed)) {
+      return;
+    }
+  } finally {
+    await cleanupLock.release();
+  }
+
+  throw new TaskServiceError({
+    code: "record_malformed",
+    status: 500,
+    category: "workspace_error",
+    message: "Idempotency transition guard changed during rollback recovery.",
+    userMessage: "The idempotency record could not be recovered safely.",
+    evidenceRefs: [evidenceRef],
+    retryable: true,
+    recommendedNextActions: ["Retry after the in-progress idempotency transition finishes."]
+  });
+}
+
+async function unlinkObservedIdempotencyTransitionGuard(
+  guardPath: string,
+  evidenceRef: string,
+  observed: IdempotencyTransitionGuard
+): Promise<boolean> {
+  const current = await readJsonRecord(
+    guardPath,
+    evidenceRef,
+    IdempotencyTransitionGuardSchema
+  );
+  if (!current) {
+    return true;
+  }
+  if (!isSameIdempotencyTransitionGuard(current, observed)) {
+    return false;
+  }
+
+  await unlinkIdempotencyTransitionGuardForRollbackRecovery(guardPath, evidenceRef);
+  return true;
+}
+
+async function unlinkRecoverableMalformedIdempotencyTransitionGuardForRollbackRecovery(
+  workspaceRoot: string,
+  scope: IdempotencyScope,
+  key: string,
+  guardPath: string,
+  evidenceRef: string,
+  transition: "complete" | "fail"
+): Promise<void> {
+  const cleanupLock = await acquireIdempotencyTransitionCleanupLock(
+    workspaceRoot,
+    scope,
+    key,
+    evidenceRef
+  );
+  if (cleanupLock.status === "busy") {
+    throw transitionGuardBusyError(scope, key, transition);
+  }
+
+  try {
+    try {
+      const current = await readJsonRecord(
+        guardPath,
+        evidenceRef,
+        IdempotencyTransitionGuardSchema
+      );
+      if (!current) {
+        return;
+      }
+    } catch (error) {
+      if (isRecoverableTransitionGuardRecordError(error)) {
+        await unlinkIdempotencyTransitionGuardForRollbackRecovery(guardPath, evidenceRef);
+        return;
+      }
+
+      throw error;
+    }
+  } finally {
+    await cleanupLock.release();
+  }
+
+  throw new TaskServiceError({
+    code: "record_malformed",
+    status: 500,
+    category: "workspace_error",
+    message: "Idempotency transition guard was replaced during rollback recovery.",
+    userMessage: "The idempotency record could not be recovered safely.",
+    evidenceRefs: [evidenceRef],
+    retryable: true,
+    recommendedNextActions: ["Retry after the in-progress idempotency transition finishes."]
+  });
+}
+
+async function acquireIdempotencyTransitionCleanupLock(
+  workspaceRoot: string,
+  scope: IdempotencyScope,
+  key: string,
+  evidenceRef: string
+): Promise<IdempotencyTransitionGuardAcquire> {
+  const directorySegments = idempotencyRecordDirectorySegments(scope);
+  const cleanupLockFileName = idempotencyTransitionCleanupLockFileName(key);
+  const cleanupLockPath = workspaceRecordPath(
+    workspaceRoot,
+    [...directorySegments, cleanupLockFileName],
+    evidenceRef
+  );
+
+  const deadline = Date.now() + IDEMPOTENCY_TRANSITION_GUARD_WAIT_MS;
+  for (;;) {
+    const cleanupLock: IdempotencyTransitionGuard = {
+      guard_id: randomUUID(),
+      owner_pid: process.pid,
+      acquired_at_ms: Date.now(),
+      acquired_at: new Date().toISOString()
+    };
+    const created = await createJsonRecordIfAbsent(
+      workspaceRoot,
+      directorySegments,
+      cleanupLockFileName,
+      cleanupLock,
+      evidenceRef,
+      IdempotencyTransitionGuardSchema
+    );
+    if (created.status === "created") {
+      return {
+        status: "acquired",
+        release: async () => {
+          const current = await readJsonRecord(
+            cleanupLockPath,
+            evidenceRef,
+            IdempotencyTransitionGuardSchema
+          ).catch(() => undefined);
+          if (current && isSameIdempotencyTransitionGuard(current, cleanupLock)) {
+            await unlink(cleanupLockPath).catch(() => undefined);
+          }
+        }
+      };
+    }
+
+    if (await removeStaleIdempotencyTransitionCleanupLock(cleanupLockPath, evidenceRef)) {
+      continue;
+    }
+
+    if (Date.now() >= deadline) {
+      return { status: "busy" };
+    }
+
+    await sleep(IDEMPOTENCY_TRANSITION_GUARD_POLL_MS);
+  }
+}
+
+async function removeStaleIdempotencyTransitionCleanupLock(
+  cleanupLockPath: string,
+  evidenceRef: string
+): Promise<boolean> {
+  const existing = await readJsonRecord(
+    cleanupLockPath,
+    evidenceRef,
+    IdempotencyTransitionGuardSchema
+  );
+  if (!existing) {
+    return true;
+  }
+  if (!isIdempotencyTransitionGuardStale(existing)) {
+    return false;
+  }
+
+  return await unlinkObservedIdempotencyTransitionGuard(
+    cleanupLockPath,
+    evidenceRef,
+    existing
+  );
+}
+
+function idempotencyTransitionCleanupLockFileName(key: string): string {
+  return `${sha256Hex(`transition-cleanup:${key}`)}.guard-cleanup`;
+}
+
+function isSameIdempotencyTransitionGuard(
+  left: IdempotencyTransitionGuard,
+  right: IdempotencyTransitionGuard
+): boolean {
+  return (
+    left.guard_id === right.guard_id &&
+    left.owner_pid === right.owner_pid &&
+    left.acquired_at_ms === right.acquired_at_ms &&
+    left.acquired_at === right.acquired_at
+  );
 }
 
 function isIdempotencyTransitionGuardStale(guard: IdempotencyTransitionGuard): boolean {
@@ -791,6 +1137,19 @@ function completedRecordStoreBypassError(evidenceRef: string): TaskServiceError 
     evidenceRefs: [evidenceRef, "idempotency.status"],
     retryable: false,
     recommendedNextActions: ["Use beginRecord and completeRecord to finish an idempotency claim."]
+  });
+}
+
+function idempotencyRecordStoreExistingError(evidenceRef: string): TaskServiceError {
+  return new TaskServiceError({
+    code: "record_schema_error",
+    status: 400,
+    category: "schema_error",
+    message: "Existing idempotency records cannot be mutated through storeRecord.",
+    userMessage: "An existing idempotency record cannot be overwritten directly.",
+    evidenceRefs: [evidenceRef, "idempotency.status"],
+    retryable: false,
+    recommendedNextActions: ["Use beginRecord, completeRecord, or failRecord for state transitions."]
   });
 }
 

--- a/packages/core/src/domain/services/index.ts
+++ b/packages/core/src/domain/services/index.ts
@@ -2,4 +2,7 @@ export const CORE_SERVICE_NAMESPACE = "core/domain/services" as const;
 
 export type CoreServiceNamespace = typeof CORE_SERVICE_NAMESPACE;
 
+export * from "./artifact-registry-service";
+export * from "./idempotency-service";
+export * from "./lock-service";
 export * from "./task-card-service";

--- a/packages/core/src/domain/services/lock-service.ts
+++ b/packages/core/src/domain/services/lock-service.ts
@@ -1,0 +1,93 @@
+import { join, resolve } from "node:path";
+import {
+  LockRecordSchema,
+  LockScopeSchema,
+  type LockRecord,
+  type LockScope
+} from "../schemas/lock";
+import { TaskServiceError } from "./task-card-service";
+import {
+  assertSafeRecordSegment,
+  readJsonRecord,
+  workspaceRecordPath,
+  writeJsonRecord
+} from "./workspace-record-store";
+
+export interface LockRecordServiceOptions {
+  workspaceRoot: string;
+}
+
+export interface LockRecordService {
+  storeLock: (record: LockRecord) => Promise<LockRecord>;
+  getLock: (scope: LockScope, lockId: string) => Promise<LockRecord | undefined>;
+}
+
+export function createLockRecordService(options: LockRecordServiceOptions): LockRecordService {
+  const workspaceRoot = resolve(options.workspaceRoot);
+
+  return {
+    async storeLock(record: LockRecord): Promise<LockRecord> {
+      const parsedRecord = LockRecordSchema.safeParse(record);
+      if (parsedRecord.success) {
+        assertSafeRecordSegment(parsedRecord.data.lock_id, "lock.lock_id");
+      }
+
+      return await writeJsonRecord(
+        workspaceRoot,
+        lockRecordDirectorySegments(parsedRecord.success ? parsedRecord.data.scope : "task"),
+        parsedRecord.success ? lockRecordFileName(parsedRecord.data.lock_id) : "invalid.json",
+        record,
+        parsedRecord.success
+          ? lockRecordEvidenceRef(parsedRecord.data.scope, parsedRecord.data.lock_id)
+          : "workspace/locks",
+        LockRecordSchema
+      );
+    },
+
+    async getLock(scope: LockScope, lockId: string): Promise<LockRecord | undefined> {
+      const parsedScope = assertLockScope(scope);
+      assertSafeRecordSegment(lockId, "lock.lock_id");
+      const recordPath = workspaceRecordPath(
+        workspaceRoot,
+        [...lockRecordDirectorySegments(parsedScope), lockRecordFileName(lockId)],
+        lockRecordEvidenceRef(parsedScope, lockId)
+      );
+
+      return await readJsonRecord(
+        recordPath,
+        lockRecordEvidenceRef(parsedScope, lockId),
+        LockRecordSchema
+      );
+    }
+  };
+}
+
+export function lockRecordDirectorySegments(scope: LockScope): readonly string[] {
+  return ["locks", assertLockScope(scope)];
+}
+
+export function lockRecordFileName(lockId: string): string {
+  assertSafeRecordSegment(lockId, "lock.lock_id");
+  return `${lockId}.json`;
+}
+
+export function lockRecordEvidenceRef(scope: LockScope, lockId: string): string {
+  return join("workspace", "locks", assertLockScope(scope), lockRecordFileName(lockId));
+}
+
+function assertLockScope(scope: LockScope): LockScope {
+  const parsedScope = LockScopeSchema.safeParse(scope);
+  if (parsedScope.success) {
+    return parsedScope.data;
+  }
+
+  throw new TaskServiceError({
+    code: "record_id_not_safe",
+    status: 400,
+    category: "schema_error",
+    message: "Lock scope is not supported.",
+    userMessage: "The lock scope is not supported.",
+    evidenceRefs: ["lock.scope"],
+    recommendedNextActions: ["Use a supported lock scope."]
+  });
+}

--- a/packages/core/src/domain/services/lock-service.ts
+++ b/packages/core/src/domain/services/lock-service.ts
@@ -53,11 +53,16 @@ export function createLockRecordService(options: LockRecordServiceOptions): Lock
         lockRecordEvidenceRef(parsedScope, lockId)
       );
 
-      return await readJsonRecord(
+      const record = await readJsonRecord(
         recordPath,
         lockRecordEvidenceRef(parsedScope, lockId),
         LockRecordSchema
       );
+      if (!record) {
+        return undefined;
+      }
+      assertLockLookupIdentity(record, parsedScope, lockId);
+      return record;
     }
   };
 }
@@ -89,5 +94,26 @@ function assertLockScope(scope: LockScope): LockScope {
     userMessage: "The lock scope is not supported.",
     evidenceRefs: ["lock.scope"],
     recommendedNextActions: ["Use a supported lock scope."]
+  });
+}
+
+function assertLockLookupIdentity(
+  record: LockRecord,
+  scope: LockScope,
+  lockId: string
+): void {
+  if (record.scope === scope && record.lock_id === lockId) {
+    return;
+  }
+
+  throw new TaskServiceError({
+    code: "record_malformed",
+    status: 500,
+    category: "workspace_error",
+    message: "Lock record identity does not match its lookup path.",
+    userMessage: "The lock record cannot be used safely.",
+    evidenceRefs: [lockRecordEvidenceRef(scope, lockId), "lock.scope", "lock.lock_id"],
+    retryable: false,
+    recommendedNextActions: ["Inspect and repair the lock record before retrying."]
   });
 }

--- a/packages/core/src/domain/services/task-card-service.ts
+++ b/packages/core/src/domain/services/task-card-service.ts
@@ -73,7 +73,7 @@ export interface TaskServiceErrorOptions {
   code: TaskServiceErrorCode;
   message: string;
   userMessage: string;
-  status: 400 | 404 | 422 | 500;
+  status: 400 | 404 | 409 | 422 | 500;
   category: string;
   evidenceRefs?: string[];
   retryable?: boolean;
@@ -82,7 +82,7 @@ export interface TaskServiceErrorOptions {
 
 export class TaskServiceError extends Error {
   readonly code: TaskServiceErrorCode;
-  readonly status: 400 | 404 | 422 | 500;
+  readonly status: 400 | 404 | 409 | 422 | 500;
   readonly category: string;
   readonly userMessage: string;
   readonly evidenceRefs: string[];
@@ -231,7 +231,16 @@ export function createTaskCardService(options: TaskCardServiceOptions): TaskCard
 
       const taskDirectory = join(workspaceRoot, "tasks", taskId);
       assertPathInsideWorkspace(workspaceRoot, taskDirectory, `workspace/tasks/${taskId}`);
-      if (!(await isSafeExistingDirectoryPath(taskDirectory))) {
+      const taskDirectoryEntry = await maybeLstat(taskDirectory);
+      if (!taskDirectoryEntry) {
+        await evictTaskAfterMissingRollbackSnapshot(tasks, taskDirectory, taskId);
+        return;
+      }
+      if (
+        !taskDirectoryEntry.isDirectory() ||
+        taskDirectoryEntry.isSymbolicLink() ||
+        !(await isSafeExistingDirectoryPath(taskDirectory))
+      ) {
         throw workspaceError(
           "task_lane_not_directory",
           `Task lane is not a safe directory: ${taskId}`,
@@ -795,6 +804,40 @@ async function readBoundedTaskSnapshot(
   return buffer.subarray(0, offset).toString("utf8");
 }
 
+async function cleanupPublishedTaskSnapshotAfterFailedWrite(
+  taskDirectory: string,
+  snapshotPath: string,
+  taskId: string
+): Promise<void> {
+  const taskDirectoryEntry = await maybeLstat(taskDirectory);
+  if (!taskDirectoryEntry) {
+    return;
+  }
+  if (
+    !taskDirectoryEntry.isDirectory() ||
+    taskDirectoryEntry.isSymbolicLink() ||
+    !(await isSafeExistingDirectoryPath(taskDirectory))
+  ) {
+    return;
+  }
+
+  try {
+    await unlink(snapshotPath);
+  } catch (error) {
+    if (!hasErrorCode(error, "ENOENT")) {
+      throw workspaceError(
+        "workspace_path_not_safe",
+        "Failed to clean up published task snapshot after a failed write.",
+        "The task snapshot could not be cleaned up safely.",
+        [taskSnapshotEvidenceRef(taskId)],
+        error
+      );
+    }
+  }
+
+  await removeEmptyTaskLaneAfterRollback(taskDirectory, taskId);
+}
+
 async function persistTaskSnapshot(
   workspaceRoot: string,
   task: TaskCard,
@@ -857,9 +900,8 @@ async function persistTaskSnapshot(
     try {
       await snapshotWriteHooks?.afterSnapshotWrite?.({ taskDirectory, taskId: task.task_id });
     } catch (error) {
-      await unlink(snapshotPath).catch(() => undefined);
+      await cleanupPublishedTaskSnapshotAfterFailedWrite(taskDirectory, snapshotPath, task.task_id);
       publishedSnapshot = false;
-      await removeEmptyTaskLaneAfterRollback(taskDirectory, task.task_id);
       throw error;
     }
     if (!(await isSafeExistingDirectoryPath(taskDirectory))) {
@@ -872,8 +914,7 @@ async function persistTaskSnapshot(
     }
   } catch (error) {
     if (publishedSnapshot) {
-      await unlink(snapshotPath).catch(() => undefined);
-      await removeEmptyTaskLaneAfterRollback(taskDirectory, task.task_id);
+      await cleanupPublishedTaskSnapshotAfterFailedWrite(taskDirectory, snapshotPath, task.task_id);
     }
     throw workspaceError(
       "workspace_path_not_safe",

--- a/packages/core/src/domain/services/task-card-service.ts
+++ b/packages/core/src/domain/services/task-card-service.ts
@@ -139,6 +139,7 @@ export interface TaskSnapshotWriteHookInput {
 
 export interface TaskSnapshotWriteHooks {
   beforeSnapshotWrite?: (input: TaskSnapshotWriteHookInput) => Promise<void> | void;
+  afterSnapshotWrite?: (input: TaskSnapshotWriteHookInput) => Promise<void> | void;
 }
 
 export function createTaskCardService(options: TaskCardServiceOptions): TaskCardService {
@@ -288,7 +289,6 @@ export function createTaskCardService(options: TaskCardServiceOptions): TaskCard
     },
 
     async getTaskFromSnapshot(taskId: string): Promise<TaskCard> {
-      await ensureHydrated();
       const task = await readTaskCardFromSnapshot(workspaceRoot, taskId, snapshotReadHooks);
       tasks.set(task.task_id, task);
       return task;
@@ -791,6 +791,15 @@ async function persistTaskSnapshot(
       );
     }
     await rename(temporaryPath, snapshotPath);
+    if (!(await isSafeExistingDirectoryPath(taskDirectory))) {
+      throw workspaceError(
+        "task_lane_not_directory",
+        `Task lane is not a safe directory: ${task.task_id}`,
+        "A task snapshot lane is blocked by a non-directory filesystem entry.",
+        [`workspace/tasks/${task.task_id}`]
+      );
+    }
+    await snapshotWriteHooks?.afterSnapshotWrite?.({ taskDirectory, taskId: task.task_id });
     if (!(await isSafeExistingDirectoryPath(taskDirectory))) {
       throw workspaceError(
         "task_lane_not_directory",

--- a/packages/core/src/domain/services/task-card-service.ts
+++ b/packages/core/src/domain/services/task-card-service.ts
@@ -54,6 +54,11 @@ export type TaskSnapshot = z.infer<typeof TaskSnapshotSchema>;
 
 export type TaskServiceErrorCode =
   | "schema_error"
+  | "record_schema_error"
+  | "record_id_not_safe"
+  | "record_not_found"
+  | "record_malformed"
+  | "idempotency_mismatch"
   | "task_not_found"
   | "task_id_not_safe"
   | "workspace_path_not_safe"
@@ -68,7 +73,7 @@ export interface TaskServiceErrorOptions {
   code: TaskServiceErrorCode;
   message: string;
   userMessage: string;
-  status: 400 | 404 | 500;
+  status: 400 | 404 | 422 | 500;
   category: string;
   evidenceRefs?: string[];
   retryable?: boolean;
@@ -77,7 +82,7 @@ export interface TaskServiceErrorOptions {
 
 export class TaskServiceError extends Error {
   readonly code: TaskServiceErrorCode;
-  readonly status: 400 | 404 | 500;
+  readonly status: 400 | 404 | 422 | 500;
   readonly category: string;
   readonly userMessage: string;
   readonly evidenceRefs: string[];

--- a/packages/core/src/domain/services/task-card-service.ts
+++ b/packages/core/src/domain/services/task-card-service.ts
@@ -117,6 +117,7 @@ export interface TaskCardService {
   rollbackTaskForIdempotency: (taskId: string) => Promise<void>;
   listTasks: () => Promise<TaskCard[]>;
   getTask: (taskId: string) => Promise<TaskCard>;
+  getTaskFromSnapshot: (taskId: string) => Promise<TaskCard>;
 }
 
 type FileStat = Awaited<ReturnType<typeof lstat>>;
@@ -238,16 +239,6 @@ export function createTaskCardService(options: TaskCardServiceOptions): TaskCard
         );
       }
 
-      const entries = await readRollbackTaskLaneEntries(taskDirectory, taskId);
-      if (entries.length !== 1 || entries[0]?.name !== "snapshot.json" || !entries[0].isFile()) {
-        throw workspaceError(
-          "task_snapshot_mismatch",
-          "Task rollback lane contains unexpected entries.",
-          "The task snapshot lane is not safe to roll back automatically.",
-          [`workspace/tasks/${taskId}`]
-        );
-      }
-
       const snapshotPath = join(taskDirectory, "snapshot.json");
       const snapshot = await readTaskSnapshot(
         snapshotPath,
@@ -266,18 +257,18 @@ export function createTaskCardService(options: TaskCardServiceOptions): TaskCard
 
       try {
         await unlink(snapshotPath);
-        await rmdir(taskDirectory);
       } catch (error) {
         throw workspaceError(
           "workspace_path_not_safe",
-          "Failed to remove idempotency rollback task lane.",
-          "The task snapshot lane could not be rolled back safely.",
-          [`workspace/tasks/${taskId}`],
+          "Failed to remove idempotency rollback task snapshot.",
+          "The task snapshot could not be rolled back safely.",
+          [taskSnapshotEvidenceRef(taskId)],
           error
         );
       }
 
       tasks.delete(taskId);
+      await removeEmptyTaskLaneAfterRollback(taskDirectory, taskId);
     },
 
     async listTasks(): Promise<TaskCard[]> {
@@ -290,17 +281,16 @@ export function createTaskCardService(options: TaskCardServiceOptions): TaskCard
       assertSafeTaskId(taskId, `path.task_id:${taskId}`);
       const task = tasks.get(taskId);
       if (!task) {
-        throw new TaskServiceError({
-          code: "task_not_found",
-          status: 404,
-          category: "not_found",
-          message: `Task not found: ${taskId}`,
-          userMessage: "The requested task does not exist.",
-          evidenceRefs: [`path.task_id:${taskId}`],
-          recommendedNextActions: ["Refresh the task list and choose an existing task."]
-        });
+        throw taskNotFoundError(taskId);
       }
 
+      return task;
+    },
+
+    async getTaskFromSnapshot(taskId: string): Promise<TaskCard> {
+      await ensureHydrated();
+      const task = await readTaskCardFromSnapshot(workspaceRoot, taskId, snapshotReadHooks);
+      tasks.set(task.task_id, task);
       return task;
     }
   };
@@ -411,6 +401,85 @@ async function hydrateTasksFromDisk(
   return tasks;
 }
 
+async function readTaskCardFromSnapshot(
+  workspaceRoot: string,
+  taskId: string,
+  snapshotReadHooks?: TaskSnapshotReadHooks
+): Promise<TaskCard> {
+  assertSafeTaskId(taskId, `path.task_id:${taskId}`);
+  const workspaceEntry = await maybeLstat(workspaceRoot);
+  if (!workspaceEntry) {
+    throw taskNotFoundError(taskId);
+  }
+  if (!(await isSafeExistingDirectoryPath(workspaceRoot))) {
+    throw workspaceError(
+      "workspace_path_not_safe",
+      "Configured workspace root is not a safe directory.",
+      "The configured workspace root is not usable.",
+      ["workspace"]
+    );
+  }
+
+  const tasksRoot = join(workspaceRoot, "tasks");
+  const tasksRootEntry = await maybeLstat(tasksRoot);
+  if (!tasksRootEntry) {
+    throw taskNotFoundError(taskId);
+  }
+  if (!(await isSafeExistingDirectoryPath(tasksRoot))) {
+    throw workspaceError(
+      "workspace_path_not_safe",
+      "Workspace tasks root is not a safe directory.",
+      "The workspace tasks directory is not usable.",
+      ["workspace/tasks"]
+    );
+  }
+
+  const lanePath = join(tasksRoot, taskId);
+  assertPathInsideWorkspace(workspaceRoot, lanePath, `workspace/tasks/${taskId}`);
+  const laneEntry = await maybeLstat(lanePath);
+  if (!laneEntry) {
+    throw taskNotFoundError(taskId);
+  }
+  if (!laneEntry.isDirectory() || laneEntry.isSymbolicLink()) {
+    throw workspaceError(
+      "task_lane_not_directory",
+      `Task lane is not a safe directory: ${taskId}`,
+      "A task snapshot lane is blocked by a non-directory filesystem entry.",
+      [`workspace/tasks/${taskId}`]
+    );
+  }
+  if (!(await isSafeExistingDirectoryPath(lanePath))) {
+    throw workspaceError(
+      "task_lane_not_directory",
+      `Task lane is not a safe directory: ${taskId}`,
+      "A task snapshot lane is blocked by a non-directory filesystem entry.",
+      [`workspace/tasks/${taskId}`]
+    );
+  }
+
+  const snapshotPath = join(lanePath, "snapshot.json");
+  if (!(await maybeLstat(snapshotPath))) {
+    throw taskNotFoundError(taskId);
+  }
+  await snapshotReadHooks?.beforeSnapshotOpen?.({ snapshotPath, laneTaskId: taskId });
+  if (!(await isSafeExistingDirectoryPath(lanePath))) {
+    throw workspaceError(
+      "task_lane_not_directory",
+      `Task lane is not a safe directory: ${taskId}`,
+      "A task snapshot lane is blocked by a non-directory filesystem entry.",
+      [`workspace/tasks/${taskId}`]
+    );
+  }
+
+  const snapshot = await readTaskSnapshot(
+    snapshotPath,
+    taskId,
+    lanePath,
+    taskSnapshotEvidenceRef(taskId)
+  );
+  return snapshot.task_card;
+}
+
 async function readBoundedTaskEntries(tasksRoot: string): Promise<Dirent[]> {
   const entries: Dirent[] = [];
   let entryCount = 0;
@@ -445,25 +514,24 @@ async function readBoundedTaskEntries(tasksRoot: string): Promise<Dirent[]> {
   return entries;
 }
 
-async function readRollbackTaskLaneEntries(
+async function removeEmptyTaskLaneAfterRollback(
   taskDirectory: string,
   taskId: string
-): Promise<Dirent[]> {
+): Promise<void> {
   try {
-    const directory = await opendir(taskDirectory);
-    const entries: Dirent[] = [];
-    for await (const entry of directory) {
-      entries.push(entry);
-      if (entries.length > 1) {
-        break;
-      }
-    }
-    return entries;
+    await rmdir(taskDirectory);
   } catch (error) {
+    if (hasErrorCode(error, "ENOTEMPTY") || hasErrorCode(error, "EEXIST")) {
+      return;
+    }
+    if (hasErrorCode(error, "ENOENT")) {
+      return;
+    }
+
     throw workspaceError(
       "workspace_path_not_safe",
-      "Task rollback lane cannot be scanned safely.",
-      "The task snapshot lane is not safe to roll back automatically.",
+      "Failed to remove empty idempotency rollback task lane.",
+      "The task snapshot lane could not be rolled back safely.",
       [`workspace/tasks/${taskId}`],
       error
     );
@@ -894,6 +962,18 @@ function assertSafeTaskId(taskId: string, evidenceRef: string): void {
     message: `Task id is not safe: ${taskId}`,
     userMessage: "The requested task id is not valid.",
     evidenceRefs: [evidenceRef],
+    recommendedNextActions: ["Refresh the task list and choose an existing task."]
+  });
+}
+
+function taskNotFoundError(taskId: string): TaskServiceError {
+  return new TaskServiceError({
+    code: "task_not_found",
+    status: 404,
+    category: "not_found",
+    message: `Task not found: ${taskId}`,
+    userMessage: "The requested task does not exist.",
+    evidenceRefs: [`path.task_id:${taskId}`],
     recommendedNextActions: ["Refresh the task list and choose an existing task."]
   });
 }

--- a/packages/core/src/domain/services/task-card-service.ts
+++ b/packages/core/src/domain/services/task-card-service.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { constants, type Dirent } from "node:fs";
-import { lstat, mkdir, open, opendir, rename, unlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, open, opendir, rename, rmdir, unlink, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, parse, relative, resolve, sep } from "node:path";
 import { z } from "zod";
 import {
@@ -114,6 +114,7 @@ export interface TaskCardServiceOptions {
 
 export interface TaskCardService {
   createTask: (input: CreateTaskInput) => Promise<TaskCard>;
+  rollbackTaskForIdempotency: (taskId: string) => Promise<void>;
   listTasks: () => Promise<TaskCard[]>;
   getTask: (taskId: string) => Promise<TaskCard>;
 }
@@ -208,6 +209,75 @@ export function createTaskCardService(options: TaskCardServiceOptions): TaskCard
       } finally {
         reservedTaskIds.delete(taskId);
       }
+    },
+
+    async rollbackTaskForIdempotency(taskId: string): Promise<void> {
+      await ensureHydrated();
+      assertSafeTaskId(taskId, `path.task_id:${taskId}`);
+      const task = tasks.get(taskId);
+      if (!task) {
+        throw new TaskServiceError({
+          code: "task_not_found",
+          status: 404,
+          category: "not_found",
+          message: `Task not found: ${taskId}`,
+          userMessage: "The task selected for idempotency rollback does not exist.",
+          evidenceRefs: [`path.task_id:${taskId}`],
+          recommendedNextActions: ["Inspect the idempotency rollback state before retrying."]
+        });
+      }
+
+      const taskDirectory = join(workspaceRoot, "tasks", taskId);
+      assertPathInsideWorkspace(workspaceRoot, taskDirectory, `workspace/tasks/${taskId}`);
+      if (!(await isSafeExistingDirectoryPath(taskDirectory))) {
+        throw workspaceError(
+          "task_lane_not_directory",
+          `Task lane is not a safe directory: ${taskId}`,
+          "A task snapshot lane is blocked by a non-directory filesystem entry.",
+          [`workspace/tasks/${taskId}`]
+        );
+      }
+
+      const entries = await readRollbackTaskLaneEntries(taskDirectory, taskId);
+      if (entries.length !== 1 || entries[0]?.name !== "snapshot.json" || !entries[0].isFile()) {
+        throw workspaceError(
+          "task_snapshot_mismatch",
+          "Task rollback lane contains unexpected entries.",
+          "The task snapshot lane is not safe to roll back automatically.",
+          [`workspace/tasks/${taskId}`]
+        );
+      }
+
+      const snapshotPath = join(taskDirectory, "snapshot.json");
+      const snapshot = await readTaskSnapshot(
+        snapshotPath,
+        taskId,
+        taskDirectory,
+        taskSnapshotEvidenceRef(taskId)
+      );
+      if (JSON.stringify(snapshot.task_card) !== JSON.stringify(task)) {
+        throw workspaceError(
+          "task_snapshot_mismatch",
+          "Task rollback snapshot does not match the in-memory task.",
+          "The task snapshot lane is not safe to roll back automatically.",
+          [taskSnapshotEvidenceRef(taskId), "snapshot.task_card"]
+        );
+      }
+
+      try {
+        await unlink(snapshotPath);
+        await rmdir(taskDirectory);
+      } catch (error) {
+        throw workspaceError(
+          "workspace_path_not_safe",
+          "Failed to remove idempotency rollback task lane.",
+          "The task snapshot lane could not be rolled back safely.",
+          [`workspace/tasks/${taskId}`],
+          error
+        );
+      }
+
+      tasks.delete(taskId);
     },
 
     async listTasks(): Promise<TaskCard[]> {
@@ -373,6 +443,31 @@ async function readBoundedTaskEntries(tasksRoot: string): Promise<Dirent[]> {
   }
 
   return entries;
+}
+
+async function readRollbackTaskLaneEntries(
+  taskDirectory: string,
+  taskId: string
+): Promise<Dirent[]> {
+  try {
+    const directory = await opendir(taskDirectory);
+    const entries: Dirent[] = [];
+    for await (const entry of directory) {
+      entries.push(entry);
+      if (entries.length > 1) {
+        break;
+      }
+    }
+    return entries;
+  } catch (error) {
+    throw workspaceError(
+      "workspace_path_not_safe",
+      "Task rollback lane cannot be scanned safely.",
+      "The task snapshot lane is not safe to roll back automatically.",
+      [`workspace/tasks/${taskId}`],
+      error
+    );
+  }
 }
 
 function assertSafeTaskLaneEntry(entry: Dirent, lanePath: string): void {

--- a/packages/core/src/domain/services/task-card-service.ts
+++ b/packages/core/src/domain/services/task-card-service.ts
@@ -241,12 +241,27 @@ export function createTaskCardService(options: TaskCardServiceOptions): TaskCard
       }
 
       const snapshotPath = join(taskDirectory, "snapshot.json");
-      const snapshot = await readTaskSnapshot(
-        snapshotPath,
-        taskId,
-        taskDirectory,
-        taskSnapshotEvidenceRef(taskId)
-      );
+      if (!(await maybeLstat(snapshotPath))) {
+        await evictTaskAfterMissingRollbackSnapshot(tasks, taskDirectory, taskId);
+        return;
+      }
+      let snapshot: TaskSnapshot;
+      try {
+        await snapshotReadHooks?.beforeSnapshotOpen?.({ snapshotPath, laneTaskId: taskId });
+        snapshot = await readTaskSnapshot(
+          snapshotPath,
+          taskId,
+          taskDirectory,
+          taskSnapshotEvidenceRef(taskId)
+        );
+      } catch (error) {
+        if (await isMissingRollbackSnapshotError(error, snapshotPath)) {
+          await evictTaskAfterMissingRollbackSnapshot(tasks, taskDirectory, taskId);
+          return;
+        }
+
+        throw error;
+      }
       if (JSON.stringify(snapshot.task_card) !== JSON.stringify(task)) {
         throw workspaceError(
           "task_snapshot_mismatch",
@@ -259,6 +274,11 @@ export function createTaskCardService(options: TaskCardServiceOptions): TaskCard
       try {
         await unlink(snapshotPath);
       } catch (error) {
+        if (await isMissingRollbackSnapshotError(error, snapshotPath)) {
+          await evictTaskAfterMissingRollbackSnapshot(tasks, taskDirectory, taskId);
+          return;
+        }
+
         throw workspaceError(
           "workspace_path_not_safe",
           "Failed to remove idempotency rollback task snapshot.",
@@ -268,8 +288,7 @@ export function createTaskCardService(options: TaskCardServiceOptions): TaskCard
         );
       }
 
-      tasks.delete(taskId);
-      await removeEmptyTaskLaneAfterRollback(taskDirectory, taskId);
+      await evictTaskAfterMissingRollbackSnapshot(tasks, taskDirectory, taskId);
     },
 
     async listTasks(): Promise<TaskCard[]> {
@@ -538,6 +557,39 @@ async function removeEmptyTaskLaneAfterRollback(
   }
 }
 
+async function evictTaskAfterMissingRollbackSnapshot(
+  tasks: Map<string, TaskCard>,
+  taskDirectory: string,
+  taskId: string
+): Promise<void> {
+  tasks.delete(taskId);
+  await removeEmptyTaskLaneAfterRollback(taskDirectory, taskId);
+}
+
+async function isMissingRollbackSnapshotError(
+  error: unknown,
+  snapshotPath: string
+): Promise<boolean> {
+  if (hasErrorCode(error, "ENOENT")) {
+    return true;
+  }
+  if (!(error instanceof TaskServiceError)) {
+    return false;
+  }
+
+  if (error.code === "task_not_found") {
+    return true;
+  }
+  if (
+    (error.code === "task_snapshot_malformed" || error.code === "workspace_path_not_safe") &&
+    !(await maybeLstat(snapshotPath))
+  ) {
+    return true;
+  }
+
+  return hasErrorCode(error.cause, "ENOENT");
+}
+
 function assertSafeTaskLaneEntry(entry: Dirent, lanePath: string): void {
   if (entry.isDirectory() && !entry.isSymbolicLink()) {
     return;
@@ -779,6 +831,7 @@ async function persistTaskSnapshot(
   assertPathInsideWorkspace(workspaceRoot, temporaryPath, `workspace/tasks/${task.task_id}/snapshot.tmp`);
 
   let wroteTemporary = false;
+  let publishedSnapshot = false;
   try {
     await writeFile(temporaryPath, snapshotText, { flag: "wx" });
     wroteTemporary = true;
@@ -791,25 +844,37 @@ async function persistTaskSnapshot(
       );
     }
     await rename(temporaryPath, snapshotPath);
-    if (!(await isSafeExistingDirectoryPath(taskDirectory))) {
-      throw workspaceError(
-        "task_lane_not_directory",
-        `Task lane is not a safe directory: ${task.task_id}`,
-        "A task snapshot lane is blocked by a non-directory filesystem entry.",
-        [`workspace/tasks/${task.task_id}`]
-      );
-    }
-    await snapshotWriteHooks?.afterSnapshotWrite?.({ taskDirectory, taskId: task.task_id });
-    if (!(await isSafeExistingDirectoryPath(taskDirectory))) {
-      throw workspaceError(
-        "task_lane_not_directory",
-        `Task lane is not a safe directory: ${task.task_id}`,
-        "A task snapshot lane is blocked by a non-directory filesystem entry.",
-        [`workspace/tasks/${task.task_id}`]
-      );
-    }
     wroteTemporary = false;
+    publishedSnapshot = true;
+    if (!(await isSafeExistingDirectoryPath(taskDirectory))) {
+      throw workspaceError(
+        "task_lane_not_directory",
+        `Task lane is not a safe directory: ${task.task_id}`,
+        "A task snapshot lane is blocked by a non-directory filesystem entry.",
+        [`workspace/tasks/${task.task_id}`]
+      );
+    }
+    try {
+      await snapshotWriteHooks?.afterSnapshotWrite?.({ taskDirectory, taskId: task.task_id });
+    } catch (error) {
+      await unlink(snapshotPath).catch(() => undefined);
+      publishedSnapshot = false;
+      await removeEmptyTaskLaneAfterRollback(taskDirectory, task.task_id);
+      throw error;
+    }
+    if (!(await isSafeExistingDirectoryPath(taskDirectory))) {
+      throw workspaceError(
+        "task_lane_not_directory",
+        `Task lane is not a safe directory: ${task.task_id}`,
+        "A task snapshot lane is blocked by a non-directory filesystem entry.",
+        [`workspace/tasks/${task.task_id}`]
+      );
+    }
   } catch (error) {
+    if (publishedSnapshot) {
+      await unlink(snapshotPath).catch(() => undefined);
+      await removeEmptyTaskLaneAfterRollback(taskDirectory, task.task_id);
+    }
     throw workspaceError(
       "workspace_path_not_safe",
       "Failed to persist task snapshot under the configured workspace.",

--- a/packages/core/src/domain/services/workspace-record-store.ts
+++ b/packages/core/src/domain/services/workspace-record-store.ts
@@ -31,11 +31,13 @@ export function assertSafeRecordSegment(segment: string, evidenceRef: string): v
 }
 
 export function assertSafeRelativeRecordPath(path: string, evidenceRef: string): void {
+  const rawSegments = path.split(/[\\/]+/).filter(Boolean);
   const normalizedPath = normalize(path);
   const segments = normalizedPath.split(sep).filter(Boolean);
   if (
     path.trim().length > 0 &&
     !isAbsolute(path) &&
+    !rawSegments.includes("..") &&
     normalizedPath !== "." &&
     normalizedPath !== ".." &&
     !normalizedPath.startsWith(`..${sep}`) &&

--- a/packages/core/src/domain/services/workspace-record-store.ts
+++ b/packages/core/src/domain/services/workspace-record-store.ts
@@ -1,0 +1,473 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { lstat, mkdir, open, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, normalize, parse, relative, resolve, sep } from "node:path";
+import { z } from "zod";
+import { TaskServiceError, type TaskServiceErrorCode } from "./task-card-service";
+
+export const MAX_SERVICE_RECORD_BYTES = 1024 * 1024;
+
+const SAFE_RECORD_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/;
+const SERVICE_RECORD_OPEN_FLAGS = constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0);
+
+type FileStat = Awaited<ReturnType<typeof lstat>>;
+type RecordFileHandle = Awaited<ReturnType<typeof open>>;
+
+export function assertSafeRecordSegment(segment: string, evidenceRef: string): void {
+  if (SAFE_RECORD_SEGMENT_PATTERN.test(segment)) {
+    return;
+  }
+
+  throw new TaskServiceError({
+    code: "record_id_not_safe",
+    status: 400,
+    category: "schema_error",
+    message: "Record id is not a safe workspace path segment.",
+    userMessage: "The record id contains unsupported path characters.",
+    evidenceRefs: [evidenceRef],
+    recommendedNextActions: ["Use an id made from letters, numbers, dots, dashes, or underscores."]
+  });
+}
+
+export function assertSafeRelativeRecordPath(path: string, evidenceRef: string): void {
+  const normalizedPath = normalize(path);
+  const segments = normalizedPath.split(sep).filter(Boolean);
+  if (
+    path.trim().length > 0 &&
+    !isAbsolute(path) &&
+    normalizedPath !== "." &&
+    normalizedPath !== ".." &&
+    !normalizedPath.startsWith(`..${sep}`) &&
+    !segments.includes("..")
+  ) {
+    return;
+  }
+
+  throw new TaskServiceError({
+    code: "record_id_not_safe",
+    status: 400,
+    category: "schema_error",
+    message: "Record path is not a safe workspace-relative path.",
+    userMessage: "The record path must stay inside the workspace.",
+    evidenceRefs: [evidenceRef],
+    recommendedNextActions: ["Use a workspace-relative path without parent-directory traversal."]
+  });
+}
+
+export function workspaceRecordPath(
+  workspaceRoot: string,
+  relativeSegments: readonly string[],
+  evidenceRef: string
+): string {
+  const resolvedRoot = resolve(workspaceRoot);
+  const targetPath = join(resolvedRoot, ...relativeSegments);
+  assertPathInsideWorkspace(resolvedRoot, targetPath, evidenceRef);
+  return targetPath;
+}
+
+export async function ensureWorkspaceRecordDirectory(
+  workspaceRoot: string,
+  relativeSegments: readonly string[],
+  evidenceRef: string
+): Promise<string> {
+  const resolvedRoot = resolve(workspaceRoot);
+  await ensureSafeDirectory(resolvedRoot, "workspace");
+
+  let currentPath = resolvedRoot;
+  for (const segment of relativeSegments) {
+    currentPath = join(currentPath, segment);
+    assertPathInsideWorkspace(resolvedRoot, currentPath, evidenceRef);
+    await ensureSafeDirectory(currentPath, evidenceRef);
+  }
+
+  return currentPath;
+}
+
+export async function readJsonRecord<T>(
+  path: string,
+  evidenceRef: string,
+  schema: z.ZodType<T>
+): Promise<T | undefined> {
+  const existingEntry = await maybeLstat(path);
+  if (!existingEntry) {
+    return undefined;
+  }
+  if (!existingEntry.isFile() || existingEntry.isSymbolicLink()) {
+    throw serviceWorkspaceError(
+      "record_malformed",
+      "Record path is not a safe regular file.",
+      "A workspace record cannot be read safely.",
+      [evidenceRef]
+    );
+  }
+  if (existingEntry.size > MAX_SERVICE_RECORD_BYTES) {
+    throw serviceWorkspaceError(
+      "record_malformed",
+      "Record exceeds the M1 bounded read size.",
+      "A workspace record is too large to read safely.",
+      [evidenceRef]
+    );
+  }
+  if (!(await isSafeExistingDirectoryPath(dirname(path)))) {
+    throw serviceWorkspaceError(
+      "record_malformed",
+      "Record parent path is not a safe directory.",
+      "A workspace record cannot be read safely.",
+      [evidenceRef]
+    );
+  }
+
+  let recordFile: RecordFileHandle;
+  try {
+    recordFile = await open(path, SERVICE_RECORD_OPEN_FLAGS);
+  } catch (error) {
+    throw serviceWorkspaceError(
+      "record_malformed",
+      "Record cannot be opened safely.",
+      "A workspace record cannot be read safely.",
+      [evidenceRef],
+      error
+    );
+  }
+
+  let rawText: string;
+  try {
+    if (!(await isSafeExistingDirectoryPath(dirname(path)))) {
+      throw serviceWorkspaceError(
+        "record_malformed",
+        "Record parent path is not a safe directory.",
+        "A workspace record cannot be read safely.",
+        [evidenceRef]
+      );
+    }
+
+    const recordEntry = await recordFile.stat().catch((error: unknown) => {
+      throw serviceWorkspaceError(
+        "record_malformed",
+        "Record cannot be inspected.",
+        "A workspace record cannot be read safely.",
+        [evidenceRef],
+        error
+      );
+    });
+    if (!recordEntry.isFile() || recordEntry.isSymbolicLink()) {
+      throw serviceWorkspaceError(
+        "record_malformed",
+        "Record path is not a safe regular file.",
+        "A workspace record cannot be read safely.",
+        [evidenceRef]
+      );
+    }
+    if (recordEntry.size > MAX_SERVICE_RECORD_BYTES) {
+      throw serviceWorkspaceError(
+        "record_malformed",
+        "Record exceeds the M1 bounded read size.",
+        "A workspace record is too large to read safely.",
+        [evidenceRef]
+      );
+    }
+
+    rawText = await readBoundedJsonRecord(recordFile, evidenceRef);
+  } finally {
+    await recordFile.close().catch(() => undefined);
+  }
+
+  let rawRecord: unknown;
+  try {
+    rawRecord = JSON.parse(rawText) as unknown;
+  } catch (error) {
+    throw serviceWorkspaceError(
+      "record_malformed",
+      "Record is not valid JSON.",
+      "A workspace record is malformed.",
+      [evidenceRef],
+      error
+    );
+  }
+
+  const parsedRecord = schema.safeParse(rawRecord);
+  if (!parsedRecord.success) {
+    throw new TaskServiceError({
+      code: "record_schema_error",
+      status: 400,
+      category: "schema_error",
+      message: "Workspace record failed schema validation.",
+      userMessage: "A workspace record has invalid fields.",
+      evidenceRefs: toSchemaEvidenceRefs(parsedRecord.error, evidenceRef),
+      recommendedNextActions: ["Inspect and repair the workspace record before retrying."]
+    });
+  }
+
+  return parsedRecord.data;
+}
+
+async function readBoundedJsonRecord(
+  recordFile: RecordFileHandle,
+  evidenceRef: string
+): Promise<string> {
+  const buffer = Buffer.allocUnsafe(MAX_SERVICE_RECORD_BYTES + 1);
+  let offset = 0;
+
+  try {
+    while (offset < buffer.length) {
+      const { bytesRead } = await recordFile.read(buffer, offset, buffer.length - offset, offset);
+      if (bytesRead === 0) {
+        break;
+      }
+      offset += bytesRead;
+    }
+  } catch (error) {
+    throw serviceWorkspaceError(
+      "record_malformed",
+      "Record cannot be read safely.",
+      "A workspace record cannot be read safely.",
+      [evidenceRef],
+      error
+    );
+  }
+
+  if (offset > MAX_SERVICE_RECORD_BYTES) {
+    throw serviceWorkspaceError(
+      "record_malformed",
+      "Record exceeds the M1 bounded read size.",
+      "A workspace record is too large to read safely.",
+      [evidenceRef]
+    );
+  }
+
+  return buffer.subarray(0, offset).toString("utf8");
+}
+
+export async function writeJsonRecord<T>(
+  workspaceRoot: string,
+  relativeDirectorySegments: readonly string[],
+  fileName: string,
+  record: T,
+  evidenceRef: string,
+  schema: z.ZodType<T>
+): Promise<T> {
+  const parsedRecord = schema.safeParse(record);
+  if (!parsedRecord.success) {
+    throw new TaskServiceError({
+      code: "record_schema_error",
+      status: 400,
+      category: "schema_error",
+      message: "Workspace record failed schema validation.",
+      userMessage: "The record is missing required fields or contains invalid values.",
+      evidenceRefs: toSchemaEvidenceRefs(parsedRecord.error, evidenceRef),
+      recommendedNextActions: ["Fix the record fields and retry."]
+    });
+  }
+
+  assertSafeRecordSegment(fileName.replace(/\.json$/, ""), `${evidenceRef}:file`);
+
+  const directoryPath = await ensureWorkspaceRecordDirectory(
+    workspaceRoot,
+    relativeDirectorySegments,
+    evidenceRef
+  );
+  const recordPath = join(directoryPath, fileName);
+  assertPathInsideWorkspace(resolve(workspaceRoot), recordPath, evidenceRef);
+
+  const recordText = `${JSON.stringify(parsedRecord.data, null, 2)}\n`;
+  if (Buffer.byteLength(recordText, "utf8") > MAX_SERVICE_RECORD_BYTES) {
+    throw new TaskServiceError({
+      code: "record_schema_error",
+      status: 400,
+      category: "schema_error",
+      message: "Workspace record would exceed the M1 bounded size.",
+      userMessage: "The record is too large to persist safely.",
+      evidenceRefs: [evidenceRef],
+      recommendedNextActions: ["Reduce record field sizes and retry."]
+    });
+  }
+
+  const temporaryPath = join(directoryPath, `.${fileName}-${process.pid}-${randomUUID()}.tmp`);
+  let wroteTemporary = false;
+  try {
+    await writeFile(temporaryPath, recordText, { flag: "wx" });
+    wroteTemporary = true;
+    if (!(await isSafeExistingDirectoryPath(directoryPath))) {
+      throw serviceWorkspaceError(
+        "workspace_path_not_safe",
+        "Record directory is not a safe directory.",
+        "A workspace record directory is not usable.",
+        [evidenceRef]
+      );
+    }
+    await rename(temporaryPath, recordPath);
+    wroteTemporary = false;
+  } catch (error) {
+    if (error instanceof TaskServiceError) {
+      throw error;
+    }
+    throw serviceWorkspaceError(
+      "workspace_path_not_safe",
+      "Failed to persist workspace record.",
+      "The workspace record could not be written safely.",
+      [evidenceRef],
+      error
+    );
+  } finally {
+    if (wroteTemporary) {
+      await unlink(temporaryPath).catch(() => undefined);
+    }
+  }
+
+  return parsedRecord.data;
+}
+
+export function assertPathInsideWorkspace(
+  workspaceRoot: string,
+  targetPath: string,
+  evidenceRef: string
+): void {
+  const relativePath = relative(resolve(workspaceRoot), resolve(targetPath));
+  if (relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath))) {
+    return;
+  }
+
+  throw serviceWorkspaceError(
+    "workspace_path_not_safe",
+    "Resolved path escapes the configured workspace.",
+    "A workspace path resolved outside the configured workspace.",
+    [evidenceRef]
+  );
+}
+
+function serviceWorkspaceError(
+  code: Extract<
+    TaskServiceErrorCode,
+    "workspace_path_not_safe" | "record_malformed"
+  >,
+  message: string,
+  userMessage: string,
+  evidenceRefs: string[],
+  cause?: unknown
+): TaskServiceError {
+  const error = new TaskServiceError({
+    code,
+    status: 500,
+    category: "workspace_error",
+    message,
+    userMessage,
+    evidenceRefs,
+    retryable: false,
+    recommendedNextActions: ["Inspect the workspace record state before retrying."]
+  });
+
+  if (cause instanceof Error) {
+    error.cause = cause;
+  }
+
+  return error;
+}
+
+async function ensureSafeDirectory(path: string, evidenceRef: string): Promise<void> {
+  const existingEntry = await maybeLstat(path);
+  if (existingEntry) {
+    if (!(await isSafeExistingDirectoryPath(path))) {
+      throw serviceWorkspaceError(
+        "workspace_path_not_safe",
+        "Path is not a safe directory.",
+        "A required workspace path is not a safe directory.",
+        [evidenceRef]
+      );
+    }
+    return;
+  }
+
+  const parentPath = dirname(path);
+  if (parentPath === path || !(await isSafeExistingDirectoryPath(parentPath))) {
+    throw serviceWorkspaceError(
+      "workspace_path_not_safe",
+      "Parent path is not a safe directory.",
+      "A required workspace parent path is not a safe directory.",
+      [`${evidenceRef}:parent`]
+    );
+  }
+
+  try {
+    await mkdir(path);
+  } catch (error) {
+    if (hasErrorCode(error, "EEXIST") && (await isSafeExistingDirectoryPath(path))) {
+      return;
+    }
+
+    throw serviceWorkspaceError(
+      "workspace_path_not_safe",
+      "Failed to create workspace directory.",
+      "A required workspace directory could not be created safely.",
+      [evidenceRef],
+      error
+    );
+  }
+
+  if (!(await isSafeExistingDirectoryPath(path))) {
+    throw serviceWorkspaceError(
+      "workspace_path_not_safe",
+      "Created path is not a safe directory.",
+      "A required workspace path is not a safe directory.",
+      [evidenceRef]
+    );
+  }
+}
+
+async function isSafeExistingDirectoryPath(path: string): Promise<boolean> {
+  const { rootPath, segments } = getPathParts(path);
+  const rootEntry = await maybeLstat(rootPath);
+  if (!isSafeDirectoryEntry(rootEntry)) {
+    return false;
+  }
+
+  let currentPath = rootPath;
+  for (const segment of segments) {
+    currentPath = join(currentPath, segment);
+    const entry = await maybeLstat(currentPath);
+    if (!isSafeDirectoryEntry(entry)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function getPathParts(path: string): { rootPath: string; segments: string[] } {
+  const resolvedPath = resolve(path);
+  const rootPath = parse(resolvedPath).root;
+  return {
+    rootPath,
+    segments: resolvedPath.slice(rootPath.length).split(sep).filter(Boolean)
+  };
+}
+
+function isSafeDirectoryEntry(entry: FileStat | undefined): boolean {
+  return Boolean(entry?.isDirectory() && !entry.isSymbolicLink());
+}
+
+async function maybeLstat(path: string): Promise<FileStat | undefined> {
+  try {
+    return await lstat(path);
+  } catch {
+    return undefined;
+  }
+}
+
+function toSchemaEvidenceRefs(error: z.ZodError, prefix: string): string[] {
+  return Array.from(
+    new Set(
+      error.issues.map((issue) =>
+        issue.path.length > 0 ? `${prefix}.${issue.path.join(".")}` : prefix
+      )
+    )
+  );
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === code
+  );
+}

--- a/packages/core/src/domain/services/workspace-record-store.ts
+++ b/packages/core/src/domain/services/workspace-record-store.ts
@@ -9,6 +9,7 @@ export const MAX_SERVICE_RECORD_BYTES = 1024 * 1024;
 
 const SAFE_RECORD_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/;
 const SERVICE_RECORD_OPEN_FLAGS = constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0);
+const SERVICE_RECORD_READ_CHUNK_BYTES = 64 * 1024;
 
 type FileStat = Awaited<ReturnType<typeof lstat>>;
 type RecordFileHandle = Awaited<ReturnType<typeof open>>;
@@ -167,7 +168,7 @@ export async function readJsonRecord<T>(
       );
     }
 
-    rawText = await readBoundedJsonRecord(recordFile, evidenceRef);
+    rawText = await readBoundedJsonRecord(recordFile, evidenceRef, recordEntry.size);
   } finally {
     await recordFile.close().catch(() => undefined);
   }
@@ -203,18 +204,31 @@ export async function readJsonRecord<T>(
 
 async function readBoundedJsonRecord(
   recordFile: RecordFileHandle,
-  evidenceRef: string
+  evidenceRef: string,
+  checkedSize: number
 ): Promise<string> {
-  const buffer = Buffer.allocUnsafe(MAX_SERVICE_RECORD_BYTES + 1);
+  const chunks: Buffer[] = [];
   let offset = 0;
 
   try {
-    while (offset < buffer.length) {
-      const { bytesRead } = await recordFile.read(buffer, offset, buffer.length - offset, offset);
+    for (;;) {
+      const remainingBytes = MAX_SERVICE_RECORD_BYTES + 1 - offset;
+      if (remainingBytes <= 0) {
+        break;
+      }
+
+      const buffer = Buffer.allocUnsafe(
+        nextBoundedReadSize(checkedSize, offset, remainingBytes)
+      );
+      const { bytesRead } = await recordFile.read(buffer, 0, buffer.length, offset);
       if (bytesRead === 0) {
         break;
       }
+      chunks.push(buffer.subarray(0, bytesRead));
       offset += bytesRead;
+      if (offset > MAX_SERVICE_RECORD_BYTES || bytesRead < buffer.length) {
+        break;
+      }
     }
   } catch (error) {
     throw serviceWorkspaceError(
@@ -235,7 +249,22 @@ async function readBoundedJsonRecord(
     );
   }
 
-  return buffer.subarray(0, offset).toString("utf8");
+  return Buffer.concat(chunks, offset).toString("utf8");
+}
+
+function nextBoundedReadSize(
+  checkedSize: number,
+  offset: number,
+  remainingBytes: number
+): number {
+  if (offset === 0) {
+    return Math.max(
+      1,
+      Math.min(remainingBytes, checkedSize + 1, SERVICE_RECORD_READ_CHUNK_BYTES)
+    );
+  }
+
+  return Math.min(remainingBytes, SERVICE_RECORD_READ_CHUNK_BYTES);
 }
 
 export async function writeJsonRecord<T>(

--- a/packages/core/src/domain/services/workspace-record-store.ts
+++ b/packages/core/src/domain/services/workspace-record-store.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
-import { lstat, mkdir, open, rename, unlink, writeFile } from "node:fs/promises";
+import { link, lstat, mkdir, open, rename, unlink } from "node:fs/promises";
 import { dirname, isAbsolute, join, normalize, parse, relative, resolve, sep } from "node:path";
 import { z } from "zod";
 import { TaskServiceError, type TaskServiceErrorCode } from "./task-card-service";
@@ -246,47 +246,19 @@ export async function writeJsonRecord<T>(
   evidenceRef: string,
   schema: z.ZodType<T>
 ): Promise<T> {
-  const parsedRecord = schema.safeParse(record);
-  if (!parsedRecord.success) {
-    throw new TaskServiceError({
-      code: "record_schema_error",
-      status: 400,
-      category: "schema_error",
-      message: "Workspace record failed schema validation.",
-      userMessage: "The record is missing required fields or contains invalid values.",
-      evidenceRefs: toSchemaEvidenceRefs(parsedRecord.error, evidenceRef),
-      recommendedNextActions: ["Fix the record fields and retry."]
-    });
-  }
-
-  assertSafeRecordSegment(fileName.replace(/\.json$/, ""), `${evidenceRef}:file`);
-
-  const directoryPath = await ensureWorkspaceRecordDirectory(
+  const { data, directoryPath, recordPath, recordText } = await prepareJsonRecordWrite(
     workspaceRoot,
     relativeDirectorySegments,
-    evidenceRef
+    fileName,
+    record,
+    evidenceRef,
+    schema
   );
-  const recordPath = join(directoryPath, fileName);
-  assertPathInsideWorkspace(resolve(workspaceRoot), recordPath, evidenceRef);
-
-  const recordText = `${JSON.stringify(parsedRecord.data, null, 2)}\n`;
-  if (Buffer.byteLength(recordText, "utf8") > MAX_SERVICE_RECORD_BYTES) {
-    throw new TaskServiceError({
-      code: "record_schema_error",
-      status: 400,
-      category: "schema_error",
-      message: "Workspace record would exceed the M1 bounded size.",
-      userMessage: "The record is too large to persist safely.",
-      evidenceRefs: [evidenceRef],
-      recommendedNextActions: ["Reduce record field sizes and retry."]
-    });
-  }
 
   const temporaryPath = join(directoryPath, `.${fileName}-${process.pid}-${randomUUID()}.tmp`);
   let wroteTemporary = false;
   try {
-    await writeFile(temporaryPath, recordText, { flag: "wx" });
-    wroteTemporary = true;
+    wroteTemporary = await writeTemporaryRecordFile(temporaryPath, recordText, evidenceRef);
     if (!(await isSafeExistingDirectoryPath(directoryPath))) {
       throw serviceWorkspaceError(
         "workspace_path_not_safe",
@@ -314,7 +286,125 @@ export async function writeJsonRecord<T>(
     }
   }
 
-  return parsedRecord.data;
+  return data;
+}
+
+export type CreateJsonRecordResult<T> =
+  | { status: "created"; record: T }
+  | { status: "exists" };
+
+export async function createJsonRecordIfAbsent<T>(
+  workspaceRoot: string,
+  relativeDirectorySegments: readonly string[],
+  fileName: string,
+  record: T,
+  evidenceRef: string,
+  schema: z.ZodType<T>
+): Promise<CreateJsonRecordResult<T>> {
+  const { data, directoryPath, recordPath, recordText } = await prepareJsonRecordWrite(
+    workspaceRoot,
+    relativeDirectorySegments,
+    fileName,
+    record,
+    evidenceRef,
+    schema
+  );
+
+  const temporaryPath = join(directoryPath, `.${fileName}-${process.pid}-${randomUUID()}.tmp`);
+  let wroteTemporary = false;
+  try {
+    if (!(await isSafeExistingDirectoryPath(directoryPath))) {
+      throw serviceWorkspaceError(
+        "workspace_path_not_safe",
+        "Record directory is not a safe directory.",
+        "A workspace record directory is not usable.",
+        [evidenceRef]
+      );
+    }
+    wroteTemporary = await writeTemporaryRecordFile(temporaryPath, recordText, evidenceRef);
+    if (!(await isSafeExistingDirectoryPath(directoryPath))) {
+      throw serviceWorkspaceError(
+        "workspace_path_not_safe",
+        "Record directory is not a safe directory.",
+        "A workspace record directory is not usable.",
+        [evidenceRef]
+      );
+    }
+  } catch (error) {
+    if (error instanceof TaskServiceError) {
+      throw error;
+    }
+    throw serviceWorkspaceError(
+      "workspace_path_not_safe",
+      "Failed to prepare workspace record claim.",
+      "The workspace record could not be written safely.",
+      [evidenceRef],
+      error
+    );
+  }
+
+  try {
+    await link(temporaryPath, recordPath);
+  } catch (error) {
+    if (hasErrorCode(error, "EEXIST")) {
+      return { status: "exists" };
+    }
+    throw serviceWorkspaceError(
+      "workspace_path_not_safe",
+      "Failed to publish workspace record claim.",
+      "The workspace record could not be written safely.",
+      [evidenceRef],
+      error
+    );
+  } finally {
+    if (wroteTemporary) {
+      await unlink(temporaryPath).catch(() => undefined);
+    }
+  }
+
+  if (!(await isSafeExistingDirectoryPath(directoryPath))) {
+    throw serviceWorkspaceError(
+      "workspace_path_not_safe",
+      "Record directory is not a safe directory.",
+      "A workspace record directory is not usable.",
+      [evidenceRef]
+    );
+  }
+
+  return { status: "created", record: data };
+}
+
+async function writeTemporaryRecordFile(
+  temporaryPath: string,
+  recordText: string,
+  evidenceRef: string
+): Promise<boolean> {
+  let temporaryFile: RecordFileHandle | undefined;
+  let shouldCleanup = false;
+  let completed = false;
+  try {
+    temporaryFile = await open(
+      temporaryPath,
+      constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY
+    );
+    shouldCleanup = true;
+    await temporaryFile.writeFile(recordText, "utf8");
+    completed = true;
+    return shouldCleanup;
+  } catch (error) {
+    throw serviceWorkspaceError(
+      "workspace_path_not_safe",
+      "Failed to write workspace record temporary file.",
+      "The workspace record could not be written safely.",
+      [evidenceRef],
+      error
+    );
+  } finally {
+    await temporaryFile?.close().catch(() => undefined);
+    if (shouldCleanup && !completed) {
+      await unlink(temporaryPath).catch(() => undefined);
+    }
+  }
 }
 
 export function assertPathInsideWorkspace(
@@ -361,6 +451,63 @@ function serviceWorkspaceError(
   }
 
   return error;
+}
+
+async function prepareJsonRecordWrite<T>(
+  workspaceRoot: string,
+  relativeDirectorySegments: readonly string[],
+  fileName: string,
+  record: T,
+  evidenceRef: string,
+  schema: z.ZodType<T>
+): Promise<{
+  data: T;
+  directoryPath: string;
+  recordPath: string;
+  recordText: string;
+}> {
+  const parsedRecord = schema.safeParse(record);
+  if (!parsedRecord.success) {
+    throw new TaskServiceError({
+      code: "record_schema_error",
+      status: 400,
+      category: "schema_error",
+      message: "Workspace record failed schema validation.",
+      userMessage: "The record is missing required fields or contains invalid values.",
+      evidenceRefs: toSchemaEvidenceRefs(parsedRecord.error, evidenceRef),
+      recommendedNextActions: ["Fix the record fields and retry."]
+    });
+  }
+
+  assertSafeRecordSegment(fileName.replace(/\.json$/, ""), `${evidenceRef}:file`);
+
+  const directoryPath = await ensureWorkspaceRecordDirectory(
+    workspaceRoot,
+    relativeDirectorySegments,
+    evidenceRef
+  );
+  const recordPath = join(directoryPath, fileName);
+  assertPathInsideWorkspace(resolve(workspaceRoot), recordPath, evidenceRef);
+
+  const recordText = `${JSON.stringify(parsedRecord.data, null, 2)}\n`;
+  if (Buffer.byteLength(recordText, "utf8") > MAX_SERVICE_RECORD_BYTES) {
+    throw new TaskServiceError({
+      code: "record_schema_error",
+      status: 400,
+      category: "schema_error",
+      message: "Workspace record would exceed the M1 bounded size.",
+      userMessage: "The record is too large to persist safely.",
+      evidenceRefs: [evidenceRef],
+      recommendedNextActions: ["Reduce record field sizes and retry."]
+    });
+  }
+
+  return {
+    data: parsedRecord.data,
+    directoryPath,
+    recordPath,
+    recordText
+  };
 }
 
 async function ensureSafeDirectory(path: string, evidenceRef: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Add file-backed IdempotencyRecord, LockRecord, and Artifact registry service skeletons in `packages/core`.
- Wire change-scoped `Idempotency-Key` handling for `POST /api/tasks` only, with canonical request digest replay and 422 mismatch handling.
- Add expanded/high OpenSpec fixture evidence for #30 and focused backend/core service tests.

## Verification

- `npx --yes bun@1.2.19 run test:backend-api`
- `npx --yes bun@1.2.19 run test:backend-ws`
- `npx --yes bun@1.2.19 run test:schemas`
- `npx --yes bun@1.2.19 run test:core-services`
- `npx --yes bun@1.2.19 run typecheck`
- `npx --yes bun@1.2.19 run check`
- `openspec validate m1-foundation --strict --no-interactive`
- `git diff --check`
- `git -C zero diff --quiet`
- `test -z "$(git ls-files workspace)"`

## Agent Review

- Reviewer agents used: pending
- Reviewed head SHA: pending
- Review evidence: pending
- OpenSpec change: `m1-foundation`; fixture level: expanded/high; selected risk packs: Public API, Config, File IO, Schema, Auth/secrets leakage, Concurrency, Resource limits, Legacy compatibility, Error handling/rollback, Release compatibility, Documentation/migration notes, Scientific governance/evidence lineage
- Key findings addressed: pending

## Notes

- `POST /api/tasks` idempotency is a change-scoped M1 validation carrier only; this PR does not expand the frozen canonical idempotency applicability list.
- Full Artifact manifest/evidence_usable semantics, payload serving, shared path helper wiring, structured request logs, cross-process lock leases, and frontend retry UI remain out of scope.

Closes #30.
