### PR TITLE
feat(core): add workspace path safety helper (#33)

### DIFF
--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -927,3 +927,85 @@ Review focus:
 - Idempotency mismatch and failed create paths do not create duplicate TaskCards or poisoned completed records.
 - Workspace record paths use safe derived segments and API error JSON never exposes raw caller headers or absolute workspace paths.
 - Artifact/Lock services stay skeleton-sized but schema-valid, workspace-local, directly queryable, and compatible with later #33 path helper wiring.
+
+## Subagent Workflow Fixture - Issue #33
+
+Fixture level: expanded; repair intensity: high
+Project profile: SHUD-Harness
+
+Expanded-trigger rationale:
+- Core triggers: shared path helper, persisted workspace writes, normalized path field storage, symlink/traversal rejection, and fail-closed no-write behavior.
+- Profile triggers: `workspace`, `artifact`, `snapshot`, path/workspace containment, and evidence-chain correctness.
+
+Change surface:
+- `packages/core/src/domain/services/workspace-path-safety.ts` shared path resolution helper.
+- Artifact registry manifest write path in `packages/core/src/domain/services/artifact-registry-service.ts`.
+- Task snapshot write path in `packages/core/src/domain/services/task-card-service.ts`.
+- Workspace JSON record write preparation in `packages/core/src/domain/services/workspace-record-store.ts`.
+
+Must preserve:
+- #29 TaskCard create/list/detail response shape, snapshot filename, restart recovery, bounded hydration, and existing workspace error envelopes.
+- #30 IdempotencyRecord, LockRecord, and Artifact schema validation, direct lookup behavior, immutable manifest semantics, and no raw caller segment leaks.
+- Runtime `workspace/` assets remain untracked; `zero/` remains source-clean.
+- No bash/sandbox behavior and no workspace allowlist expansion beyond explicit read-only root support in the helper.
+
+Must add/change:
+- A shared helper resolves input paths, normalizes them, checks workspace or allowed read-only boundaries, rejects symlink crossings and non-directory ancestors, and returns the normalized path.
+- Artifact registry normalizes `artifact.path` before manifest storage and rejects unsafe paths before writing manifests.
+- Task snapshot write surfaces resolve the task root, task lane, snapshot path, and temporary path through the helper before writing.
+- Workspace JSON record writes use the shared helper at the point of write preparation.
+
+Risk packs considered:
+- Public API / CLI / script entry: not selected - no route or CLI contract changes.
+- Config / project setup: selected - all behavior is rooted in the configured workspace root and optional allowed read-only roots.
+- File IO / path safety / overwrite: selected - this issue owns traversal, symlink, boundary, and no-write regression coverage for workspace write surfaces.
+- Schema / columns / units / field names: selected - Artifact manifest `path` is normalized before storage.
+- Auth / permissions / secrets: not selected - no credential or permission model changes.
+- Concurrency / shared state / ordering: selected - helper checks are applied immediately before write preparation and preserve existing atomic/no-clobber paths.
+- Resource limits / large input / discovery: selected - helper walks only path ancestors and stops at the first missing segment; no broad workspace scan is introduced.
+- Legacy compatibility / examples: selected - existing #29/#30/#31/#32 tests and response/storage behavior remain compatible.
+- Error handling / rollback / partial outputs: selected - rejected paths fail closed and must not create workspace-external files or partial manifests/snapshots.
+- Release / packaging / dependency compatibility: not selected - no new dependency.
+- Documentation / migration notes: selected - PR evidence states helper boundaries and out-of-scope bash/sandbox behavior.
+Domain packs:
+- Scientific governance / PI gate / evidence lineage: selected - Artifact paths are future evidence references and must not be silently rewritten outside the workspace.
+- Hydrology runtime / SHUD-rSHUD-AutoSHUD compatibility: not selected - no solver/runtime behavior changes.
+- Zero adapter / tool registry / agent role governance: not selected - no Zero/tool governance changes.
+
+Invariant Matrix:
+- Governing invariant: Every M1 workspace write surface introduced by #29/#30 records only normalized paths inside the configured workspace, or rejects before write when a path traverses outside, crosses a symlink, targets a read-only boundary for write, or encounters a non-directory ancestor.
+- Source-of-truth identity/contract: configured `workspaceRoot`, optional `allowedReadonlyRoots`, normalized workspace-relative path, `Artifact.path`, task snapshot paths, and `workspace_path_not_safe` evidence refs.
+- Producers: Artifact registry `registerArtifact`, TaskCard snapshot persistence, Workspace JSON record write preparation, and the shared helper.
+- Validators/preflight: segment/id validators from #29/#30 plus shared `resolveWorkspacePath` boundary and symlink checks.
+- Storage/cache/query: task snapshots under `workspace/tasks/<task_id>/snapshot.json`, temporary snapshot files, and Artifact manifests under `workspace/artifacts/manifests/`.
+- Public routes/entrypoints: none directly - #29/#30 backend routes consume these services indirectly.
+- Frontend/downstream consumers: #35 Dashboard and future artifact/evidence consumers read normalized stored paths without API shape changes.
+- Failure paths/rollback/stale state: traversal, absolute path outside workspace, symlinked ancestor/leaf, write under allowed read-only root, missing parent segments, existing regular-file lanes, and existing rollback/cleanup paths.
+- Evidence/audit/readiness: core service tests, root check, OpenSpec validation, diff check, zero diff, and no tracked `workspace`.
+- Regression rows:
+  - Legal relative Artifact path with `./` -> stored manifest path is normalized workspace-relative and `getArtifact(id)` returns the normalized record.
+  - `../` traversal or absolute outside workspace -> helper throws `WorkspacePathSafetyError`/mapped `workspace_path_not_safe` before any outside file exists.
+  - Workspace symlink ancestor pointing outside -> Artifact registry and TaskCard snapshot writes reject before writing a manifest or snapshot outside.
+  - Allowed read-only root with `access=read` -> helper returns boundary `allowed_readonly`; same root with `access=write` -> rejection.
+  - Existing #29/#30 service tests -> snapshot recovery, idempotency, lock, artifact lookup, and immutable duplicate behavior remain green.
+
+Boundary-surface checklist:
+- Shared helper roots: `resolveWorkspacePath`, `assertPathInsideWorkspace`, and existing local workspace guards.
+- Read surfaces: helper read-only resolution for allowed read-only roots; existing snapshot/record reads are compatibility surfaces.
+- Write/delete/overwrite surfaces: Artifact manifest writes, Task snapshot writes, temporary snapshot publish, and JSON record writes.
+- Staging/publish/rollback surfaces: snapshot temp-file write/rename/unlink and existing record no-clobber writes.
+- Producer/consumer evidence boundaries: Artifact input path -> normalized manifest path; TaskCard id -> normalized snapshot lane.
+- Stale-state/idempotency boundaries: existing #30 idempotency/lock behavior; no new cross-process locking.
+- Unchanged downstream consumers: backend task routes, idempotency/lock services, structured logging, perf smoke, and future Dashboard.
+
+Required evidence:
+- Core service tests for traversal rejection, symlink escape rejection, legal path normalization, allowed read-only read/write split, normalized Artifact manifest storage, Artifact symlink no-write, and Task snapshot normalized/no-write cases.
+- Gate commands: `bun run test:core-services`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
+
+Non-goals:
+- Bash/sandbox execution path controls, M3 executor behavior, raw-data write denial telemetry, artifact payload serving/download APIs, and expanding workspace external allowlists.
+
+Review focus:
+- Helper boundary checks are centralized and fail closed before writes.
+- Artifact and Task snapshot write surfaces actually call the helper and persist normalized paths where applicable.
+- Tests prove no outside file/manifest/snapshot is created on traversal or symlink escape.

--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -950,7 +950,7 @@ Must preserve:
 - No bash/sandbox behavior and no workspace allowlist expansion beyond explicit read-only root support in the helper.
 
 Must add/change:
-- A shared helper resolves input paths, normalizes them, checks workspace or allowed read-only boundaries, rejects symlink crossings and non-directory ancestors, and returns the normalized path.
+- A shared helper resolves input paths against the currently observed path tree, normalizes them, checks workspace or allowed read-only boundaries, rejects pre-existing symlink crossings and non-directory ancestors, and returns the normalized path.
 - Artifact registry normalizes `artifact.path` before manifest storage and rejects unsafe paths before writing manifests.
 - Task snapshot write surfaces resolve the task root, task lane, snapshot path, and temporary path through the helper before writing.
 - Workspace JSON record writes use the shared helper at the point of write preparation.
@@ -958,13 +958,13 @@ Must add/change:
 Risk packs considered:
 - Public API / CLI / script entry: not selected - no route or CLI contract changes.
 - Config / project setup: selected - all behavior is rooted in the configured workspace root and optional allowed read-only roots.
-- File IO / path safety / overwrite: selected - this issue owns traversal, symlink, boundary, and no-write regression coverage for workspace write surfaces.
+- File IO / path safety / overwrite: selected - this issue owns static/pre-existing traversal, symlink, boundary, and no-write regression coverage for workspace write surfaces.
 - Schema / columns / units / field names: selected - Artifact manifest `path` is normalized before storage.
 - Auth / permissions / secrets: not selected - no credential or permission model changes.
-- Concurrency / shared state / ordering: selected - helper checks are applied immediately before write preparation and preserve existing atomic/no-clobber paths.
+- Concurrency / shared state / ordering: selected - helper checks are applied immediately before write preparation and preserve existing atomic/no-clobber paths; M1 remains ADR-0002 single-user/cooperative workspace and does not add cross-process locking or directory-fd anchoring.
 - Resource limits / large input / discovery: selected - helper walks only path ancestors and stops at the first missing segment; no broad workspace scan is introduced.
 - Legacy compatibility / examples: selected - existing #29/#30/#31/#32 tests and response/storage behavior remain compatible.
-- Error handling / rollback / partial outputs: selected - rejected paths fail closed and must not create workspace-external files or partial manifests/snapshots.
+- Error handling / rollback / partial outputs: selected - rejected pre-existing/static unsafe paths fail closed and must not create workspace-external files or partial manifests/snapshots.
 - Release / packaging / dependency compatibility: not selected - no new dependency.
 - Documentation / migration notes: selected - PR evidence states helper boundaries and out-of-scope bash/sandbox behavior.
 Domain packs:
@@ -973,19 +973,19 @@ Domain packs:
 - Zero adapter / tool registry / agent role governance: not selected - no Zero/tool governance changes.
 
 Invariant Matrix:
-- Governing invariant: Every M1 workspace write surface introduced by #29/#30 records only normalized paths inside the configured workspace, or rejects before write when a path traverses outside, crosses a symlink, targets a read-only boundary for write, or encounters a non-directory ancestor.
+- Governing invariant: Every M1 workspace write surface introduced by #29/#30 records only normalized paths inside the configured workspace, or rejects before write when the currently observed path tree traverses outside, crosses a pre-existing symlink, targets a read-only boundary for write, or encounters a non-directory ancestor.
 - Source-of-truth identity/contract: configured `workspaceRoot`, optional `allowedReadonlyRoots`, normalized workspace-relative path, `Artifact.path`, task snapshot paths, and `workspace_path_not_safe` evidence refs.
 - Producers: Artifact registry `registerArtifact`, TaskCard snapshot persistence, Workspace JSON record write preparation, and the shared helper.
 - Validators/preflight: segment/id validators from #29/#30 plus shared `resolveWorkspacePath` boundary and symlink checks.
 - Storage/cache/query: task snapshots under `workspace/tasks/<task_id>/snapshot.json`, temporary snapshot files, and Artifact manifests under `workspace/artifacts/manifests/`.
 - Public routes/entrypoints: none directly - #29/#30 backend routes consume these services indirectly.
 - Frontend/downstream consumers: #35 Dashboard and future artifact/evidence consumers read normalized stored paths without API shape changes.
-- Failure paths/rollback/stale state: traversal, absolute path outside workspace, symlinked ancestor/leaf, write under allowed read-only root, missing parent segments, existing regular-file lanes, and existing rollback/cleanup paths.
+- Failure paths/rollback/stale state: traversal, absolute path outside workspace, pre-existing symlinked ancestor/leaf, write under allowed read-only root, missing parent segments, existing regular-file lanes, and existing rollback/cleanup paths. External concurrent directory swaps between helper validation and the filesystem syscall are outside #33's M1 authority boundary by ADR-0002 D1/D6 and this fixture's "no new cross-process locking" constraint; any future race-resilient guarantee belongs with M3 executor/workspace locking or an OS/native directory-fd boundary.
 - Evidence/audit/readiness: core service tests, root check, OpenSpec validation, diff check, zero diff, and no tracked `workspace`.
 - Regression rows:
   - Legal relative Artifact path with `./` -> stored manifest path is normalized workspace-relative and `getArtifact(id)` returns the normalized record.
   - `../` traversal or absolute outside workspace -> helper throws `WorkspacePathSafetyError`/mapped `workspace_path_not_safe` before any outside file exists.
-  - Workspace symlink ancestor pointing outside -> Artifact registry and TaskCard snapshot writes reject before writing a manifest or snapshot outside.
+  - Pre-existing workspace symlink ancestor pointing outside -> Artifact registry and TaskCard snapshot writes reject before writing a manifest or snapshot outside.
   - Allowed read-only root with `access=read` -> helper returns boundary `allowed_readonly`; same root with `access=write` -> rejection.
   - Existing #29/#30 service tests -> snapshot recovery, idempotency, lock, artifact lookup, and immutable duplicate behavior remain green.
 
@@ -995,7 +995,7 @@ Boundary-surface checklist:
 - Write/delete/overwrite surfaces: Artifact manifest writes, Task snapshot writes, temporary snapshot publish, and JSON record writes.
 - Staging/publish/rollback surfaces: snapshot temp-file write/rename/unlink and existing record no-clobber writes.
 - Producer/consumer evidence boundaries: Artifact input path -> normalized manifest path; TaskCard id -> normalized snapshot lane.
-- Stale-state/idempotency boundaries: existing #30 idempotency/lock behavior; no new cross-process locking.
+- Stale-state/idempotency boundaries: existing #30 idempotency/lock behavior; no new cross-process locking, external-mutator race defense, or directory-fd/openat-style anchoring.
 - Unchanged downstream consumers: backend task routes, idempotency/lock services, structured logging, perf smoke, and future Dashboard.
 
 Required evidence:
@@ -1003,7 +1003,7 @@ Required evidence:
 - Gate commands: `bun run test:core-services`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 
 Non-goals:
-- Bash/sandbox execution path controls, M3 executor behavior, raw-data write denial telemetry, artifact payload serving/download APIs, and expanding workspace external allowlists.
+- Bash/sandbox execution path controls, M3 executor behavior, raw-data write denial telemetry, race-resilient directory-fd/openat-style write anchoring, artifact payload serving/download APIs, and expanding workspace external allowlists.
 
 Review focus:
 - Helper boundary checks are centralized and fail closed before writes.

--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -950,7 +950,7 @@ Must preserve:
 - No bash/sandbox behavior and no workspace allowlist expansion beyond explicit read-only root support in the helper.
 
 Must add/change:
-- A shared helper resolves input paths against the currently observed path tree, normalizes them, checks workspace or allowed read-only boundaries, rejects pre-existing symlink crossings and non-directory ancestors, and returns the normalized path.
+- A shared helper requires absolute stable `workspaceRoot` / `allowedReadonlyRoots`, resolves input paths against the currently observed path tree, normalizes them, checks workspace or allowed read-only boundaries, rejects pre-existing symlink crossings and non-directory ancestors, and returns the normalized path.
 - Artifact registry normalizes `artifact.path` before manifest storage and rejects unsafe paths before writing manifests.
 - Task snapshot write surfaces resolve the task root, task lane, snapshot path, and temporary path through the helper before writing.
 - Workspace JSON record writes use the shared helper at the point of write preparation.
@@ -973,8 +973,8 @@ Domain packs:
 - Zero adapter / tool registry / agent role governance: not selected - no Zero/tool governance changes.
 
 Invariant Matrix:
-- Governing invariant: Every M1 workspace write surface introduced by #29/#30 records only normalized paths inside the configured workspace, or rejects before write when the currently observed path tree traverses outside, crosses a pre-existing symlink, targets a read-only boundary for write, or encounters a non-directory ancestor.
-- Source-of-truth identity/contract: configured `workspaceRoot`, optional `allowedReadonlyRoots`, normalized workspace-relative path, `Artifact.path`, task snapshot paths, and `workspace_path_not_safe` evidence refs.
+- Governing invariant: Every M1 workspace write surface introduced by #29/#30 records only normalized paths inside the configured workspace, or rejects before write when roots are relative, the currently observed path tree traverses outside, crosses a pre-existing symlink, targets a read-only boundary for write, or encounters a non-directory ancestor.
+- Source-of-truth identity/contract: configured absolute `workspaceRoot`, optional absolute `allowedReadonlyRoots`, normalized workspace-relative path, `Artifact.path`, task snapshot paths, and `workspace_path_not_safe` evidence refs.
 - Producers: Artifact registry `registerArtifact`, TaskCard snapshot persistence, Workspace JSON record write preparation, and the shared helper.
 - Validators/preflight: segment/id validators from #29/#30 plus shared `resolveWorkspacePath` boundary and symlink checks.
 - Storage/cache/query: task snapshots under `workspace/tasks/<task_id>/snapshot.json`, temporary snapshot files, and Artifact manifests under `workspace/artifacts/manifests/`.
@@ -987,6 +987,7 @@ Invariant Matrix:
   - `../` traversal or absolute outside workspace -> helper throws `WorkspacePathSafetyError`/mapped `workspace_path_not_safe` before any outside file exists.
   - Pre-existing workspace symlink ancestor pointing outside -> Artifact registry and TaskCard snapshot writes reject before writing a manifest or snapshot outside.
   - Allowed read-only root with `access=read` -> helper returns boundary `allowed_readonly`; same root with `access=write` -> rejection.
+  - Relative `workspaceRoot` or `allowedReadonlyRoots` -> helper rejects instead of resolving against process cwd.
   - Existing #29/#30 service tests -> snapshot recovery, idempotency, lock, artifact lookup, and immutable duplicate behavior remain green.
 
 Boundary-surface checklist:
@@ -999,7 +1000,7 @@ Boundary-surface checklist:
 - Unchanged downstream consumers: backend task routes, idempotency/lock services, structured logging, perf smoke, and future Dashboard.
 
 Required evidence:
-- Core service tests for traversal rejection, symlink escape rejection, legal path normalization, allowed read-only read/write split, normalized Artifact manifest storage, Artifact symlink no-write, and Task snapshot normalized/no-write cases.
+- Core service tests for traversal rejection, symlink escape rejection, legal path normalization, absolute root enforcement/cwd-drift rejection, allowed read-only read/write split, normalized Artifact manifest storage, Artifact symlink no-write, and Task snapshot normalized/no-write cases.
 - Gate commands: `bun run test:core-services`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 
 Non-goals:

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -200,6 +200,17 @@
     - PR CI `linux-base` runs `bun run test:perf:api` after schema drift check.
     - `bun run test:perf:api`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 - [ ] 6.6 路径安全 helper（packages/core 共享 service，遵 Workspace_Conventions §9：resolve 规范化 → workspace 边界校验 → 拒 symlink escape → 记录规范化路径）+ Artifact registry 落盘与 task snapshot 写入两处接线 + 正负例单测（`../` 穿越拒绝、symlink escape 拒绝、合法路径规范化记录；承接 Test_Plan W1 Unit「path normalization」）——依赖: 6.2、6.3（两处落盘写入面在位）
+  - Risk packs (#33):
+    - Workspace path safety / filesystem writes: selected - introduces shared path resolution and rewires two write surfaces.
+    - Error handling / fail-closed behavior: selected - rejected paths must not create or mutate workspace-external files.
+    - Schema / record fields: selected - Artifact manifest `path` is normalized before storage.
+    - Other packs: not selected - no API route, frontend, observability, performance, hydrology runtime, or Zero governance behavior changes.
+  - Evidence floor (#33):
+    - `packages/core/src/domain/services/workspace-path-safety.ts` resolves paths, enforces workspace/read-only boundaries, rejects symlink crossings, and returns normalized workspace-relative paths.
+    - Artifact registry normalizes `artifact.path` before manifest storage and rejects symlink escapes before writing manifests.
+    - Task snapshot writes resolve `tasks/`, task lane, snapshot, and temporary paths through the shared helper.
+    - Core service tests cover traversal rejection, symlink escape rejection, legal normalized paths, Artifact manifest normalized storage, Artifact symlink no-write, and Task snapshot normalized path/no-write cases.
+    - `bun run test:core-services`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 
 ## 7. 四栏壳（workbench-shell）
 

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -201,15 +201,15 @@
     - `bun run test:perf:api`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 - [ ] 6.6 路径安全 helper（packages/core 共享 service，遵 Workspace_Conventions §9：resolve 规范化 → workspace 边界校验 → 拒 symlink escape → 记录规范化路径）+ Artifact registry 落盘与 task snapshot 写入两处接线 + 正负例单测（`../` 穿越拒绝、symlink escape 拒绝、合法路径规范化记录；承接 Test_Plan W1 Unit「path normalization」）——依赖: 6.2、6.3（两处落盘写入面在位）
   - Risk packs (#33):
-    - Workspace path safety / filesystem writes: selected - introduces shared path resolution and rewires two write surfaces.
-    - Error handling / fail-closed behavior: selected - rejected paths must not create or mutate workspace-external files.
+    - Workspace path safety / filesystem writes: selected - introduces shared path resolution and rewires two write surfaces for static/pre-existing traversal, symlink, and boundary escapes.
+    - Error handling / fail-closed behavior: selected - rejected pre-existing/static unsafe paths must not create or mutate workspace-external files.
     - Schema / record fields: selected - Artifact manifest `path` is normalized before storage.
     - Other packs: not selected - no API route, frontend, observability, performance, hydrology runtime, or Zero governance behavior changes.
   - Evidence floor (#33):
-    - `packages/core/src/domain/services/workspace-path-safety.ts` resolves paths, enforces workspace/read-only boundaries, rejects symlink crossings, and returns normalized workspace-relative paths.
+    - `packages/core/src/domain/services/workspace-path-safety.ts` resolves paths against the currently observed path tree, enforces workspace/read-only boundaries, rejects pre-existing symlink crossings, and returns normalized workspace-relative paths.
     - Artifact registry normalizes `artifact.path` before manifest storage and rejects symlink escapes before writing manifests.
     - Task snapshot writes resolve `tasks/`, task lane, snapshot, and temporary paths through the shared helper.
-    - Core service tests cover traversal rejection, symlink escape rejection, legal normalized paths, Artifact manifest normalized storage, Artifact symlink no-write, and Task snapshot normalized path/no-write cases.
+    - Core service tests cover traversal rejection, pre-existing symlink escape rejection, legal normalized paths, allowed read-only read/write split, Artifact manifest normalized storage, Artifact symlink no-write, and Task snapshot normalized path/no-write cases. Race-resilient protection against external concurrent directory swaps between validation and syscall is outside #33's M1 authority boundary and belongs with later executor/workspace-locking work.
     - `bun run test:core-services`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 
 ## 7. 四栏壳（workbench-shell）

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -206,10 +206,10 @@
     - Schema / record fields: selected - Artifact manifest `path` is normalized before storage.
     - Other packs: not selected - no API route, frontend, observability, performance, hydrology runtime, or Zero governance behavior changes.
   - Evidence floor (#33):
-    - `packages/core/src/domain/services/workspace-path-safety.ts` resolves paths against the currently observed path tree, enforces workspace/read-only boundaries, rejects pre-existing symlink crossings, and returns normalized workspace-relative paths.
+    - `packages/core/src/domain/services/workspace-path-safety.ts` requires absolute stable `workspaceRoot` / `allowedReadonlyRoots`, resolves paths against the currently observed path tree, enforces workspace/read-only boundaries, rejects pre-existing symlink crossings, and returns normalized workspace-relative paths.
     - Artifact registry normalizes `artifact.path` before manifest storage and rejects symlink escapes before writing manifests.
     - Task snapshot writes resolve `tasks/`, task lane, snapshot, and temporary paths through the shared helper.
-    - Core service tests cover traversal rejection, pre-existing symlink escape rejection, legal normalized paths, allowed read-only read/write split, Artifact manifest normalized storage, Artifact symlink no-write, and Task snapshot normalized path/no-write cases. Race-resilient protection against external concurrent directory swaps between validation and syscall is outside #33's M1 authority boundary and belongs with later executor/workspace-locking work.
+    - Core service tests cover traversal rejection, pre-existing symlink escape rejection, legal normalized paths, absolute root enforcement/cwd-drift rejection, allowed read-only read/write split, Artifact manifest normalized storage, Artifact symlink no-write, and Task snapshot normalized path/no-write cases. Race-resilient protection against external concurrent directory swaps between validation and syscall is outside #33's M1 authority boundary and belongs with later executor/workspace-locking work.
     - `bun run test:core-services`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 
 ## 7. 四栏壳（workbench-shell）

--- a/packages/core/src/domain/services/artifact-registry-service.ts
+++ b/packages/core/src/domain/services/artifact-registry-service.ts
@@ -9,6 +9,7 @@ import {
   workspaceRecordPath,
   writeJsonRecord
 } from "./workspace-record-store";
+import { WorkspacePathSafetyError, resolveWorkspacePath } from "./workspace-path-safety";
 
 export interface ArtifactRegistryServiceOptions {
   workspaceRoot: string;
@@ -31,25 +32,26 @@ export function createArtifactRegistryService(
         assertSafeRecordSegment(parsedArtifact.data.artifact_id, "artifact.artifact_id");
         assertSafeRelativeRecordPath(parsedArtifact.data.path, "artifact.path");
         ArtifactTypeSchema.parse(parsedArtifact.data.type);
+        const artifact = await normalizeArtifactPath(workspaceRoot, parsedArtifact.data);
 
         const created = await createJsonRecordIfAbsent(
           workspaceRoot,
           artifactManifestDirectorySegments(),
-          artifactManifestFileName(parsedArtifact.data.artifact_id),
-          parsedArtifact.data,
-          artifactManifestEvidenceRef(parsedArtifact.data.artifact_id),
+          artifactManifestFileName(artifact.artifact_id),
+          artifact,
+          artifactManifestEvidenceRef(artifact.artifact_id),
           ArtifactSchema
         );
         if (created.status === "created") {
           return created.record;
         }
 
-        const existing = await readArtifactManifest(workspaceRoot, parsedArtifact.data.artifact_id);
-        if (existing && canonicalJson(existing) === canonicalJson(parsedArtifact.data)) {
+        const existing = await readArtifactManifest(workspaceRoot, artifact.artifact_id);
+        if (existing && canonicalJson(existing) === canonicalJson(artifact)) {
           return existing;
         }
 
-        throw artifactManifestImmutableError(parsedArtifact.data.artifact_id);
+        throw artifactManifestImmutableError(artifact.artifact_id);
       }
 
       return await writeJsonRecord(
@@ -71,6 +73,32 @@ export function createArtifactRegistryService(
       return artifact;
     }
   };
+}
+
+async function normalizeArtifactPath(workspaceRoot: string, artifact: Artifact): Promise<Artifact> {
+  try {
+    const resolvedPath = await resolveWorkspacePath({
+      workspaceRoot,
+      inputPath: artifact.path,
+      evidenceRef: "artifact.path",
+      access: "write"
+    });
+    return { ...artifact, path: resolvedPath.normalizedPath };
+  } catch (error) {
+    if (error instanceof WorkspacePathSafetyError) {
+      throw new TaskServiceError({
+        code: "workspace_path_not_safe",
+        status: 500,
+        category: "workspace_error",
+        message: error.message,
+        userMessage: "The artifact path is not safe to write.",
+        evidenceRefs: [error.evidenceRef],
+        retryable: false,
+        recommendedNextActions: ["Choose an artifact path inside the workspace."]
+      });
+    }
+    throw error;
+  }
 }
 
 export function artifactManifestDirectorySegments(): readonly string[] {

--- a/packages/core/src/domain/services/artifact-registry-service.ts
+++ b/packages/core/src/domain/services/artifact-registry-service.ts
@@ -47,7 +47,7 @@ export function createArtifactRegistryService(
         }
 
         const existing = await readArtifactManifest(workspaceRoot, artifact.artifact_id);
-        if (existing && canonicalJson(existing) === canonicalJson(artifact)) {
+        if (existing && (await artifactsMatchForDuplicate(workspaceRoot, existing, artifact))) {
           return existing;
         }
 
@@ -96,6 +96,30 @@ async function normalizeArtifactPath(workspaceRoot: string, artifact: Artifact):
         retryable: false,
         recommendedNextActions: ["Choose an artifact path inside the workspace."]
       });
+    }
+    throw error;
+  }
+}
+
+async function artifactsMatchForDuplicate(
+  workspaceRoot: string,
+  existing: Artifact,
+  candidate: Artifact
+): Promise<boolean> {
+  if (canonicalJson(existing) === canonicalJson(candidate)) {
+    return true;
+  }
+
+  try {
+    assertSafeRelativeRecordPath(existing.path, "artifact.path");
+    const normalizedExisting = await normalizeArtifactPath(workspaceRoot, existing);
+    return canonicalJson(normalizedExisting) === canonicalJson(candidate);
+  } catch (error) {
+    if (
+      error instanceof TaskServiceError &&
+      (error.code === "workspace_path_not_safe" || error.code === "record_id_not_safe")
+    ) {
+      return false;
     }
     throw error;
   }

--- a/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
+++ b/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
@@ -22,10 +22,12 @@ import {
   idempotencyRecordEvidenceRef,
   idempotencyRecordFileName,
   sha256Hex,
+  resolveWorkspacePath,
   type Artifact,
   type IdempotencyRecord,
   type IdempotencyRecordService,
-  type LockRecord
+  type LockRecord,
+  WorkspacePathSafetyError
 } from "./index";
 import { MAX_SERVICE_RECORD_BYTES } from "./workspace-record-store";
 
@@ -1168,6 +1170,174 @@ describe("idempotency, lock, and artifact services", () => {
     await expectPathMissing(join(invalidId.workspaceRoot, "locks"));
   });
 
+  test("workspace path helper rejects traversal and symlink escape while normalizing legal paths", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+
+    const traversalError = await captureWorkspacePathSafetyError(() =>
+      resolveWorkspacePath({
+        workspaceRoot,
+        inputPath: "../outside/report.md",
+        evidenceRef: "artifact.path"
+      })
+    );
+
+    expect(traversalError.evidenceRef).toBe("artifact.path");
+    await expectPathMissing(join(tempRoot, "outside", "report.md"));
+
+    await mkdir(join(workspaceRoot, "artifacts"), { recursive: true });
+    const outsideRoot = join(tempRoot, "outside-artifacts");
+    await mkdir(outsideRoot, { recursive: true });
+    await symlink(outsideRoot, join(workspaceRoot, "artifacts", "reports"), "dir");
+
+    const symlinkError = await captureWorkspacePathSafetyError(() =>
+      resolveWorkspacePath({
+        workspaceRoot,
+        inputPath: "artifacts/reports/report.md",
+        evidenceRef: "artifact.path"
+      })
+    );
+
+    expect(symlinkError.evidenceRef).toBe("artifact.path");
+    await expectPathMissing(join(outsideRoot, "report.md"));
+
+    await rm(join(workspaceRoot, "artifacts", "reports"), { force: true });
+    const resolved = await resolveWorkspacePath({
+      workspaceRoot,
+      inputPath: "artifacts/reports/./TASK-0001/report.md",
+      evidenceRef: "artifact.path"
+    });
+
+    expect(resolved.absolutePath).toBe(
+      join(workspaceRoot, "artifacts", "reports", "TASK-0001", "report.md")
+    );
+    expect(resolved.normalizedPath).toBe("artifacts/reports/TASK-0001/report.md");
+
+    const readonlyRoot = join(tempRoot, "readonly-source");
+    await mkdir(readonlyRoot, { recursive: true });
+    const readonlyResolution = await resolveWorkspacePath({
+      workspaceRoot,
+      inputPath: join(readonlyRoot, "input.dat"),
+      evidenceRef: "readonly.path",
+      access: "read",
+      allowedReadonlyRoots: [readonlyRoot]
+    });
+    expect(readonlyResolution.boundary).toBe("allowed_readonly");
+    expect(readonlyResolution.normalizedPath).toBe(join(readonlyRoot, "input.dat"));
+
+    const readonlyWriteError = await captureWorkspacePathSafetyError(() =>
+      resolveWorkspacePath({
+        workspaceRoot,
+        inputPath: join(readonlyRoot, "input.dat"),
+        evidenceRef: "readonly.path",
+        access: "write",
+        allowedReadonlyRoots: [readonlyRoot]
+      })
+    );
+    expect(readonlyWriteError.evidenceRef).toBe("readonly.path");
+  });
+
+  test("TaskCard snapshot writes expose normalized task directories and reject symlink escape", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const observedTaskDirectories: string[] = [];
+    const service = createTaskCardService({
+      workspaceRoot: join(workspaceRoot, "."),
+      now: () => new Date("2026-07-07T13:40:00.000Z"),
+      taskIdFactory: () => "TASK-path-normalized",
+      snapshotWriteHooks: {
+        beforeSnapshotWrite: ({ taskDirectory }) => {
+          observedTaskDirectories.push(taskDirectory);
+        }
+      }
+    });
+
+    const task = await service.createTask({
+      type: "engineering",
+      title: "Normalize task path",
+      question_or_goal: "Write a task snapshot through normalized workspace paths.",
+      inference_budget: { mode: "normal" },
+      created_by: "pi"
+    });
+
+    expect(observedTaskDirectories).toEqual([
+      join(workspaceRoot, "tasks", "TASK-path-normalized")
+    ]);
+    expect((await stat(join(workspaceRoot, "tasks", task.task_id, "snapshot.json"))).isFile()).toBe(
+      true
+    );
+
+    const escapeCase = await createTempWorkspacePath();
+    tempRoots.push(escapeCase.tempRoot);
+    const outsideTasksRoot = join(escapeCase.tempRoot, "outside-tasks");
+    await mkdir(escapeCase.workspaceRoot, { recursive: true });
+    await mkdir(outsideTasksRoot, { recursive: true });
+    await symlink(outsideTasksRoot, join(escapeCase.workspaceRoot, "tasks"), "dir");
+    const escapeService = createTaskCardService({
+      workspaceRoot: escapeCase.workspaceRoot,
+      taskIdFactory: () => "TASK-symlink-escape"
+    });
+
+    const escapeError = await captureTaskServiceError(() =>
+      escapeService.createTask({
+        type: "engineering",
+        title: "Reject task symlink",
+        question_or_goal: "Do not write a task snapshot outside the workspace.",
+        inference_budget: { mode: "normal" },
+        created_by: "pi"
+      })
+    );
+
+    expect(escapeError.code).toBe("workspace_path_not_safe");
+    await expectPathMissing(join(outsideTasksRoot, "TASK-symlink-escape", "snapshot.json"));
+  });
+
+  test("Artifact registry normalizes artifact paths in stored manifests", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createArtifactRegistryService({ workspaceRoot });
+    const artifact = {
+      ...validArtifact(),
+      path: "artifacts/reports/./TASK-0001/report.md"
+    };
+    const expectedArtifact = {
+      ...artifact,
+      path: "artifacts/reports/TASK-0001/report.md"
+    };
+    const manifestPath = join(
+      workspaceRoot,
+      "artifacts",
+      "manifests",
+      `${artifact.artifact_id}.json`
+    );
+
+    await expect(service.registerArtifact(artifact)).resolves.toEqual(expectedArtifact);
+    expect(await service.getArtifact(artifact.artifact_id)).toEqual(expectedArtifact);
+    expect(JSON.parse(await readFile(manifestPath, "utf8"))).toEqual(expectedArtifact);
+  });
+
+  test("Artifact registry rejects symlink escapes before writing manifests", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createArtifactRegistryService({ workspaceRoot });
+    const outsideRoot = join(tempRoot, "outside-artifacts");
+    await mkdir(join(workspaceRoot, "artifacts"), { recursive: true });
+    await mkdir(outsideRoot, { recursive: true });
+    await symlink(outsideRoot, join(workspaceRoot, "artifacts", "reports"), "dir");
+
+    const error = await captureTaskServiceError(() =>
+      service.registerArtifact({
+        ...validArtifact(),
+        path: "artifacts/reports/TASK-0001/report.md"
+      })
+    );
+
+    expect(error.code).toBe("workspace_path_not_safe");
+    expect(error.evidenceRefs).toEqual(["artifact.path"]);
+    await expectPathMissing(join(workspaceRoot, "artifacts", "manifests"));
+    await expectPathMissing(join(outsideRoot, "TASK-0001", "report.md"));
+  });
+
   test("Artifact registry register/get persists metadata under manifests only", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -1402,6 +1572,19 @@ async function captureTaskServiceError(action: () => Promise<unknown>): Promise<
   }
 
   throw new Error("Expected TaskServiceError.");
+}
+
+async function captureWorkspacePathSafetyError(
+  action: () => Promise<unknown>
+): Promise<WorkspacePathSafetyError> {
+  try {
+    await action();
+  } catch (error) {
+    expect(error).toBeInstanceOf(WorkspacePathSafetyError);
+    return error as WorkspacePathSafetyError;
+  }
+
+  throw new Error("Expected WorkspacePathSafetyError.");
 }
 
 function expectErrorNotToLeakRecordContent(error: TaskServiceError, content: string): void {

--- a/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
+++ b/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
@@ -22,6 +22,7 @@ import {
   idempotencyRecordEvidenceRef,
   idempotencyRecordFileName,
   sha256Hex,
+  assertPathInsideWorkspace,
   resolveWorkspacePath,
   type Artifact,
   type IdempotencyRecord,
@@ -1298,6 +1299,44 @@ describe("idempotency, lock, and artifact services", () => {
       })
     );
     expect(nestedReadonlyWriteError.evidenceRef).toBe("nested-readonly.path");
+
+    const otherCwd = join(tempRoot, "other-cwd");
+    await mkdir(otherCwd, { recursive: true });
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(otherCwd);
+
+      const relativeWorkspaceRootError = await captureWorkspacePathSafetyError(() =>
+        resolveWorkspacePath({
+          workspaceRoot: "workspace",
+          inputPath: "data/raw/out.csv",
+          evidenceRef: "workspace.root"
+        })
+      );
+      expect(relativeWorkspaceRootError.message).toBe("workspaceRoot must be absolute.");
+      expect(relativeWorkspaceRootError.evidenceRef).toBe("workspace.root");
+
+      const relativeReadonlyRootError = await captureWorkspacePathSafetyError(() =>
+        resolveWorkspacePath({
+          workspaceRoot,
+          inputPath: "data/raw/out.csv",
+          evidenceRef: "readonly.root",
+          access: "read",
+          allowedReadonlyRoots: ["data/raw"]
+        })
+      );
+      expect(relativeReadonlyRootError.message).toBe("allowedReadonlyRoots must be absolute.");
+      expect(relativeReadonlyRootError.evidenceRef).toBe("readonly.root");
+
+      expect(() =>
+        assertPathInsideWorkspace("workspace", join(workspaceRoot, "data", "raw"), "workspace.root")
+      ).toThrow(WorkspacePathSafetyError);
+      expect(() =>
+        assertPathInsideWorkspace(workspaceRoot, "data/raw/out.csv", "workspace.target")
+      ).toThrow(WorkspacePathSafetyError);
+    } finally {
+      process.chdir(originalCwd);
+    }
   });
 
   test("workspace path helper accepts dot-prefixed names and rejects unsafe boundaries", async () => {

--- a/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
+++ b/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
@@ -1170,6 +1170,45 @@ describe("idempotency, lock, and artifact services", () => {
     await expectPathMissing(join(invalidId.workspaceRoot, "locks"));
   });
 
+  test("LockRecord write preparation rejects unsafe record directories before partial writes", async () => {
+    const nonDirectoryCase = await createTempWorkspacePath();
+    tempRoots.push(nonDirectoryCase.tempRoot);
+    const nonDirectoryService = createLockRecordService({
+      workspaceRoot: nonDirectoryCase.workspaceRoot
+    });
+    await mkdir(nonDirectoryCase.workspaceRoot, { recursive: true });
+    await writeFile(join(nonDirectoryCase.workspaceRoot, "locks"), "not a directory", {
+      flag: "wx"
+    });
+
+    const nonDirectoryError = await captureTaskServiceError(() =>
+      nonDirectoryService.storeLock(validLockRecord())
+    );
+
+    expect(nonDirectoryError.code).toBe("workspace_path_not_safe");
+    expect(nonDirectoryError.category).toBe("workspace_error");
+    await expectPathMissing(
+      join(nonDirectoryCase.workspaceRoot, "locks", "task", "LOCK-0001.json")
+    );
+
+    const symlinkCase = await createTempWorkspacePath();
+    tempRoots.push(symlinkCase.tempRoot);
+    const symlinkService = createLockRecordService({ workspaceRoot: symlinkCase.workspaceRoot });
+    const outsideLocksRoot = join(symlinkCase.tempRoot, "outside-locks");
+    await mkdir(symlinkCase.workspaceRoot, { recursive: true });
+    await mkdir(outsideLocksRoot, { recursive: true });
+    await symlink(outsideLocksRoot, join(symlinkCase.workspaceRoot, "locks"), "dir");
+
+    const symlinkError = await captureTaskServiceError(() =>
+      symlinkService.storeLock(validLockRecord())
+    );
+
+    expect(symlinkError.code).toBe("workspace_path_not_safe");
+    expect(symlinkError.category).toBe("workspace_error");
+    expect(await readdir(outsideLocksRoot)).toEqual([]);
+    await expectPathMissing(join(outsideLocksRoot, "task", "LOCK-0001.json"));
+  });
+
   test("workspace path helper rejects traversal and symlink escape while normalizing legal paths", async () => {
     const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
     tempRoots.push(tempRoot);
@@ -1235,6 +1274,46 @@ describe("idempotency, lock, and artifact services", () => {
       })
     );
     expect(readonlyWriteError.evidenceRef).toBe("readonly.path");
+  });
+
+  test("workspace path helper accepts dot-prefixed names and rejects unsafe boundaries", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+
+    const dotPrefixedResolution = await resolveWorkspacePath({
+      workspaceRoot,
+      inputPath: "..draft/report.md",
+      evidenceRef: "artifact.path"
+    });
+
+    expect(dotPrefixedResolution.absolutePath).toBe(join(workspaceRoot, "..draft", "report.md"));
+    expect(dotPrefixedResolution.normalizedPath).toBe("..draft/report.md");
+
+    const outsidePath = join(tempRoot, "outside", "report.md");
+    const absoluteOutsideError = await captureWorkspacePathSafetyError(() =>
+      resolveWorkspacePath({
+        workspaceRoot,
+        inputPath: outsidePath,
+        evidenceRef: "artifact.path"
+      })
+    );
+
+    expect(absoluteOutsideError.evidenceRef).toBe("artifact.path");
+    await expectPathMissing(outsidePath);
+
+    await mkdir(workspaceRoot, { recursive: true });
+    await writeFile(join(workspaceRoot, "artifacts"), "not a directory", { flag: "wx" });
+
+    const nonDirectoryAncestorError = await captureWorkspacePathSafetyError(() =>
+      resolveWorkspacePath({
+        workspaceRoot,
+        inputPath: "artifacts/reports/report.md",
+        evidenceRef: "artifact.path"
+      })
+    );
+
+    expect(nonDirectoryAncestorError.evidenceRef).toBe("artifact.path");
+    await expectPathMissing(join(workspaceRoot, "artifacts", "reports", "report.md"));
   });
 
   test("TaskCard snapshot writes expose normalized task directories and reject symlink escape", async () => {
@@ -1314,6 +1393,50 @@ describe("idempotency, lock, and artifact services", () => {
     await expect(service.registerArtifact(artifact)).resolves.toEqual(expectedArtifact);
     expect(await service.getArtifact(artifact.artifact_id)).toEqual(expectedArtifact);
     expect(JSON.parse(await readFile(manifestPath, "utf8"))).toEqual(expectedArtifact);
+  });
+
+  test("Artifact registry preserves trailing-space artifact path identity", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createArtifactRegistryService({ workspaceRoot });
+    const artifact = {
+      ...validArtifact(),
+      path: "artifacts/reports/TASK-0001/report.md "
+    };
+    const manifestPath = join(
+      workspaceRoot,
+      "artifacts",
+      "manifests",
+      `${artifact.artifact_id}.json`
+    );
+
+    await expect(service.registerArtifact(artifact)).resolves.toEqual(artifact);
+    expect(await service.getArtifact(artifact.artifact_id)).toEqual(artifact);
+    expect(JSON.parse(await readFile(manifestPath, "utf8"))).toEqual(artifact);
+  });
+
+  test("Artifact registry treats legacy dot-segment manifests as equivalent duplicates", async () => {
+    const { tempRoot, workspaceRoot } = await createTempWorkspacePath();
+    tempRoots.push(tempRoot);
+    const service = createArtifactRegistryService({ workspaceRoot });
+    const artifact = validArtifact();
+    const legacyArtifact = {
+      ...artifact,
+      path: "artifacts/reports/./TASK-0001/report.md"
+    };
+    const manifestPath = join(
+      workspaceRoot,
+      "artifacts",
+      "manifests",
+      `${artifact.artifact_id}.json`
+    );
+    const legacyManifestText = `${JSON.stringify(legacyArtifact)}\n`;
+    await mkdir(join(workspaceRoot, "artifacts", "manifests"), { recursive: true });
+    await writeFile(manifestPath, legacyManifestText, { flag: "wx" });
+
+    await expect(service.registerArtifact(artifact)).resolves.toEqual(legacyArtifact);
+    expect(await service.getArtifact(artifact.artifact_id)).toEqual(legacyArtifact);
+    expect(await readFile(manifestPath, "utf8")).toBe(legacyManifestText);
   });
 
   test("Artifact registry rejects symlink escapes before writing manifests", async () => {

--- a/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
+++ b/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
@@ -29,7 +29,7 @@ import {
   type LockRecord,
   WorkspacePathSafetyError
 } from "./index";
-import { MAX_SERVICE_RECORD_BYTES } from "./workspace-record-store";
+import { MAX_SERVICE_RECORD_BYTES, workspaceRecordPath } from "./workspace-record-store";
 
 const tempRoots: string[] = [];
 
@@ -1274,6 +1274,30 @@ describe("idempotency, lock, and artifact services", () => {
       })
     );
     expect(readonlyWriteError.evidenceRef).toBe("readonly.path");
+
+    const nestedReadonlyRoot = join(workspaceRoot, "data", "raw");
+    await mkdir(nestedReadonlyRoot, { recursive: true });
+    const nestedReadonlyResolution = await resolveWorkspacePath({
+      workspaceRoot,
+      inputPath: "data/raw/out.csv",
+      evidenceRef: "nested-readonly.path",
+      access: "read",
+      allowedReadonlyRoots: [nestedReadonlyRoot]
+    });
+    expect(nestedReadonlyResolution.boundary).toBe("allowed_readonly");
+    expect(nestedReadonlyResolution.boundaryRoot).toBe(nestedReadonlyRoot);
+    expect(nestedReadonlyResolution.normalizedPath).toBe(join(nestedReadonlyRoot, "out.csv"));
+
+    const nestedReadonlyWriteError = await captureWorkspacePathSafetyError(() =>
+      resolveWorkspacePath({
+        workspaceRoot,
+        inputPath: "data/raw/out.csv",
+        evidenceRef: "nested-readonly.path",
+        access: "write",
+        allowedReadonlyRoots: [nestedReadonlyRoot]
+      })
+    );
+    expect(nestedReadonlyWriteError.evidenceRef).toBe("nested-readonly.path");
   });
 
   test("workspace path helper accepts dot-prefixed names and rejects unsafe boundaries", async () => {
@@ -1288,6 +1312,13 @@ describe("idempotency, lock, and artifact services", () => {
 
     expect(dotPrefixedResolution.absolutePath).toBe(join(workspaceRoot, "..draft", "report.md"));
     expect(dotPrefixedResolution.normalizedPath).toBe("..draft/report.md");
+    expect(
+      workspaceRecordPath(
+        workspaceRoot,
+        ["..draft", "record.json"],
+        "workspace/..draft/record.json"
+      )
+    ).toBe(join(workspaceRoot, "..draft", "record.json"));
 
     const outsidePath = join(tempRoot, "outside", "report.md");
     const absoluteOutsideError = await captureWorkspacePathSafetyError(() =>

--- a/packages/core/src/domain/services/index.ts
+++ b/packages/core/src/domain/services/index.ts
@@ -6,3 +6,4 @@ export * from "./artifact-registry-service";
 export * from "./idempotency-service";
 export * from "./lock-service";
 export * from "./task-card-service";
+export * from "./workspace-path-safety";

--- a/packages/core/src/domain/services/task-card-service.ts
+++ b/packages/core/src/domain/services/task-card-service.ts
@@ -11,6 +11,7 @@ import {
   TaskTypeSchema,
   type TaskCard
 } from "../schemas/task";
+import { WorkspacePathSafetyError, resolveWorkspacePath } from "./workspace-path-safety";
 
 export const DEFAULT_TASK_CREATED_BY = "pi" as const;
 export const DEFAULT_TASK_CURRENT_OWNER = "coordinator" as const;
@@ -867,11 +868,17 @@ async function persistTaskSnapshot(
       [`workspace/tasks/${task.task_id}`]
     );
   }
-  const snapshotPath = join(taskDirectory, "snapshot.json");
-  assertPathInsideWorkspace(workspaceRoot, snapshotPath, `workspace/tasks/${task.task_id}/snapshot.json`);
+  const snapshotPath = await resolveTaskWorkspacePath(
+    workspaceRoot,
+    join(taskDirectory, "snapshot.json"),
+    `workspace/tasks/${task.task_id}/snapshot.json`
+  );
 
-  const temporaryPath = join(taskDirectory, `.snapshot-${process.pid}-${randomUUID()}.tmp`);
-  assertPathInsideWorkspace(workspaceRoot, temporaryPath, `workspace/tasks/${task.task_id}/snapshot.tmp`);
+  const temporaryPath = await resolveTaskWorkspacePath(
+    workspaceRoot,
+    join(taskDirectory, `.snapshot-${process.pid}-${randomUUID()}.tmp`),
+    `workspace/tasks/${task.task_id}/snapshot.tmp`
+  );
 
   let wroteTemporary = false;
   let publishedSnapshot = false;
@@ -951,15 +958,45 @@ async function ensureTaskDirectory(workspaceRoot: string, taskId: string): Promi
   assertSafeTaskId(taskId, `task.task_id:${taskId}`);
   await ensureSafeDirectory(workspaceRoot, "workspace_path_not_safe", "workspace");
 
-  const tasksRoot = join(workspaceRoot, "tasks");
-  assertPathInsideWorkspace(workspaceRoot, tasksRoot, "workspace/tasks");
+  const tasksRoot = await resolveTaskWorkspacePath(workspaceRoot, "tasks", "workspace/tasks");
   await ensureSafeDirectory(tasksRoot, "workspace_path_not_safe", "workspace/tasks");
 
-  const taskDirectory = join(tasksRoot, taskId);
-  assertPathInsideWorkspace(workspaceRoot, taskDirectory, `workspace/tasks/${taskId}`);
+  const taskDirectory = await resolveTaskWorkspacePath(
+    workspaceRoot,
+    join("tasks", taskId),
+    `workspace/tasks/${taskId}`
+  );
   await ensureSafeDirectory(taskDirectory, "task_lane_not_directory", `workspace/tasks/${taskId}`);
 
   return taskDirectory;
+}
+
+async function resolveTaskWorkspacePath(
+  workspaceRoot: string,
+  path: string,
+  evidenceRef: string
+): Promise<string> {
+  try {
+    return (
+      await resolveWorkspacePath({
+        workspaceRoot,
+        inputPath: path,
+        evidenceRef,
+        access: "write"
+      })
+    ).absolutePath;
+  } catch (error) {
+    if (error instanceof WorkspacePathSafetyError) {
+      throw workspaceError(
+        "workspace_path_not_safe",
+        error.message,
+        "The task snapshot path is not safe to write.",
+        [error.evidenceRef],
+        error
+      );
+    }
+    throw error;
+  }
 }
 
 async function ensureSafeDirectory(

--- a/packages/core/src/domain/services/task-card-service.ts
+++ b/packages/core/src/domain/services/task-card-service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { constants, type Dirent } from "node:fs";
 import { lstat, mkdir, open, opendir, rename, rmdir, unlink, writeFile } from "node:fs/promises";
-import { dirname, isAbsolute, join, parse, relative, resolve, sep } from "node:path";
+import { dirname, join, parse, resolve, sep } from "node:path";
 import { z } from "zod";
 import {
   InferenceBudgetSchema,
@@ -11,7 +11,11 @@ import {
   TaskTypeSchema,
   type TaskCard
 } from "../schemas/task";
-import { WorkspacePathSafetyError, resolveWorkspacePath } from "./workspace-path-safety";
+import {
+  WorkspacePathSafetyError,
+  isPathInsideBoundary,
+  resolveWorkspacePath
+} from "./workspace-path-safety";
 
 export const DEFAULT_TASK_CREATED_BY = "pi" as const;
 export const DEFAULT_TASK_CURRENT_OWNER = "coordinator" as const;
@@ -1135,8 +1139,7 @@ function assertPathInsideWorkspace(
   targetPath: string,
   evidenceRef: string
 ): void {
-  const relativePath = relative(workspaceRoot, resolve(targetPath));
-  if (relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath))) {
+  if (isPathInsideBoundary(workspaceRoot, targetPath)) {
     return;
   }
 

--- a/packages/core/src/domain/services/workspace-path-safety.ts
+++ b/packages/core/src/domain/services/workspace-path-safety.ts
@@ -39,6 +39,11 @@ type FileStat = Awaited<ReturnType<typeof lstat>>;
 export async function resolveWorkspacePath(
   input: ResolveWorkspacePathInput
 ): Promise<WorkspacePathResolution> {
+  assertAbsolutePath(input.workspaceRoot, "workspaceRoot", input.evidenceRef);
+  for (const readonlyRoot of input.allowedReadonlyRoots ?? []) {
+    assertAbsolutePath(readonlyRoot, "allowedReadonlyRoots", input.evidenceRef);
+  }
+
   const workspaceRoot = resolve(input.workspaceRoot);
   const rawPath = input.inputPath;
   if (rawPath.trim().length === 0) {
@@ -79,6 +84,9 @@ export function assertPathInsideWorkspace(
   targetPath: string,
   evidenceRef: string
 ): void {
+  assertAbsolutePath(workspaceRoot, "workspaceRoot", evidenceRef);
+  assertAbsolutePath(targetPath, "targetPath", evidenceRef);
+
   if (isPathInsideBoundary(resolve(workspaceRoot), resolve(targetPath))) {
     return;
   }
@@ -134,6 +142,14 @@ function matchingBoundary(
   if (isPathInsideBoundary(workspaceBoundary.root, targetPath)) {
     return workspaceBoundary;
   }
+}
+
+function assertAbsolutePath(path: string, label: string, evidenceRef: string): void {
+  if (isAbsolute(path)) {
+    return;
+  }
+
+  throw new WorkspacePathSafetyError(`${label} must be absolute.`, evidenceRef);
 }
 
 async function rejectSymlinkEscape(path: string, evidenceRef: string): Promise<void> {

--- a/packages/core/src/domain/services/workspace-path-safety.ts
+++ b/packages/core/src/domain/services/workspace-path-safety.ts
@@ -40,8 +40,8 @@ export async function resolveWorkspacePath(
   input: ResolveWorkspacePathInput
 ): Promise<WorkspacePathResolution> {
   const workspaceRoot = resolve(input.workspaceRoot);
-  const rawPath = input.inputPath.trim();
-  if (rawPath.length === 0) {
+  const rawPath = input.inputPath;
+  if (rawPath.trim().length === 0) {
     throw new WorkspacePathSafetyError("Workspace path is blank.", input.evidenceRef);
   }
 
@@ -91,7 +91,12 @@ export function assertPathInsideWorkspace(
 
 export function isPathInsideBoundary(boundaryRoot: string, targetPath: string): boolean {
   const relativePath = relative(resolve(boundaryRoot), resolve(targetPath));
-  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+  return (
+    relativePath === "" ||
+    (!isAbsolute(relativePath) &&
+      relativePath !== ".." &&
+      !relativePath.startsWith(`..${sep}`))
+  );
 }
 
 export async function isSafeExistingDirectoryPath(path: string): Promise<boolean> {
@@ -135,7 +140,7 @@ async function rejectSymlinkEscape(path: string, evidenceRef: string): Promise<v
 
   for (const segment of segments) {
     currentPath = join(currentPath, segment);
-    const entry = await maybeLstat(currentPath);
+    const entry = await lstatExistingPath(currentPath, evidenceRef);
     if (!entry) {
       return;
     }
@@ -175,4 +180,30 @@ async function maybeLstat(path: string): Promise<FileStat | undefined> {
   } catch {
     return undefined;
   }
+}
+
+async function lstatExistingPath(
+  path: string,
+  evidenceRef: string
+): Promise<FileStat | undefined> {
+  try {
+    return await lstat(path);
+  } catch (error) {
+    if (hasErrorCode(error, "ENOENT")) {
+      return undefined;
+    }
+    throw new WorkspacePathSafetyError(
+      "Workspace path cannot be inspected safely.",
+      evidenceRef
+    );
+  }
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === code
+  );
 }

--- a/packages/core/src/domain/services/workspace-path-safety.ts
+++ b/packages/core/src/domain/services/workspace-path-safety.ts
@@ -1,0 +1,178 @@
+import { lstat } from "node:fs/promises";
+import { isAbsolute, join, parse, relative, resolve, sep } from "node:path";
+
+export type WorkspacePathBoundary = "workspace" | "allowed_readonly";
+export type WorkspacePathAccess = "read" | "write";
+
+export interface WorkspacePathResolution {
+  absolutePath: string;
+  normalizedPath: string;
+  boundary: WorkspacePathBoundary;
+  boundaryRoot: string;
+}
+
+export interface ResolveWorkspacePathInput {
+  workspaceRoot: string;
+  inputPath: string;
+  evidenceRef: string;
+  access?: WorkspacePathAccess;
+  allowedReadonlyRoots?: readonly string[];
+}
+
+export class WorkspacePathSafetyError extends Error {
+  readonly evidenceRef: string;
+
+  constructor(message: string, evidenceRef: string) {
+    super(message);
+    this.name = "WorkspacePathSafetyError";
+    this.evidenceRef = evidenceRef;
+  }
+}
+
+type BoundaryCandidate = {
+  kind: WorkspacePathBoundary;
+  root: string;
+};
+
+type FileStat = Awaited<ReturnType<typeof lstat>>;
+
+export async function resolveWorkspacePath(
+  input: ResolveWorkspacePathInput
+): Promise<WorkspacePathResolution> {
+  const workspaceRoot = resolve(input.workspaceRoot);
+  const rawPath = input.inputPath.trim();
+  if (rawPath.length === 0) {
+    throw new WorkspacePathSafetyError("Workspace path is blank.", input.evidenceRef);
+  }
+
+  const access = input.access ?? "write";
+  const absolutePath = isAbsolute(rawPath) ? resolve(rawPath) : resolve(workspaceRoot, rawPath);
+  const boundary = matchingBoundary(workspaceRoot, input.allowedReadonlyRoots ?? [], absolutePath);
+  if (!boundary) {
+    throw new WorkspacePathSafetyError(
+      "Resolved path escapes the configured workspace.",
+      input.evidenceRef
+    );
+  }
+  if (boundary.kind === "allowed_readonly" && access !== "read") {
+    throw new WorkspacePathSafetyError(
+      "Resolved path targets a read-only boundary for a write operation.",
+      input.evidenceRef
+    );
+  }
+
+  await rejectSymlinkEscape(absolutePath, input.evidenceRef);
+
+  return {
+    absolutePath,
+    normalizedPath:
+      boundary.kind === "workspace"
+        ? workspaceRelativePath(workspaceRoot, absolutePath)
+        : absolutePath,
+    boundary: boundary.kind,
+    boundaryRoot: boundary.root
+  };
+}
+
+export function assertPathInsideWorkspace(
+  workspaceRoot: string,
+  targetPath: string,
+  evidenceRef: string
+): void {
+  if (isPathInsideBoundary(resolve(workspaceRoot), resolve(targetPath))) {
+    return;
+  }
+
+  throw new WorkspacePathSafetyError(
+    "Resolved path escapes the configured workspace.",
+    evidenceRef
+  );
+}
+
+export function isPathInsideBoundary(boundaryRoot: string, targetPath: string): boolean {
+  const relativePath = relative(resolve(boundaryRoot), resolve(targetPath));
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+export async function isSafeExistingDirectoryPath(path: string): Promise<boolean> {
+  const { rootPath, segments } = pathParts(path);
+  const rootEntry = await maybeLstat(rootPath);
+  if (!isSafeDirectoryEntry(rootEntry)) {
+    return false;
+  }
+
+  let currentPath = rootPath;
+  for (const segment of segments) {
+    currentPath = join(currentPath, segment);
+    const entry = await maybeLstat(currentPath);
+    if (!isSafeDirectoryEntry(entry)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function matchingBoundary(
+  workspaceRoot: string,
+  allowedReadonlyRoots: readonly string[],
+  targetPath: string
+): BoundaryCandidate | undefined {
+  const workspaceBoundary = { kind: "workspace" as const, root: workspaceRoot };
+  if (isPathInsideBoundary(workspaceBoundary.root, targetPath)) {
+    return workspaceBoundary;
+  }
+
+  return allowedReadonlyRoots
+    .map((root) => ({ kind: "allowed_readonly" as const, root: resolve(root) }))
+    .find((boundary) => isPathInsideBoundary(boundary.root, targetPath));
+}
+
+async function rejectSymlinkEscape(path: string, evidenceRef: string): Promise<void> {
+  const targetPath = resolve(path);
+  const { rootPath, segments } = pathParts(targetPath);
+  let currentPath = rootPath;
+
+  for (const segment of segments) {
+    currentPath = join(currentPath, segment);
+    const entry = await maybeLstat(currentPath);
+    if (!entry) {
+      return;
+    }
+    if (entry.isSymbolicLink()) {
+      throw new WorkspacePathSafetyError("Workspace path crosses a symlink.", evidenceRef);
+    }
+    if (currentPath !== targetPath && !entry.isDirectory()) {
+      throw new WorkspacePathSafetyError(
+        "Workspace path crosses a non-directory ancestor.",
+        evidenceRef
+      );
+    }
+  }
+}
+
+function workspaceRelativePath(workspaceRoot: string, targetPath: string): string {
+  const relativePath = relative(resolve(workspaceRoot), resolve(targetPath));
+  return relativePath === "" ? "." : relativePath.split(sep).join("/");
+}
+
+function pathParts(path: string): { rootPath: string; segments: string[] } {
+  const resolvedPath = resolve(path);
+  const rootPath = parse(resolvedPath).root;
+  return {
+    rootPath,
+    segments: resolvedPath.slice(rootPath.length).split(sep).filter(Boolean)
+  };
+}
+
+function isSafeDirectoryEntry(entry: FileStat | undefined): boolean {
+  return Boolean(entry?.isDirectory() && !entry.isSymbolicLink());
+}
+
+async function maybeLstat(path: string): Promise<FileStat | undefined> {
+  try {
+    return await lstat(path);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/core/src/domain/services/workspace-path-safety.ts
+++ b/packages/core/src/domain/services/workspace-path-safety.ts
@@ -123,14 +123,17 @@ function matchingBoundary(
   allowedReadonlyRoots: readonly string[],
   targetPath: string
 ): BoundaryCandidate | undefined {
+  const readonlyBoundary = allowedReadonlyRoots
+    .map((root) => ({ kind: "allowed_readonly" as const, root: resolve(root) }))
+    .find((boundary) => isPathInsideBoundary(boundary.root, targetPath));
+  if (readonlyBoundary) {
+    return readonlyBoundary;
+  }
+
   const workspaceBoundary = { kind: "workspace" as const, root: workspaceRoot };
   if (isPathInsideBoundary(workspaceBoundary.root, targetPath)) {
     return workspaceBoundary;
   }
-
-  return allowedReadonlyRoots
-    .map((root) => ({ kind: "allowed_readonly" as const, root: resolve(root) }))
-    .find((boundary) => isPathInsideBoundary(boundary.root, targetPath));
 }
 
 async function rejectSymlinkEscape(path: string, evidenceRef: string): Promise<void> {

--- a/packages/core/src/domain/services/workspace-record-store.ts
+++ b/packages/core/src/domain/services/workspace-record-store.ts
@@ -1,10 +1,14 @@
 import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import { link, lstat, mkdir, open, rename, unlink } from "node:fs/promises";
-import { dirname, isAbsolute, join, normalize, parse, relative, resolve, sep } from "node:path";
+import { dirname, isAbsolute, join, normalize, parse, resolve, sep } from "node:path";
 import { z } from "zod";
 import { TaskServiceError, type TaskServiceErrorCode } from "./task-card-service";
-import { WorkspacePathSafetyError, resolveWorkspacePath } from "./workspace-path-safety";
+import {
+  WorkspacePathSafetyError,
+  isPathInsideBoundary,
+  resolveWorkspacePath
+} from "./workspace-path-safety";
 
 export const MAX_SERVICE_RECORD_BYTES = 1024 * 1024;
 
@@ -444,8 +448,7 @@ export function assertPathInsideWorkspace(
   targetPath: string,
   evidenceRef: string
 ): void {
-  const relativePath = relative(resolve(workspaceRoot), resolve(targetPath));
-  if (relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath))) {
+  if (isPathInsideBoundary(workspaceRoot, targetPath)) {
     return;
   }
 

--- a/packages/core/src/domain/services/workspace-record-store.ts
+++ b/packages/core/src/domain/services/workspace-record-store.ts
@@ -4,6 +4,7 @@ import { link, lstat, mkdir, open, rename, unlink } from "node:fs/promises";
 import { dirname, isAbsolute, join, normalize, parse, relative, resolve, sep } from "node:path";
 import { z } from "zod";
 import { TaskServiceError, type TaskServiceErrorCode } from "./task-card-service";
+import { WorkspacePathSafetyError, resolveWorkspacePath } from "./workspace-path-safety";
 
 export const MAX_SERVICE_RECORD_BYTES = 1024 * 1024;
 
@@ -517,8 +518,11 @@ async function prepareJsonRecordWrite<T>(
     relativeDirectorySegments,
     evidenceRef
   );
-  const recordPath = join(directoryPath, fileName);
-  assertPathInsideWorkspace(resolve(workspaceRoot), recordPath, evidenceRef);
+  const recordPath = await resolveWorkspaceRecordPath(
+    workspaceRoot,
+    join(directoryPath, fileName),
+    evidenceRef
+  );
 
   const recordText = `${JSON.stringify(parsedRecord.data, null, 2)}\n`;
   if (Buffer.byteLength(recordText, "utf8") > MAX_SERVICE_RECORD_BYTES) {
@@ -539,6 +543,34 @@ async function prepareJsonRecordWrite<T>(
     recordPath,
     recordText
   };
+}
+
+async function resolveWorkspaceRecordPath(
+  workspaceRoot: string,
+  path: string,
+  evidenceRef: string
+): Promise<string> {
+  try {
+    return (
+      await resolveWorkspacePath({
+        workspaceRoot,
+        inputPath: path,
+        evidenceRef,
+        access: "write"
+      })
+    ).absolutePath;
+  } catch (error) {
+    if (error instanceof WorkspacePathSafetyError) {
+      throw serviceWorkspaceError(
+        "workspace_path_not_safe",
+        error.message,
+        "The workspace record path is not safe to write.",
+        [error.evidenceRef],
+        error
+      );
+    }
+    throw error;
+  }
 }
 
 async function ensureSafeDirectory(path: string, evidenceRef: string): Promise<void> {


### PR DESCRIPTION
Part of #11
Closes #33

## Summary
- Add a shared workspace path safety helper for normalized workspace/read-only path resolution, absolute-root enforcement, boundary checks, and pre-existing symlink/non-directory ancestor rejection.
- Wire Artifact registry manifest writes, TaskCard snapshot writes, and workspace JSON record write preparation through the helper.
- Add path safety regressions for traversal, symlink escape, legal normalization, absolute root/cwd-drift rejection, read-only root access split, normalized Artifact manifests, and Task snapshot no-write behavior.
- Clarify the #33 OpenSpec fixture boundary: #33 covers static/pre-existing path escapes under M1 single-user/cooperative workspace assumptions; race-resilient directory-fd/openat-style anchoring remains out of scope for later executor/workspace-locking work.

## Verification
- `npx --yes bun@1.2.19 run test:core-services` (36 pass, 256 expects)
- `npx --yes bun@1.2.19 run typecheck`
- `npx --yes bun@1.2.19 run check`
- `openspec validate m1-foundation --strict --no-interactive`
- `git diff --check`
- `git -C zero diff --quiet && test -z "$(git ls-files workspace)"`
- GitHub checks at `054b222`: `check`, `docs-links`, `linux-base`, `macos-seatbelt` all pass.

## Agent Review
- Reviewed head SHA: `054b222b9b2210086b6fb6bdec7f8725be601397`
- Reviewer agents used: correctness, integration, security/perf, test-evidence, spec-compliance, invariant/state; final focused security review after cand-07 fix.
- Verifier agents used: cand-01..cand-07; cand-07 fix confirmed at latest SHA.
- Key findings addressed: path identity trimming, `..draft` boundary false positive, lstat fail-open, missing negative evidence, legacy dot-segment manifest compatibility, nested readonly root precedence/stale local guards, M1 race-boundary overclaim, relative root/cwd drift.
- OpenSpec change: `m1-foundation`; fixture level: expanded; repair intensity: high; selected risk packs: File IO / path safety / overwrite, Config / project setup, Schema / record fields, Error handling / rollback / partial outputs, Resource limits / discovery, Legacy compatibility, Documentation / migration notes, Scientific governance / evidence lineage.
