### PR TITLE
feat(frontend): add workbench layout shell (#34)

### DIFF
--- a/docs/review-loop-log.jsonl
+++ b/docs/review-loop-log.jsonl
@@ -11,3 +11,4 @@
 {"issue":61,"pr":63,"date":"2026-07-07","fixture":"expanded","rounds":2,"gate_net_catch":2,"verdicts":{"confirmed":2,"plausible":0,"refuted":0},"residual_deferred":0,"premerge_skip_blocks":0}
 {"issue":28,"pr":64,"date":"2026-07-07","fixture":"expanded/high","rounds":4,"gate_net_catch":10,"verdicts":{"confirmed":9,"plausible":1,"refuted":2},"residual_deferred":1,"premerge_skip_blocks":0}
 {"issue":29,"pr":65,"date":"2026-07-07","fixture":"expanded/high","rounds":4,"gate_net_catch":13,"verdicts":{"confirmed":11,"plausible":2,"refuted":0},"residual_deferred":2,"premerge_skip_blocks":0}
+{"issue":34,"pr":70,"date":"2026-07-08","fixture":"expanded/medium","rounds":2,"gate_net_catch":6,"verdicts":{"confirmed":6,"plausible":0,"refuted":0},"residual_deferred":0,"premerge_skip_blocks":0}

--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -1010,3 +1010,61 @@ Review focus:
 - Helper boundary checks are centralized and fail closed before writes.
 - Artifact and Task snapshot write surfaces actually call the helper and persist normalized paths where applicable.
 - Tests prove no outside file/manifest/snapshot is created on traversal or symlink escape.
+
+## Subagent Workflow Fixture - Issue #34
+
+Fixture level: expanded; repair intensity: medium
+Project profile: SHUD-Harness
+
+Expanded-trigger rationale:
+- Core triggers: frontend page route skeleton, visible four-panel layout, package check wiring, and browser-openable static document rendering.
+- Profile triggers: `workbench`, `frontend`, `TaskCard`, and M1 acceptance evidence.
+
+Change surface:
+- `packages/frontend/src/pages/Workbench.ts` Workbench route/document renderer.
+- `packages/frontend/src/pages/Workbench.preview.ts` deterministic stdout preview entry for manual browser opening.
+- `packages/frontend/src/layouts/WorkbenchLayout.ts` four-panel layout shell and CSS contract.
+- `packages/frontend/src/components/{SideNav,AgentActivityFeed,ExperimentPanel,ResultsPanel}.ts` placeholder panel producers.
+- Frontend smoke tests plus root `test:frontend` check wiring.
+
+Must preserve:
+- #35 Dashboard list/create/recovery remains unimplemented.
+- Dashboard-to-Workbench task context navigation and SideNav task-list data wiring remain deferred M2 per design Non-Goals.
+- Backend routes/static serving, WebSocket behavior, runtime `workspace/`, and `zero/` source remain unchanged.
+
+Must add/change:
+- A deterministic Workbench route skeleton at `/workbench`.
+- A browser-openable HTML document renderer and stdout preview entry that include SideNav, AgentFeed, Experiment, and Results exactly once.
+- A stable four-column desktop grid matching UI_Implementation_Spec column proportions, with bounded fallbacks for narrower viewports.
+- Chinese-first visible placeholder copy and explicit text wrapping for long task identifiers.
+
+Risk packs considered:
+- Public page/route skeleton: selected - `/workbench` becomes the M1 browser-openable Workbench entry representation inside the frontend package.
+- Layout/responsive behavior: selected - panel dimensions must be stable enough for smoke acceptance and future hydration.
+- Dependency/build compatibility: selected - #34 must not introduce an unresolved bundler/runtime dependency; React runtime and router/static serving can be connected by later frontend wiring issues when package-manager behavior and serving surface are explicit.
+- Data/API integration: not selected - no task fetch, create, refresh recovery, or route context transfer in #34.
+- Error handling / visible shell failure: selected - render-time smoke test captures `console.error` and fails on a noisy shell.
+
+Invariant Matrix:
+- Governing invariant: Opening/rendering the M1 Workbench shell yields exactly the four canonical panels without depending on backend data or runtime workspace state.
+- Source-of-truth identity/contract: route `/workbench`, panel slots `side-nav | agent-feed | experiment | results`, UI_Implementation_Spec grid proportions, and workbench-shell spec scenario "四栏可见".
+- Producers: Workbench page renderer and WorkbenchLayout renderer.
+- Validators/preflight: frontend smoke test, typecheck, root check, OpenSpec validation, diff check, zero/workspace boundary checks.
+- Storage/cache/query: none - #34 has no persistence or backend fetch.
+- Public routes/entrypoints: frontend route skeleton `/workbench`; backend HTTP serving is not introduced in #34.
+- Frontend/downstream consumers: #35 Dashboard and #36 ExperimentHeader/StatusBar can import/extend the shell without changing the four panel slots.
+- Failure paths/rollback/stale state: unknown route returns no Workbench document; render-time console errors fail the smoke test.
+- Evidence/audit/readiness: PR evidence records `test:frontend`, `typecheck`, `check`, OpenSpec validation, diff check, and zero/workspace checks.
+- Regression rows:
+  - `renderWorkbenchDocument({ activeTaskId })` -> full HTML document includes the active task id, `data-workbench-layout="four-column"`, and exactly one instance of each panel slot.
+  - `bun packages/frontend/src/pages/Workbench.preview.ts` -> stdout begins with `<!doctype html>` and can be redirected to a browser-openable HTML file.
+  - `renderWorkbenchRoute("/workbench")` -> document; `renderWorkbenchRoute("/")` -> `undefined`, proving Dashboard navigation is not silently implemented.
+  - Layout CSS includes the canonical four-column grid, narrower viewport fallbacks that keep every canonical panel reachable, and `overflow-wrap` protection for long identifiers.
+
+Non-goals:
+- Dashboard list/create/recovery (#35), ExperimentHeader/StatusBar (#36), backend static serving, router integration, WebSocket/data wiring, PI actions, report rendering, and full React runtime/bundler setup.
+
+Review focus:
+- Four panel slots are present exactly once and exported through the expected frontend boundaries.
+- The shell stays deterministic, dependency-light, and compatible with existing `bun install`/`check`.
+- Visible placeholder copy is operational state, not explanatory product marketing.

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -215,6 +215,22 @@
 ## 7. 四栏壳（workbench-shell）
 
 - [ ] 7.1 WorkbenchLayout 四栏骨架（SideNav + AgentFeed + Experiment + Results 占位；SideNav 任务列表与 Dashboard→Workbench 任务上下文导航接线 deferred M2，见 design Non-Goals）——依赖: 2.1
+  - Fixture (#34): expanded / medium
+    - Change surface: `packages/frontend/src/components/**`, `packages/frontend/src/layouts/**`, `packages/frontend/src/pages/**`, root frontend test script/check wiring, and OpenSpec fixture evidence.
+    - Must preserve: no backend API/static-serving changes, no task data wiring, no Dashboard→Workbench context navigation, no SideNav task-list integration, no `zero/` source diff, and no tracked runtime `workspace/` assets.
+    - Must add/change: Workbench page route skeleton (`/workbench`), WorkbenchLayout four-panel renderer, SideNav/AgentFeed/Experiment/Results placeholder components, browser-openable HTML document renderer plus stdout preview entry, and frontend smoke tests proving all four panels render without console errors.
+    - Risk packs considered:
+      - Frontend shell / route skeleton: selected - this issue owns the direct Workbench page skeleton for M1 browser-openable acceptance.
+      - Layout / responsive behavior: selected - four-panel desktop grid must keep stable column proportions and avoid text overlap.
+      - Dependency / build compatibility: selected - no new unresolved runtime dependency or bundler assumption may break `bun install`/`check`.
+      - Data/API integration: not selected - task list, create form, and refresh recovery belong to #35; Dashboard→Workbench navigation is deferred M2.
+    - Evidence floor (#34):
+      - Workbench renderer returns a full HTML document for `/workbench` with exactly one `side-nav`, `agent-feed`, `experiment`, and `results` panel.
+      - `bun packages/frontend/src/pages/Workbench.preview.ts > /tmp/workbench.html` emits a directly openable HTML document without backend/static-serving changes.
+      - Frontend smoke test captures render-time `console.error` and observes none.
+      - Layout CSS keeps the desktop four-column grid `240px minmax(320px, 1fr) minmax(400px, 1.5fr) minmax(280px, 1fr)`, includes bounded narrower-viewport fallbacks without hiding any canonical panel, and wraps long task ids without text overflow.
+      - User-visible placeholder copy is Chinese-first while preserving canonical code identifiers where needed.
+      - `bun run test:frontend`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 - [ ] 7.2 Dashboard 页（GET /api/tasks 列表 + 建卡表单 + 刷新恢复）——依赖: 6.2
 - [ ] 7.3 ExperimentHeader + StatusBar 占位组件（task 上下文 props）
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:tool-registry-governance": "bun test ./packages/core/src/tools/role-tool-map.test.ts",
     "test:backend-api": "bun test ./packages/backend/src/routes/*.test.ts",
     "test:backend-ws": "bun test ./packages/backend/src/ws/index.test.ts",
+    "test:frontend": "bun test ./packages/frontend/src/**/*.test.ts ./packages/frontend/src/**/*.test.tsx",
     "test:schemas": "bun test ./packages/core/src/domain/schemas/core-schemas.test.ts",
     "test:core-services": "bun test ./packages/core/src/domain/services/*.test.ts",
     "test:perf:api": "bun scripts/perf/api.ts",
@@ -21,7 +22,7 @@
     "schema:check": "sh scripts/schema/check.sh",
     "validate:dependency-lock": "node scripts/dependency-lock/validate.mjs",
     "test:dependency-lock": "sh scripts/dependency-lock/self_test.sh",
-    "check": "bun run typecheck && bun run test:policy-gate && bun run test:tool-registry-governance && bun run test:backend-api && bun run test:backend-ws && bun run test:schemas && bun run test:core-services"
+    "check": "bun run typecheck && bun run test:policy-gate && bun run test:tool-registry-governance && bun run test:backend-api && bun run test:backend-ws && bun run test:frontend && bun run test:schemas && bun run test:core-services"
   },
   "devDependencies": {
     "typescript": "5.8.3"

--- a/packages/frontend/src/components/AgentActivityFeed.ts
+++ b/packages/frontend/src/components/AgentActivityFeed.ts
@@ -1,0 +1,12 @@
+import type { WorkbenchPanel } from "./rendering";
+
+export function createAgentActivityFeedPanel(): WorkbenchPanel {
+  return {
+    slot: "agent-feed",
+    eyebrow: "活动",
+    title: "Agent 动态",
+    body: "Coordinator 已就绪。",
+    items: ["coordinator：任务已创建", "worker：等待执行", "reviewer：待命"],
+    footer: "实时流待接入"
+  };
+}

--- a/packages/frontend/src/components/ExperimentPanel.ts
+++ b/packages/frontend/src/components/ExperimentPanel.ts
@@ -1,0 +1,12 @@
+import type { WorkbenchPanel } from "./rendering";
+
+export function createExperimentPanel(): WorkbenchPanel {
+  return {
+    slot: "experiment",
+    eyebrow: "实验",
+    title: "运行工作区",
+    body: "当前没有运行中的 RunJob。",
+    items: ["SHUD pin：待定", "StackLock：待定", "DataProvenance：待定"],
+    footer: "本机 workspace"
+  };
+}

--- a/packages/frontend/src/components/ResultsPanel.ts
+++ b/packages/frontend/src/components/ResultsPanel.ts
@@ -1,0 +1,12 @@
+import type { WorkbenchPanel } from "./rendering";
+
+export function createResultsPanel(): WorkbenchPanel {
+  return {
+    slot: "results",
+    eyebrow: "结果",
+    title: "证据",
+    body: "尚无 EvidenceReport。",
+    items: ["NSE --", "洪峰误差 --", "耗时 --", "报告草稿 --"],
+    footer: "等待 PI 决策"
+  };
+}

--- a/packages/frontend/src/components/SideNav.ts
+++ b/packages/frontend/src/components/SideNav.ts
@@ -1,0 +1,18 @@
+import type { WorkbenchPanel } from "./rendering";
+
+export interface SideNavPlaceholderProps {
+  activeTaskId?: string;
+}
+
+export function createSideNavPanel(props: SideNavPlaceholderProps = {}): WorkbenchPanel {
+  const activeTaskId = props.activeTaskId ?? "TASK-M1-DEMO";
+
+  return {
+    slot: "side-nav",
+    eyebrow: "任务",
+    title: activeTaskId,
+    body: "已创建",
+    items: ["任务卡", "分析计划", "证据报告", "变更请求"],
+    footer: "M1 工作台壳"
+  };
+}

--- a/packages/frontend/src/components/index.ts
+++ b/packages/frontend/src/components/index.ts
@@ -1,3 +1,9 @@
 export const FRONTEND_COMPONENTS_NAMESPACE = "frontend/components" as const;
 
 export type FrontendComponentsNamespace = typeof FRONTEND_COMPONENTS_NAMESPACE;
+
+export * from "./AgentActivityFeed";
+export * from "./ExperimentPanel";
+export * from "./ResultsPanel";
+export * from "./SideNav";
+export * from "./rendering";

--- a/packages/frontend/src/components/rendering.ts
+++ b/packages/frontend/src/components/rendering.ts
@@ -1,0 +1,37 @@
+export interface WorkbenchPanel {
+  slot: "side-nav" | "agent-feed" | "experiment" | "results";
+  title: string;
+  eyebrow: string;
+  body: string;
+  items: readonly string[];
+  footer?: string;
+}
+
+export function renderPanel(panel: WorkbenchPanel): string {
+  const itemsMarkup =
+    panel.items.length > 0
+      ? `<ul class="workbench-panel__list">${panel.items
+          .map((item) => `<li>${escapeHtml(item)}</li>`)
+          .join("")}</ul>`
+      : "";
+  const footerMarkup = panel.footer
+    ? `<footer class="workbench-panel__footer">${escapeHtml(panel.footer)}</footer>`
+    : "";
+
+  return [
+    `<section class="workbench-panel workbench-panel--${panel.slot}" data-panel="${panel.slot}" aria-labelledby="${panel.slot}-title">`,
+    `<header class="workbench-panel__header"><span>${escapeHtml(panel.eyebrow)}</span><h2 id="${panel.slot}-title">${escapeHtml(panel.title)}</h2></header>`,
+    `<div class="workbench-panel__body"><p>${escapeHtml(panel.body)}</p>${itemsMarkup}</div>`,
+    footerMarkup,
+    "</section>"
+  ].join("");
+}
+
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/packages/frontend/src/layouts/WorkbenchLayout.ts
+++ b/packages/frontend/src/layouts/WorkbenchLayout.ts
@@ -1,0 +1,194 @@
+import {
+  createAgentActivityFeedPanel,
+  createExperimentPanel,
+  createResultsPanel,
+  createSideNavPanel,
+  renderPanel,
+  type SideNavPlaceholderProps
+} from "../components";
+
+export interface WorkbenchLayoutProps {
+  sideNav?: SideNavPlaceholderProps;
+}
+
+export const WORKBENCH_LAYOUT_PANEL_SLOTS = [
+  "side-nav",
+  "agent-feed",
+  "experiment",
+  "results"
+] as const;
+
+export function renderWorkbenchLayout(props: WorkbenchLayoutProps = {}): string {
+  const panels = [
+    createSideNavPanel(props.sideNav),
+    createAgentActivityFeedPanel(),
+    createExperimentPanel(),
+    createResultsPanel()
+  ];
+
+  return `<main class="workbench" data-workbench-layout="four-column">${panels
+    .map((panel) => renderPanel(panel))
+    .join("")}</main>`;
+}
+
+export const WORKBENCH_LAYOUT_CSS = `
+:root {
+  color-scheme: light;
+  --workbench-bg: #f6f8fb;
+  --panel-bg: #ffffff;
+  --panel-border: #d8dee8;
+  --text-primary: #172033;
+  --text-muted: #5e6a7d;
+  --accent-blue: #2563eb;
+  --accent-teal: #0f766e;
+  --accent-green: #15803d;
+  --accent-amber: #b45309;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background: var(--workbench-bg);
+  color: var(--text-primary);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.workbench {
+  display: grid;
+  grid-template-columns: 240px minmax(320px, 1fr) minmax(400px, 1.5fr) minmax(280px, 1fr);
+  grid-template-rows: minmax(0, 1fr);
+  gap: 0;
+  height: 100vh;
+  min-height: 520px;
+  overflow: hidden;
+}
+
+.workbench-panel {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--panel-border);
+  background: var(--panel-bg);
+}
+
+.workbench-panel:last-child {
+  border-right: 0;
+}
+
+.workbench-panel__header {
+  min-height: 64px;
+  padding: 14px 16px 12px;
+  border-bottom: 1px solid var(--panel-border);
+  min-width: 0;
+}
+
+.workbench-panel__header span {
+  display: block;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.workbench-panel__header h2 {
+  margin: 4px 0 0;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 650;
+  overflow-wrap: anywhere;
+}
+
+.workbench-panel__body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 16px;
+}
+
+.workbench-panel__body p {
+  margin: 0 0 14px;
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 20px;
+  overflow-wrap: anywhere;
+}
+
+.workbench-panel__list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.workbench-panel__list li {
+  min-height: 36px;
+  padding: 9px 10px;
+  border: 1px solid var(--panel-border);
+  border-left: 4px solid var(--accent-blue);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 18px;
+  background: #fbfcfe;
+  overflow-wrap: anywhere;
+}
+
+.workbench-panel--agent-feed .workbench-panel__list li {
+  border-left-color: var(--accent-teal);
+}
+
+.workbench-panel--experiment .workbench-panel__list li {
+  border-left-color: var(--accent-green);
+}
+
+.workbench-panel--results .workbench-panel__list li {
+  border-left-color: var(--accent-amber);
+}
+
+.workbench-panel__footer {
+  min-height: 36px;
+  padding: 9px 16px;
+  border-top: 1px solid var(--panel-border);
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 16px;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 1279px) {
+  .workbench {
+    grid-template-columns: 56px minmax(320px, 1fr) minmax(420px, 1.4fr);
+    grid-template-rows: minmax(320px, 1fr) minmax(220px, 0.7fr);
+    overflow: auto;
+  }
+
+  .workbench-panel--results {
+    grid-column: 2 / 4;
+    grid-row: 2;
+    border-top: 1px solid var(--panel-border);
+  }
+}
+
+@media (max-width: 795px) {
+  .workbench {
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(4, minmax(220px, 1fr));
+    height: auto;
+    overflow: visible;
+  }
+
+  .workbench-panel,
+  .workbench-panel--results {
+    display: flex;
+    grid-column: auto;
+    grid-row: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--panel-border);
+  }
+}
+`;

--- a/packages/frontend/src/layouts/index.ts
+++ b/packages/frontend/src/layouts/index.ts
@@ -1,3 +1,5 @@
 export const FRONTEND_LAYOUTS_NAMESPACE = "frontend/layouts" as const;
 
 export type FrontendLayoutsNamespace = typeof FRONTEND_LAYOUTS_NAMESPACE;
+
+export * from "./WorkbenchLayout";

--- a/packages/frontend/src/pages/Workbench.preview.ts
+++ b/packages/frontend/src/pages/Workbench.preview.ts
@@ -1,0 +1,5 @@
+import { renderWorkbenchDocument } from "./Workbench";
+
+if (import.meta.main) {
+  process.stdout.write(renderWorkbenchDocument());
+}

--- a/packages/frontend/src/pages/Workbench.ts
+++ b/packages/frontend/src/pages/Workbench.ts
@@ -1,0 +1,42 @@
+import { escapeHtml } from "../components";
+import { WORKBENCH_LAYOUT_CSS, renderWorkbenchLayout } from "../layouts";
+
+export const WORKBENCH_ROUTE = "/workbench" as const;
+
+export interface WorkbenchPageOptions {
+  activeTaskId?: string;
+}
+
+export function renderWorkbenchPage(options: WorkbenchPageOptions = {}): string {
+  return renderWorkbenchLayout({
+    sideNav: {
+      activeTaskId: options.activeTaskId
+    }
+  });
+}
+
+export function renderWorkbenchDocument(options: WorkbenchPageOptions = {}): string {
+  const title = "SHUD Harness 工作台";
+
+  return [
+    "<!doctype html>",
+    '<html lang="zh-CN">',
+    "<head>",
+    '<meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width, initial-scale=1">',
+    `<title>${escapeHtml(title)}</title>`,
+    `<style>${WORKBENCH_LAYOUT_CSS}</style>`,
+    "</head>",
+    "<body>",
+    renderWorkbenchPage(options),
+    "</body>",
+    "</html>"
+  ].join("");
+}
+
+export function renderWorkbenchRoute(
+  path: string,
+  options: WorkbenchPageOptions = {}
+): string | undefined {
+  return path === WORKBENCH_ROUTE ? renderWorkbenchDocument(options) : undefined;
+}

--- a/packages/frontend/src/pages/index.ts
+++ b/packages/frontend/src/pages/index.ts
@@ -1,3 +1,5 @@
 export const FRONTEND_PAGES_NAMESPACE = "frontend/pages" as const;
 
 export type FrontendPagesNamespace = typeof FRONTEND_PAGES_NAMESPACE;
+
+export * from "./Workbench";

--- a/packages/frontend/src/pages/workbench.test.ts
+++ b/packages/frontend/src/pages/workbench.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  WORKBENCH_LAYOUT_CSS,
+  WORKBENCH_LAYOUT_PANEL_SLOTS,
+  WORKBENCH_ROUTE,
+  renderWorkbenchDocument,
+  renderWorkbenchRoute
+} from "../index";
+
+describe("Workbench shell", () => {
+  test("renders the browser-openable four-column workbench document", () => {
+    const longTaskId =
+      "TASK-M1-UI-EXTREMELY-LONG-IDENTIFIER-WITHOUT-SPACES-000000000000000000000000000000";
+    const observedConsoleErrors: unknown[] = [];
+    const originalConsoleError = console.error;
+    console.error = (...args: unknown[]) => {
+      observedConsoleErrors.push(args);
+    };
+
+    try {
+      const document = renderWorkbenchDocument({ activeTaskId: "TASK-M1-UI" });
+
+      expect(observedConsoleErrors).toEqual([]);
+      expect(document.startsWith("<!doctype html>")).toBe(true);
+      expect(document).toContain('<html lang="zh-CN">');
+      expect(document).toContain("<title>SHUD Harness 工作台</title>");
+      expect(document).toContain('data-workbench-layout="four-column"');
+      expect(document).toContain("TASK-M1-UI");
+      expect(renderWorkbenchDocument({ activeTaskId: longTaskId })).toContain(
+        "TASK-M1-UI-EXTREMELY-LONG-IDENTIFIER-WITHOUT-SPACES"
+      );
+      expect(document).not.toContain("undefined");
+      expect(document).not.toContain("[object Object]");
+
+      for (const slot of WORKBENCH_LAYOUT_PANEL_SLOTS) {
+        expect(document.match(new RegExp(`data-panel="${slot}"`, "g")) ?? []).toHaveLength(1);
+      }
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
+  test("exposes the Workbench route skeleton without wiring Dashboard navigation", () => {
+    expect(renderWorkbenchRoute(WORKBENCH_ROUTE)).toContain("Agent 动态");
+    expect(renderWorkbenchRoute("/")).toBeUndefined();
+  });
+
+  test("keeps the desktop four-column grid contract stable", () => {
+    expect(WORKBENCH_LAYOUT_CSS).toContain(
+      "grid-template-columns: 240px minmax(320px, 1fr) minmax(400px, 1.5fr) minmax(280px, 1fr)"
+    );
+    expect(WORKBENCH_LAYOUT_CSS).toContain("@media (max-width: 1279px)");
+    expect(WORKBENCH_LAYOUT_CSS).toContain("@media (max-width: 795px)");
+    expect(WORKBENCH_LAYOUT_CSS).not.toContain("@media (max-width: 767px)");
+    expect(WORKBENCH_LAYOUT_CSS).not.toContain("display: none");
+    expect(WORKBENCH_LAYOUT_CSS).toContain("grid-column: 2 / 4");
+    expect(WORKBENCH_LAYOUT_CSS).toContain("grid-column: auto");
+    expect(WORKBENCH_LAYOUT_CSS).toContain("grid-row: auto");
+    expect(WORKBENCH_LAYOUT_CSS).toContain("overflow-wrap: anywhere");
+    expect(WORKBENCH_LAYOUT_CSS).toContain("overflow: auto");
+  });
+});


### PR DESCRIPTION
Part of #11
Closes #34

## Summary
- Add the M1 Workbench shell under `packages/frontend/src`: four canonical panels (`side-nav`, `agent-feed`, `experiment`, `results`), WorkbenchLayout renderer, `/workbench` route skeleton, and stdout preview entry.
- Wire `bun run test:frontend` into root `check` and add frontend smoke coverage for four-panel rendering, no render-time `console.error`, route non-wiring, responsive fallback guards, Chinese-first document shell, and long task-id wrapping.
- Add #34 OpenSpec fixture/evidence rows plus `docs/review-loop-log.jsonl` accountability row clarifying the delivery boundary: dependency-light browser-openable shell now; Dashboard data wiring, backend static serving, router integration, and full React runtime/bundler setup remain non-goals for #34.

## Verification
- `npx --yes bun@1.2.19 install --frozen-lockfile`
- `npx --yes bun@1.2.19 packages/frontend/src/pages/Workbench.preview.ts > /tmp/shud-workbench-preview.html`
- `npx --yes bun@1.2.19 run test:frontend` (3 pass, 25 expects)
- `npx --yes bun@1.2.19 run typecheck`
- `npx --yes bun@1.2.19 run check`
- `openspec validate m1-foundation --strict --no-interactive`
- `git diff --check`
- `node -e "...JSON.parse(line)..."` for `docs/review-loop-log.jsonl`
- `git -C zero diff --quiet && test -z "$(git ls-files workspace)"`
- GitHub CI at final head `c154d08549c829f0bbcf06b6b726e9211db91b67`: `docs-links`, `linux-base`, `macos-seatbelt`, `check` all pass

## Agent Review
- Spec/scope reviewer: PASS for PR diff boundary and OpenSpec/issue alignment.
- Frontend/layout reviewers: fixed and confirmed medium Results reachability, mobile grid reset, long task id wrapping, Chinese-first visible copy, 768-795px fallback, and `zh-CN`/Chinese title document shell.
- Integration/build reviewer: PASS; no backend/static serving, lockfile, `zero/`, tracked `workspace`, or package-boundary drift.
- Final Phase 7 review: PASS at `c154d08549c829f0bbcf06b6b726e9211db91b67`; no P0/P1/P2 findings.

## Known Limits
- #34 intentionally delivers a dependency-light, browser-openable shell and preview entry. React runtime/router/static serving, Dashboard navigation, and real task/result data wiring remain later milestone work per the #34 fixture.
