### PR TITLE
feat(api): add PERF-API-001 smoke test (#32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,8 @@ jobs:
       - name: Check generated schema drift
         run: bun run schema:check
 
-      # Future hook (#32): PERF-API-001 smoke plugs in here after the API fixture lands.
+      - name: PERF-API-001 API metadata smoke
+        run: bun run test:perf:api
 
       # 项目铁律：zero 作为 root submodule 钉住不 fork，spike 条 5 要求 diff 为零。
       - name: Verify zero submodule unchanged

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -189,6 +189,16 @@
       - Secret redaction tests send fake secret `sk-test-secret-value` through query (`api_key`), `authorization` header, and malformed JSON body; the serialized log omits the plaintext, `authorization`, and `api_key`, while the redaction helper preserves `env:GLM_API_KEY` ref form and redacts the fake secret to `[REDACTED]`.
       - `bun run test:backend-api`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 - [ ] 6.5 PERF-API-001 冒烟脚本 `bun run test:perf:api`（fixture = mock workspace + 100 tasks；GET /api/tasks、GET /api/tasks/:id、health ready P95 ≤ 300ms）+ 接入 1.2 的 PR CI——依赖: 1.2
+  - Risk packs (#32):
+    - Public API / CLI / script entry: selected - adds the canonical `bun run test:perf:api` command and PR CI step.
+    - Performance / timing: selected - enforces PERF-API-001 P95 thresholds and must print measured P95 on failure.
+    - Workspace fixture / repeatability: selected - fixture generation must be scripted and use a disposable mock workspace with 100 tasks.
+    - Other packs: not selected - no API implementation, schema, auth, hydrology runtime, frontend, or Zero governance behavior changes.
+  - Evidence floor (#32):
+    - `scripts/perf/api.ts` creates a disposable workspace, initializes it through the backend API, creates exactly 100 TaskCards through `POST /api/tasks`, then samples `GET /api/tasks`, `GET /api/tasks/:id`, and `GET /api/health/ready`.
+    - `bun run test:perf:api` fails if any endpoint P95 exceeds 300ms and prints each measured P95 with the limit.
+    - PR CI `linux-base` runs `bun run test:perf:api` after schema drift check.
+    - `bun run test:perf:api`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 - [ ] 6.6 路径安全 helper（packages/core 共享 service，遵 Workspace_Conventions §9：resolve 规范化 → workspace 边界校验 → 拒 symlink escape → 记录规范化路径）+ Artifact registry 落盘与 task snapshot 写入两处接线 + 正负例单测（`../` 穿越拒绝、symlink escape 拒绝、合法路径规范化记录；承接 Test_Plan W1 Unit「path normalization」）——依赖: 6.2、6.3（两处落盘写入面在位）
 
 ## 7. 四栏壳（workbench-shell）

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -195,7 +195,7 @@
     - Workspace fixture / repeatability: selected - fixture generation must be scripted and use a disposable mock workspace with 100 tasks.
     - Other packs: not selected - no API implementation, schema, auth, hydrology runtime, frontend, or Zero governance behavior changes.
   - Evidence floor (#32):
-    - `scripts/perf/api.ts` creates a disposable workspace, initializes it through the backend API, creates exactly 100 TaskCards through `POST /api/tasks`, then samples `GET /api/tasks`, `GET /api/tasks/:id`, and `GET /api/health/ready`.
+    - `scripts/perf/api.ts` creates a disposable workspace, initializes it through the backend API, creates exactly 100 TaskCards through `POST /api/tasks`, verifies `GET /api/tasks` lists exactly 100 tasks, then samples `GET /api/tasks`, `GET /api/tasks/:id`, and `GET /api/health/ready`.
     - `bun run test:perf:api` fails if any endpoint P95 exceeds 300ms and prints each measured P95 with the limit.
     - PR CI `linux-base` runs `bun run test:perf:api` after schema drift check.
     - `bun run test:perf:api`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:backend-ws": "bun test ./packages/backend/src/ws/index.test.ts",
     "test:schemas": "bun test ./packages/core/src/domain/schemas/core-schemas.test.ts",
     "test:core-services": "bun test ./packages/core/src/domain/services/*.test.ts",
+    "test:perf:api": "bun scripts/perf/api.ts",
     "schema:generate": "bun scripts/schema/generate.ts",
     "test:schema-generation": "bun scripts/schema/generate.ts --self-test",
     "schema:check": "sh scripts/schema/check.sh",

--- a/scripts/perf/api.ts
+++ b/scripts/perf/api.ts
@@ -18,6 +18,10 @@ type EndpointMeasurement = {
   p95Ms: number;
 };
 
+type TaskListResponse = {
+  tasks: TaskCard[];
+};
+
 async function main(): Promise<void> {
   const tempRoot = await realpath(await mkdtemp(join(tmpdir(), "shud-harness-perf-api-")));
   try {
@@ -38,6 +42,7 @@ async function main(): Promise<void> {
     if (!targetTask) {
       throw new Error("PERF-API-001 fixture did not create a target task.");
     }
+    await expectTaskListCount(app, TASK_COUNT);
 
     const measurements: EndpointMeasurement[] = [
       await measureEndpoint(app, "GET /api/tasks", "/api/tasks", 200),
@@ -84,6 +89,20 @@ async function createTaskFixture(app: ReturnType<typeof createBackendApi>): Prom
   return tasks;
 }
 
+async function expectTaskListCount(
+  app: ReturnType<typeof createBackendApi>,
+  expectedCount: number
+): Promise<void> {
+  const response = await expectStatus(app.request("/api/tasks"), 200, "GET /api/tasks", false);
+  const body = (await response.json()) as TaskListResponse;
+  if (!Array.isArray(body.tasks) || body.tasks.length !== expectedCount) {
+    const actualCount = Array.isArray(body.tasks) ? body.tasks.length : "non-array";
+    throw new Error(
+      `PERF-API-001 fixture listed ${actualCount} tasks, expected ${expectedCount}.`
+    );
+  }
+}
+
 async function measureEndpoint(
   app: ReturnType<typeof createBackendApi>,
   label: string,
@@ -112,13 +131,16 @@ async function measureEndpoint(
 async function expectStatus(
   responsePromise: Response | Promise<Response>,
   expectedStatus: number,
-  label: string
+  label: string,
+  consumeBody = true
 ): Promise<Response> {
   const response = await responsePromise;
   if (response.status !== expectedStatus) {
     throw new Error(`${label} returned HTTP ${response.status}, expected ${expectedStatus}.`);
   }
-  await response.arrayBuffer();
+  if (consumeBody) {
+    await response.arrayBuffer();
+  }
   return response;
 }
 

--- a/scripts/perf/api.ts
+++ b/scripts/perf/api.ts
@@ -1,0 +1,166 @@
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+
+import { createBackendApi } from "../../packages/backend/src/index";
+import type { CreateTaskInput, TaskCard } from "../../packages/core/src/index";
+
+const TASK_COUNT = 100;
+const WARMUP_REQUESTS_PER_ENDPOINT = 5;
+const SAMPLE_REQUESTS_PER_ENDPOINT = 40;
+const P95_LIMIT_MS = 300;
+
+type EndpointMeasurement = {
+  label: string;
+  path: string;
+  expectedStatus: number;
+  p95Ms: number;
+};
+
+async function main(): Promise<void> {
+  const tempRoot = await realpath(await mkdtemp(join(tmpdir(), "shud-harness-perf-api-")));
+  try {
+    const workspaceRoot = join(tempRoot, "workspace");
+    const app = createBackendApi({
+      workspaceRoot,
+      requestLogSink: () => undefined,
+      taskIdFactory: sequentialTaskIdFactory()
+    });
+
+    await expectStatus(
+      app.request("/api/workspace/init", { method: "POST" }),
+      200,
+      "POST /api/workspace/init"
+    );
+    const tasks = await createTaskFixture(app);
+    const targetTask = tasks[0];
+    if (!targetTask) {
+      throw new Error("PERF-API-001 fixture did not create a target task.");
+    }
+
+    const measurements: EndpointMeasurement[] = [
+      await measureEndpoint(app, "GET /api/tasks", "/api/tasks", 200),
+      await measureEndpoint(app, "GET /api/tasks/:id", `/api/tasks/${targetTask.task_id}`, 200),
+      await measureEndpoint(app, "GET /api/health/ready", "/api/health/ready", 200)
+    ];
+
+    printMeasurements(measurements);
+    const failures = measurements.filter((measurement) => measurement.p95Ms > P95_LIMIT_MS);
+    if (failures.length > 0) {
+      const summary = failures
+        .map(
+          (measurement) =>
+            `${measurement.label} P95 ${formatMs(measurement.p95Ms)} > ${P95_LIMIT_MS}ms`
+        )
+        .join("; ");
+      throw new Error(`PERF-API-001 failed: ${summary}`);
+    }
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+async function createTaskFixture(app: ReturnType<typeof createBackendApi>): Promise<TaskCard[]> {
+  const tasks: TaskCard[] = [];
+  for (let index = 0; index < TASK_COUNT; index += 1) {
+    const response = await app.request("/api/tasks", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(taskCreateInput(index))
+    });
+    if (response.status !== 201) {
+      throw new Error(
+        `PERF-API-001 fixture failed to create task ${index + 1}: HTTP ${response.status}`
+      );
+    }
+    tasks.push((await response.json()) as TaskCard);
+  }
+
+  if (tasks.length !== TASK_COUNT) {
+    throw new Error(`PERF-API-001 fixture created ${tasks.length} tasks, expected ${TASK_COUNT}.`);
+  }
+
+  return tasks;
+}
+
+async function measureEndpoint(
+  app: ReturnType<typeof createBackendApi>,
+  label: string,
+  path: string,
+  expectedStatus: number
+): Promise<EndpointMeasurement> {
+  for (let index = 0; index < WARMUP_REQUESTS_PER_ENDPOINT; index += 1) {
+    await expectStatus(app.request(path), expectedStatus, label);
+  }
+
+  const samples: number[] = [];
+  for (let index = 0; index < SAMPLE_REQUESTS_PER_ENDPOINT; index += 1) {
+    const startedAtMs = performance.now();
+    await expectStatus(app.request(path), expectedStatus, label);
+    samples.push(performance.now() - startedAtMs);
+  }
+
+  return {
+    label,
+    path,
+    expectedStatus,
+    p95Ms: percentile(samples, 95)
+  };
+}
+
+async function expectStatus(
+  responsePromise: Response | Promise<Response>,
+  expectedStatus: number,
+  label: string
+): Promise<Response> {
+  const response = await responsePromise;
+  if (response.status !== expectedStatus) {
+    throw new Error(`${label} returned HTTP ${response.status}, expected ${expectedStatus}.`);
+  }
+  await response.arrayBuffer();
+  return response;
+}
+
+function percentile(samples: readonly number[], percentileValue: number): number {
+  if (samples.length === 0) {
+    throw new Error("Cannot compute percentile for an empty sample set.");
+  }
+  const sorted = [...samples].sort((left, right) => left - right);
+  const index = Math.ceil((percentileValue / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(sorted.length - 1, index))] as number;
+}
+
+function printMeasurements(measurements: readonly EndpointMeasurement[]): void {
+  console.log(`PERF-API-001 fixture: ${TASK_COUNT} tasks`);
+  for (const measurement of measurements) {
+    console.log(
+      `${measurement.label} P95=${formatMs(measurement.p95Ms)} limit=${P95_LIMIT_MS}ms status=${measurement.expectedStatus}`
+    );
+  }
+}
+
+function formatMs(value: number): string {
+  return `${value.toFixed(2)}ms`;
+}
+
+function sequentialTaskIdFactory(): () => string {
+  let nextId = 1;
+  return () => `TASK-perf-${String(nextId++).padStart(3, "0")}`;
+}
+
+function taskCreateInput(index: number): CreateTaskInput {
+  const sequence = String(index + 1).padStart(3, "0");
+  return {
+    type: "engineering",
+    title: `PERF-API-001 fixture task ${sequence}`,
+    question_or_goal: `Exercise metadata API latency for fixture task ${sequence}.`,
+    inference_budget: { mode: "normal" },
+    created_by: "pi"
+  };
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Add `bun run test:perf:api` for PERF-API-001 using a disposable workspace and 100 TaskCards.
- Verify the fixture list contains exactly 100 tasks, then measure P95 for `GET /api/tasks`, `GET /api/tasks/:id`, and `GET /api/health/ready`.
- Fail with measured P95 when any endpoint exceeds 300ms, and wire the smoke into PR CI `linux-base` after schema drift check.

## Verification
- `npx --yes bun@1.2.19 run test:perf:api`
- `npx --yes bun@1.2.19 run typecheck`
- `npx --yes bun@1.2.19 run check`
- `npx --yes bun@1.2.19 run schema:check`
- `openspec validate m1-foundation --strict --no-interactive`
- `git diff --check`
- `git -C zero diff --quiet && test -z "$(git ls-files workspace)"`
- GitHub CI: `docs-links`, `linux-base`, `macos-seatbelt`, `check` all pass on `b546438720cf79e4f2c240a199c066b0ba551af4`.
- GitHub linux-base PERF output: `GET /api/tasks P95=0.27ms`, `GET /api/tasks/:id P95=0.08ms`, `GET /api/health/ready P95=9.02ms`.

## Agent Review
- Reviewer agents used: script correctness, CI/package integration, performance measurement validity, OpenSpec/acceptance alignment, plus final follow-up after task-count assertion.
- Reviewed head SHA: `b546438720cf79e4f2c240a199c066b0ba551af4`.
- Review evidence: all review perspectives clean; no open P0/P1/P2 findings.
- OpenSpec change: `m1-foundation`; fixture level: expanded; selected risk packs: Public API/CLI, Performance/timing, Workspace fixture/repeatability.
- Key finding addressed: strengthened fixture proof by asserting `GET /api/tasks` lists exactly 100 tasks before sampling.
- Residual non-blocking risks: smoke uses in-process Hono requests rather than real network transport, and does not cover concurrency or later PERF-* tests; both are outside #32 scope.

Closes #32.