### PR TITLE
feat(frontend): add dashboard task page (#35)

### DIFF
--- a/docs/review-loop-log.jsonl
+++ b/docs/review-loop-log.jsonl
@@ -12,3 +12,4 @@
 {"issue":28,"pr":64,"date":"2026-07-07","fixture":"expanded/high","rounds":4,"gate_net_catch":10,"verdicts":{"confirmed":9,"plausible":1,"refuted":2},"residual_deferred":1,"premerge_skip_blocks":0}
 {"issue":29,"pr":65,"date":"2026-07-07","fixture":"expanded/high","rounds":4,"gate_net_catch":13,"verdicts":{"confirmed":11,"plausible":2,"refuted":0},"residual_deferred":2,"premerge_skip_blocks":0}
 {"issue":34,"pr":70,"date":"2026-07-08","fixture":"expanded/medium","rounds":2,"gate_net_catch":6,"verdicts":{"confirmed":6,"plausible":0,"refuted":0},"residual_deferred":0,"premerge_skip_blocks":0}
+{"issue":35,"pr":71,"date":"2026-07-08","fixture":"expanded/medium","rounds":2,"gate_net_catch":4,"verdicts":{"confirmed":4,"plausible":0,"refuted":0},"residual_deferred":0,"premerge_skip_blocks":0}

--- a/openspec/changes/m1-foundation/design.md
+++ b/openspec/changes/m1-foundation/design.md
@@ -1068,3 +1068,61 @@ Review focus:
 - Four panel slots are present exactly once and exported through the expected frontend boundaries.
 - The shell stays deterministic, dependency-light, and compatible with existing `bun install`/`check`.
 - Visible placeholder copy is operational state, not explanatory product marketing.
+
+## Subagent Workflow Fixture - Issue #35
+
+Fixture level: expanded; repair intensity: medium
+Project profile: SHUD-Harness
+
+Expanded-trigger rationale:
+- Core triggers: frontend public page skeleton, existing public API consumption, schema field display, create/list failure states, and refresh recovery.
+- Profile triggers: `TaskCard`, `snapshot`, M1 acceptance evidence, and frontend/backend contract drift risk.
+
+Change surface:
+- `packages/frontend/src/pages/**` Dashboard route/page renderer, page-local typed task API helper, and frontend smoke tests.
+- Frontend export boundaries needed by downstream #36 and M1 acceptance.
+
+Must preserve:
+- Backend `GET /api/tasks -> { tasks: TaskCard[] }` and `POST /api/tasks -> TaskCard` contracts remain unchanged.
+- #34 Workbench `/workbench` route renderer, four canonical panel slots, CSS fallback behavior, and preview entry remain compatible.
+- Dashboard-to-Workbench task context navigation, idempotency header UI wiring, backend static serving, auth/permissions, WebSocket updates, runtime `workspace/`, and `zero/` source remain unchanged.
+
+Must add/change:
+- Deterministic Dashboard route/page renderer with Chinese-first task list, create form, loading/empty/error states, and status-bearing rows.
+- Page-local typed task API helpers that call the existing backend contracts and surface stable errors without introducing a new `src/api/**` surface in #35.
+- Create flow state transition: initial list -> successful create -> list contains new `TaskCard` with `status=created`.
+- Refresh recovery path: a fresh render from server-provided `GET /api/tasks` data reproduces the persisted task list without relying on frontend memory.
+
+Risk packs considered:
+- Public page / route skeleton: selected - Dashboard is the M1 browser-visible task management entry representation.
+- Public API consumption: selected - frontend consumes existing task list/create endpoints and must not drift from their shapes.
+- Schema / field names: selected - UI and tests bind to shared `TaskCard` and `CreateTaskInput` fields.
+- Error handling / visible failure: selected - failed list/create must not render stale success or phantom rows.
+- Refresh / shared state ordering: selected - recovered server snapshot is the source of truth after browser refresh.
+- Dependency / build compatibility: selected - no unresolved runtime dependency or serving assumption may enter #35.
+- Backend behavior / idempotency header UI / Dashboard-to-Workbench navigation / auth / hydrology runtime / Zero governance: not selected - outside #35 by issue and M1 fixture.
+
+Invariant Matrix:
+- Governing invariant: Dashboard renders task list and create-result state from backend `TaskCard` data only; refresh recovery comes from `GET /api/tasks`, not frontend memory.
+- Source-of-truth identity/contract: `TaskCard.task_id`, `TaskCard.status`, `TaskCard.title`, `CreateTaskInput`, and backend task endpoints.
+- Producers: page-local Dashboard API helper and Dashboard page renderer.
+- Validators/preflight: frontend smoke tests, typecheck, root check, OpenSpec validation, diff check, zero/workspace boundary checks.
+- Storage/cache/query: browser memory may hold transient render state, but persisted truth is backend snapshot behind `GET /api/tasks`.
+- Public routes/entrypoints: frontend Dashboard route representation; backend HTTP route implementation is not changed in #35.
+- Frontend/downstream consumers: #36 can receive selected task context props later without changing Dashboard API helper semantics.
+- Failure paths/rollback/stale state: list/create failures render stable Chinese-first error copy and do not add optimistic phantom tasks.
+- Evidence/audit/readiness: PR evidence records `test:frontend`, `typecheck`, `check`, OpenSpec validation, diff check, and zero/workspace checks.
+- Regression rows:
+  - `GET /api/tasks -> { tasks: [] }` -> Dashboard renders an empty state and create form.
+  - Outbound `POST /api/tasks` body includes exactly the documented create payload keys `type`, `title`, `question_or_goal`, and `inference_budget: { mode }`; `POST /api/tasks -> TaskCard(status=created)` followed by `GET /api/tasks -> { tasks: [task] }` -> Dashboard row shows that task id/title/status exactly once.
+  - Fresh render from `GET /api/tasks -> { tasks: [previouslyCreated] }` -> Dashboard includes the previously created TaskCard without any prior in-memory state.
+  - List or create non-2xx / malformed response -> Dashboard renders an error state and no phantom created row.
+  - Existing `/workbench` renderer and preview tests continue to pass unchanged.
+
+Non-goals:
+- Dashboard-to-Workbench task context navigation, SideNav task-list wiring, real backend static serving, WebSocket live updates, idempotency-key UI, authentication/authorization, and full React runtime/router setup.
+
+Review focus:
+- Page-local API helper matches backend task endpoint shapes and exact create payload keys without changing backend contracts.
+- Dashboard state is server-sourced on refresh and does not fabricate success rows on failure.
+- The implementation remains dependency-light and compatible with #34 Workbench exports/tests.

--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -232,6 +232,25 @@
       - User-visible placeholder copy is Chinese-first while preserving canonical code identifiers where needed.
       - `bun run test:frontend`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 - [ ] 7.2 Dashboard 页（GET /api/tasks 列表 + 建卡表单 + 刷新恢复）——依赖: 6.2
+  - Fixture (#35): expanded / medium
+    - Change surface: `packages/frontend/src/pages/**`, frontend page exports, frontend smoke tests, and OpenSpec fixture evidence. Any fetch helper must be page-local under `pages/**`; do not introduce a new `src/api/**` surface in #35.
+    - Must preserve: existing backend `GET /api/tasks` and `POST /api/tasks` contracts, #34 Workbench `/workbench` renderer and four-panel CSS, no Dashboard→Workbench task-context navigation, no backend/static-serving changes, no `zero/` source diff, and no tracked runtime `workspace/` assets.
+    - Must add/change: Dashboard renderer/page skeleton, page-local typed task API helpers for list/create, create-task form markup, status-bearing task list markup, refresh-recovery render path from server-provided tasks, and tests proving the list updates after create and can be reconstructed from a fresh `GET /api/tasks` result.
+    - Risk packs considered:
+      - Public page / route skeleton: selected - Dashboard becomes the M1 browser-openable task list/create entry representation inside the frontend package.
+      - Public API consumption: selected - frontend must consume the existing `{ tasks: TaskCard[] }` list shape and `TaskCard` create response without mutating backend contracts.
+      - Schema / field names: selected - visible rows must use shared `TaskCard`/`CreateTaskInput` fields and show `status=created` for a newly created task.
+      - Error handling / visible failure: selected - failed list/create responses must render stable Chinese-first error state and must not add optimistic phantom tasks.
+      - Refresh / recovered state: selected - a fresh render from `GET /api/tasks` output must reproduce the accepted task list without relying on frontend memory.
+      - Dependency / build compatibility: selected - no unresolved browser/runtime dependency or bundler assumption may break `bun install`/`check`.
+      - Backend behavior, idempotency header frontend wiring, Dashboard→Workbench navigation, auth/secrets, hydrology runtime, and Zero governance: not selected - explicitly outside #35.
+    - Evidence floor (#35):
+      - Page-local Dashboard API helper serializes the exact documented create payload keys `type`, `title`, `question_or_goal`, and `inference_budget: { mode }`; parses `GET /api/tasks -> { tasks }` plus `POST /api/tasks -> TaskCard`.
+      - Dashboard renderer shows every provided TaskCard id/title/status exactly once and includes a create form with task type, title, goal, and budget mode controls.
+      - Create-flow test uses a fake fetch client: initial list empty -> outbound `POST /api/tasks` body equals the exact create payload keys above -> POST returns a `TaskCard` with matching rendered `task_id`, `title`, and `status=created` -> follow-up list contains that TaskCard and renders status `created`.
+      - Refresh-recovery test renders the Dashboard from a fresh `GET /api/tasks` result containing a previously created TaskCard; no in-memory carryover is required.
+      - Error tests cover list failure and create failure with Chinese-first error copy and no phantom task row.
+      - `bun run test:frontend`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 - [ ] 7.3 ExperimentHeader + StatusBar 占位组件（task 上下文 props）
 
 ## 8. GLM provider（glm-provider）

--- a/packages/frontend/src/pages/Dashboard.ts
+++ b/packages/frontend/src/pages/Dashboard.ts
@@ -1,0 +1,754 @@
+import {
+  CreateTaskInputSchema,
+  TaskCardSchema,
+  type CreateTaskInput,
+  type TaskCard,
+  type TaskType
+} from "@shud-harness/core";
+import { escapeHtml } from "../components";
+
+export const DASHBOARD_ROUTE = "/" as const;
+export const DASHBOARD_ALTERNATE_ROUTE = "/dashboard" as const;
+export const DASHBOARD_TASKS_ENDPOINT = "/api/tasks" as const;
+
+export type DashboardFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit
+) => Promise<Response>;
+
+export type DashboardBudgetMode = CreateTaskInput["inference_budget"]["mode"];
+
+export interface DashboardCreateTaskInput {
+  type: TaskType;
+  title: string;
+  question_or_goal: string;
+  inference_budget: {
+    mode: DashboardBudgetMode;
+  };
+}
+
+export interface DashboardFormValues {
+  type: TaskType;
+  title: string;
+  question_or_goal: string;
+  budgetMode: DashboardBudgetMode;
+}
+
+export interface DashboardRenderState {
+  tasks: readonly TaskCard[];
+  phase?: "loading" | "ready" | "submitting";
+  listError?: string;
+  createError?: string;
+  formValues?: Partial<DashboardFormValues>;
+}
+
+export class DashboardTaskApiError extends Error {
+  readonly endpoint: string;
+  readonly status?: number;
+
+  constructor(message: string, options: { endpoint: string; status?: number }) {
+    super(message);
+    this.name = "DashboardTaskApiError";
+    this.endpoint = options.endpoint;
+    this.status = options.status;
+  }
+}
+
+export async function listDashboardTasks(
+  fetchClient: DashboardFetch = fetch
+): Promise<TaskCard[]> {
+  const response = await fetchClient(DASHBOARD_TASKS_ENDPOINT, {
+    method: "GET",
+    headers: {
+      accept: "application/json"
+    }
+  });
+
+  if (!response.ok) {
+    throw new DashboardTaskApiError(`任务列表请求失败（HTTP ${response.status}）。`, {
+      endpoint: DASHBOARD_TASKS_ENDPOINT,
+      status: response.status
+    });
+  }
+
+  const payload = await readJsonResponse(response, DASHBOARD_TASKS_ENDPOINT);
+  return parseDashboardTaskListResponse(payload, DASHBOARD_TASKS_ENDPOINT);
+}
+
+export async function createDashboardTask(
+  input: DashboardCreateTaskInput,
+  fetchClient: DashboardFetch = fetch
+): Promise<TaskCard> {
+  const body = dashboardCreateTaskBody(input);
+  const response = await fetchClient(DASHBOARD_TASKS_ENDPOINT, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(body)
+  });
+
+  if (!response.ok) {
+    throw new DashboardTaskApiError(`任务创建请求失败（HTTP ${response.status}）。`, {
+      endpoint: DASHBOARD_TASKS_ENDPOINT,
+      status: response.status
+    });
+  }
+
+  const payload = await readJsonResponse(response, DASHBOARD_TASKS_ENDPOINT);
+  return parseDashboardTaskCardResponse(payload, DASHBOARD_TASKS_ENDPOINT);
+}
+
+export function dashboardCreateTaskBody(
+  input: DashboardCreateTaskInput
+): DashboardCreateTaskInput {
+  const parsed = CreateTaskInputSchema.parse(input);
+
+  return {
+    type: parsed.type,
+    title: parsed.title,
+    question_or_goal: parsed.question_or_goal,
+    inference_budget: {
+      mode: parsed.inference_budget.mode
+    }
+  };
+}
+
+export function createDashboardController(fetchClient: DashboardFetch = fetch) {
+  let state: DashboardRenderState = {
+    tasks: [],
+    phase: "loading"
+  };
+
+  return {
+    async load(): Promise<string> {
+      state = {
+        tasks: [],
+        phase: "loading"
+      };
+
+      try {
+        state = {
+          tasks: await listDashboardTasks(fetchClient),
+          phase: "ready"
+        };
+      } catch (error) {
+        state = {
+          tasks: [],
+          phase: "ready",
+          listError: dashboardErrorMessage(error, "任务列表加载失败。")
+        };
+      }
+
+      return renderDashboardPage(state);
+    },
+
+    async createTask(input: DashboardCreateTaskInput): Promise<string> {
+      state = {
+        ...state,
+        phase: "submitting",
+        createError: undefined
+      };
+
+      try {
+        await createDashboardTask(input, fetchClient);
+      } catch (error) {
+        state = {
+          ...state,
+          phase: "ready",
+          createError: dashboardErrorMessage(error, "任务创建失败。")
+        };
+        return renderDashboardPage(state);
+      }
+
+      try {
+        state = {
+          tasks: await listDashboardTasks(fetchClient),
+          phase: "ready"
+        };
+      } catch (error) {
+        state = {
+          ...state,
+          phase: "ready",
+          listError: dashboardErrorMessage(error, "任务已提交，但列表刷新失败。")
+        };
+      }
+
+      return renderDashboardPage(state);
+    },
+
+    render(): string {
+      return renderDashboardPage(state);
+    }
+  };
+}
+
+export async function renderDashboardFromServer(
+  fetchClient: DashboardFetch = fetch
+): Promise<string> {
+  const tasks = await listDashboardTasks(fetchClient);
+  return renderDashboardDocument({ tasks, phase: "ready" });
+}
+
+export function renderDashboardPage(state: DashboardRenderState): string {
+  const phaseMarkup =
+    state.phase === "loading"
+      ? '<p class="dashboard-status" role="status">正在加载任务列表...</p>'
+      : state.phase === "submitting"
+        ? '<p class="dashboard-status" role="status">正在创建 TaskCard...</p>'
+        : "";
+
+  return [
+    '<main class="dashboard" data-dashboard-page="task-list-create">',
+    '<section class="dashboard__tasks" aria-labelledby="dashboard-task-list-title">',
+    '<header class="dashboard__header">',
+    '<span class="dashboard__eyebrow">TaskCard</span>',
+    '<h1 id="dashboard-task-list-title">任务看板</h1>',
+    "</header>",
+    phaseMarkup,
+    renderDashboardErrors(state),
+    renderTaskList(state),
+    "</section>",
+    '<section class="dashboard__create" aria-labelledby="dashboard-create-title">',
+    '<header class="dashboard__header">',
+    '<span class="dashboard__eyebrow">Create</span>',
+    '<h2 id="dashboard-create-title">新建任务卡</h2>',
+    "</header>",
+    renderCreateTaskForm(state.formValues),
+    "</section>",
+    "</main>"
+  ].join("");
+}
+
+export function renderDashboardDocument(state: DashboardRenderState): string {
+  const title = "SHUD Harness 任务看板";
+
+  return [
+    "<!doctype html>",
+    '<html lang="zh-CN">',
+    "<head>",
+    '<meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width, initial-scale=1">',
+    `<title>${escapeHtml(title)}</title>`,
+    `<style>${DASHBOARD_CSS}</style>`,
+    "</head>",
+    "<body>",
+    renderDashboardPage(state),
+    `<script data-dashboard-create-script>${DASHBOARD_CREATE_FORM_SCRIPT}</script>`,
+    "</body>",
+    "</html>"
+  ].join("");
+}
+
+export function renderDashboardRoute(
+  path: string,
+  state: DashboardRenderState = { tasks: [], phase: "ready" }
+): string | undefined {
+  return path === DASHBOARD_ROUTE || path === DASHBOARD_ALTERNATE_ROUTE
+    ? renderDashboardDocument(state)
+    : undefined;
+}
+
+function renderDashboardErrors(state: DashboardRenderState): string {
+  const messages = [
+    state.listError ? ["dashboard-list-error", state.listError] : undefined,
+    state.createError ? ["dashboard-create-error", state.createError] : undefined
+  ].filter((entry): entry is [string, string] => Boolean(entry));
+
+  const hidden = messages.length === 0 ? " hidden" : "";
+
+  return `<div class="dashboard-errors" data-dashboard-errors${hidden}>${messages
+    .map(
+      ([id, message]) =>
+        `<p class="dashboard-error" id="${id}" role="alert">${escapeHtml(message)}</p>`
+    )
+    .join("")}</div>`;
+}
+
+function renderTaskList(state: DashboardRenderState): string {
+  const contents = renderTaskListContents(state);
+  return `<div data-dashboard-task-list>${contents}</div>`;
+}
+
+function renderTaskListContents(state: DashboardRenderState): string {
+  if (state.listError) {
+    return '<div class="dashboard-empty" data-task-empty-state>任务列表暂不可用。</div>';
+  }
+
+  if (state.tasks.length === 0) {
+    return '<div class="dashboard-empty" data-task-empty-state>当前没有 TaskCard。</div>';
+  }
+
+  return [
+    '<table class="dashboard-task-table" aria-label="TaskCard 列表">',
+    "<thead><tr>",
+    "<th>task_id</th>",
+    "<th>标题</th>",
+    "<th>status</th>",
+    "</tr></thead>",
+    "<tbody>",
+    state.tasks.map((task) => renderTaskRow(task)).join(""),
+    "</tbody>",
+    "</table>"
+  ].join("");
+}
+
+function renderTaskRow(task: TaskCard): string {
+  return [
+    "<tr data-task-row>",
+    `<td>${escapeHtml(task.task_id)}</td>`,
+    `<td>${escapeHtml(task.title)}</td>`,
+    `<td>${escapeHtml(task.status)}</td>`,
+    "</tr>"
+  ].join("");
+}
+
+function renderCreateTaskForm(values: Partial<DashboardFormValues> = {}): string {
+  const taskType = values.type ?? "engineering";
+  const budgetMode = values.budgetMode ?? "normal";
+  const title = values.title ?? "";
+  const questionOrGoal = values.question_or_goal ?? "";
+
+  return [
+    '<form class="dashboard-form" data-create-task-form method="post" action="/api/tasks">',
+    '<label for="dashboard-task-type">任务类型</label>',
+    '<select id="dashboard-task-type" name="type">',
+    renderOption("engineering", "工程 engineering", taskType),
+    renderOption("science_assist", "科研协助 science_assist", taskType),
+    renderOption("ops", "运维 ops", taskType),
+    "</select>",
+    '<label for="dashboard-task-title">标题</label>',
+    `<input id="dashboard-task-title" name="title" type="text" value="${escapeHtml(title)}" autocomplete="off">`,
+    '<label for="dashboard-task-goal">问题 / 目标</label>',
+    `<textarea id="dashboard-task-goal" name="question_or_goal" rows="5">${escapeHtml(
+      questionOrGoal
+    )}</textarea>`,
+    '<label for="dashboard-budget-mode">预算模式</label>',
+    '<select id="dashboard-budget-mode" name="budget_mode">',
+    renderOption("cheap", "cheap", budgetMode),
+    renderOption("normal", "normal", budgetMode),
+    renderOption("deep", "deep", budgetMode),
+    "</select>",
+    '<button type="submit">创建 TaskCard</button>',
+    "</form>"
+  ].join("");
+}
+
+function renderOption(
+  value: TaskType | DashboardBudgetMode,
+  label: string,
+  selectedValue: TaskType | DashboardBudgetMode
+): string {
+  const selected = value === selectedValue ? " selected" : "";
+  return `<option value="${escapeHtml(value)}"${selected}>${escapeHtml(label)}</option>`;
+}
+
+function parseDashboardTaskListResponse(payload: unknown, endpoint: string): TaskCard[] {
+  if (!isRecord(payload) || !Array.isArray(payload.tasks)) {
+    throw new DashboardTaskApiError("任务列表响应格式不符合 TaskCard 契约。", {
+      endpoint
+    });
+  }
+
+  try {
+    return payload.tasks.map((task) => TaskCardSchema.parse(task));
+  } catch {
+    throw new DashboardTaskApiError("任务列表响应格式不符合 TaskCard 契约。", {
+      endpoint
+    });
+  }
+}
+
+function parseDashboardTaskCardResponse(payload: unknown, endpoint: string): TaskCard {
+  try {
+    return TaskCardSchema.parse(payload);
+  } catch {
+    throw new DashboardTaskApiError("任务创建响应格式不符合 TaskCard 契约。", {
+      endpoint
+    });
+  }
+}
+
+async function readJsonResponse(response: Response, endpoint: string): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    throw new DashboardTaskApiError("API 响应不是有效 JSON。", {
+      endpoint,
+      status: response.status
+    });
+  }
+}
+
+function dashboardErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof DashboardTaskApiError) {
+    return `${fallback} ${error.message}`;
+  }
+
+  if (error instanceof Error && error.message.length > 0) {
+    return `${fallback} ${error.message}`;
+  }
+
+  return fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export const DASHBOARD_CREATE_FORM_SCRIPT = `
+(() => {
+  const endpoint = "/api/tasks";
+  const form = document.querySelector("[data-create-task-form]");
+  const listRegion = document.querySelector("[data-dashboard-task-list]");
+  const errorRegion = document.querySelector("[data-dashboard-errors]");
+  if (!form || !listRegion || !errorRegion || typeof window.fetch !== "function") {
+    return;
+  }
+
+  const escapeHtml = (value) =>
+    String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
+
+  const setErrors = (messages) => {
+    errorRegion.innerHTML = messages
+      .map(
+        (message, index) =>
+          '<p class="dashboard-error" id="dashboard-client-error-' +
+          index +
+          '" role="alert">' +
+          escapeHtml(message) +
+          "</p>"
+      )
+      .join("");
+    errorRegion.hidden = messages.length === 0;
+  };
+
+  const renderTaskRows = (tasks) =>
+    tasks
+      .map(
+        (task) =>
+          "<tr data-" +
+          "task-row><td>" +
+          escapeHtml(task.task_id) +
+          "</td><td>" +
+          escapeHtml(task.title) +
+          "</td><td>" +
+          escapeHtml(task.status) +
+          "</td></tr>"
+      )
+      .join("");
+
+  const renderTasks = (tasks) => {
+    if (tasks.length === 0) {
+      listRegion.innerHTML =
+        '<div class="dashboard-empty" data-task-empty-state>当前没有 TaskCard。</div>';
+      return;
+    }
+
+    listRegion.innerHTML =
+      '<table class="dashboard-task-table" aria-label="TaskCard 列表"><thead><tr><th>task_id</th><th>标题</th><th>status</th></tr></thead><tbody>' +
+      renderTaskRows(tasks) +
+      "</tbody></table>";
+  };
+
+  const errorMessage = (error, fallback) =>
+    fallback + " " + (error instanceof Error && error.message ? error.message : "API 请求失败。");
+
+  const allowedTaskStatuses = new Set([
+    "created",
+    "planned",
+    "running",
+    "parked",
+    "reporting",
+    "awaiting_pi",
+    "done",
+    "cancelled",
+    "blocked"
+  ]);
+
+  const isTaskCardLike = (task) =>
+    task &&
+    typeof task === "object" &&
+    typeof task.task_id === "string" &&
+    task.task_id.length > 0 &&
+    typeof task.title === "string" &&
+    task.title.length > 0 &&
+    typeof task.status === "string" &&
+    allowedTaskStatuses.has(task.status);
+
+  const assertTaskCard = (task, message) => {
+    if (!isTaskCardLike(task)) {
+      throw new Error(message);
+    }
+    return task;
+  };
+
+  const assertTaskList = (payload) => {
+    if (!payload || !Array.isArray(payload.tasks)) {
+      throw new Error("任务列表响应格式不符合 TaskCard 契约。");
+    }
+    return payload.tasks.map((task) =>
+      assertTaskCard(task, "任务列表响应格式不符合 TaskCard 契约。")
+    );
+  };
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    setErrors([]);
+
+    const data = new FormData(form);
+    const payload = {
+      type: String(data.get("type") ?? ""),
+      title: String(data.get("title") ?? ""),
+      question_or_goal: String(data.get("question_or_goal") ?? ""),
+      inference_budget: {
+        mode: String(data.get("budget_mode") ?? "normal")
+      }
+    };
+
+    try {
+      const createResponse = await window.fetch(endpoint, {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      });
+      if (!createResponse.ok) {
+        throw new Error("任务创建请求失败（HTTP " + createResponse.status + "）。");
+      }
+      assertTaskCard(await createResponse.json(), "任务创建响应格式不符合 TaskCard 契约。");
+    } catch (error) {
+      setErrors([errorMessage(error, "任务创建失败。")]);
+      return;
+    }
+
+    try {
+      const listResponse = await window.fetch(endpoint, {
+        method: "GET",
+        headers: {
+          accept: "application/json"
+        }
+      });
+      if (!listResponse.ok) {
+        throw new Error("任务列表请求失败（HTTP " + listResponse.status + "）。");
+      }
+      const listPayload = await listResponse.json();
+      renderTasks(assertTaskList(listPayload));
+      form.reset();
+    } catch (error) {
+      setErrors([errorMessage(error, "任务已提交，但列表刷新失败。")]);
+    }
+  });
+})();
+`;
+
+export const DASHBOARD_CSS = `
+:root {
+  color-scheme: light;
+  --dashboard-bg: #f6f8fb;
+  --surface-bg: #ffffff;
+  --surface-border: #d8dee8;
+  --text-primary: #172033;
+  --text-muted: #5e6a7d;
+  --accent-blue: #2563eb;
+  --accent-green: #15803d;
+  --accent-amber: #b45309;
+  --danger-bg: #fef2f2;
+  --danger-border: #fca5a5;
+  --danger-text: #991b1b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background: var(--dashboard-bg);
+  color: var(--text-primary);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.dashboard {
+  display: grid;
+  grid-template-columns: minmax(360px, 1fr) minmax(320px, 420px);
+  gap: 0;
+  min-height: 100vh;
+}
+
+.dashboard__tasks,
+.dashboard__create {
+  min-width: 0;
+  background: var(--surface-bg);
+}
+
+.dashboard__tasks {
+  border-right: 1px solid var(--surface-border);
+}
+
+.dashboard__create {
+  padding-bottom: 24px;
+}
+
+.dashboard__header {
+  min-height: 72px;
+  padding: 16px 20px 14px;
+  border-bottom: 1px solid var(--surface-border);
+}
+
+.dashboard__eyebrow {
+  display: block;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.dashboard__header h1,
+.dashboard__header h2 {
+  margin: 4px 0 0;
+  font-size: 20px;
+  line-height: 26px;
+  font-weight: 650;
+  overflow-wrap: anywhere;
+}
+
+.dashboard-status,
+.dashboard-empty,
+.dashboard-error {
+  margin: 16px 20px 0;
+  font-size: 14px;
+  line-height: 20px;
+  overflow-wrap: anywhere;
+}
+
+.dashboard-status,
+.dashboard-empty {
+  color: var(--text-muted);
+}
+
+.dashboard-errors {
+  display: grid;
+  gap: 8px;
+  margin: 16px 20px 0;
+}
+
+.dashboard-error {
+  margin: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--danger-border);
+  border-radius: 8px;
+  background: var(--danger-bg);
+  color: var(--danger-text);
+}
+
+.dashboard-task-table {
+  width: calc(100% - 40px);
+  margin: 20px;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.dashboard-task-table th,
+.dashboard-task-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--surface-border);
+  text-align: left;
+  vertical-align: top;
+  overflow-wrap: anywhere;
+}
+
+.dashboard-task-table th {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 650;
+}
+
+.dashboard-task-table tbody tr {
+  min-height: 44px;
+}
+
+.dashboard-task-table td:first-child {
+  width: 34%;
+  color: var(--accent-blue);
+}
+
+.dashboard-task-table td:nth-child(3) {
+  width: 120px;
+  color: var(--accent-green);
+  font-weight: 650;
+}
+
+.dashboard-form {
+  display: grid;
+  gap: 10px;
+  padding: 18px 20px 0;
+}
+
+.dashboard-form label {
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.dashboard-form input,
+.dashboard-form select,
+.dashboard-form textarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--surface-border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  color: var(--text-primary);
+  background: #ffffff;
+  font: inherit;
+  line-height: 20px;
+}
+
+.dashboard-form textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.dashboard-form button {
+  min-height: 40px;
+  border: 0;
+  border-radius: 8px;
+  padding: 10px 14px;
+  background: var(--accent-blue);
+  color: #ffffff;
+  font: inherit;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.dashboard-form button:focus,
+.dashboard-form input:focus,
+.dashboard-form select:focus,
+.dashboard-form textarea:focus {
+  outline: 3px solid #bfdbfe;
+  outline-offset: 1px;
+}
+
+@media (max-width: 900px) {
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard__tasks {
+    border-right: 0;
+    border-bottom: 1px solid var(--surface-border);
+  }
+}
+`;

--- a/packages/frontend/src/pages/dashboard.test.ts
+++ b/packages/frontend/src/pages/dashboard.test.ts
@@ -1,0 +1,548 @@
+import { describe, expect, test } from "bun:test";
+
+import type { TaskCard } from "@shud-harness/core";
+import {
+  DASHBOARD_CREATE_FORM_SCRIPT,
+  DASHBOARD_TASKS_ENDPOINT,
+  createDashboardController,
+  createDashboardTask,
+  listDashboardTasks,
+  renderDashboardDocument,
+  renderDashboardFromServer
+} from "../index";
+
+describe("Dashboard task page", () => {
+  test("page-local helpers parse task list and create responses", async () => {
+    const existingTask = taskCardFixture("TASK-dashboard-list", {
+      title: "恢复已有 TaskCard"
+    });
+    const createdTask = taskCardFixture("TASK-dashboard-create", {
+      title: "新建 TaskCard"
+    });
+    const fake = createFakeFetch([
+      { body: { tasks: [existingTask] } },
+      { status: 201, body: createdTask }
+    ]);
+
+    await expect(listDashboardTasks(fake.fetchClient)).resolves.toEqual([existingTask]);
+    await expect(
+      createDashboardTask(
+        {
+          type: "engineering",
+          title: "新建 TaskCard",
+          question_or_goal: "检查 Dashboard 建卡 helper。",
+          inference_budget: { mode: "normal" }
+        },
+        fake.fetchClient
+      )
+    ).resolves.toEqual(createdTask);
+
+    expect(fake.requests.map((request) => request.url)).toEqual([
+      DASHBOARD_TASKS_ENDPOINT,
+      DASHBOARD_TASKS_ENDPOINT
+    ]);
+    expect(fake.requests.map((request) => request.method)).toEqual(["GET", "POST"]);
+  });
+
+  test("renders empty state and create controls", () => {
+    const document = renderDashboardDocument({ tasks: [], phase: "ready" });
+
+    expect(document.startsWith("<!doctype html>")).toBe(true);
+    expect(document).toContain('<html lang="zh-CN">');
+    expect(document).toContain("当前没有 TaskCard。");
+    expect(document).toContain('name="type"');
+    expect(document).toContain('name="title"');
+    expect(document).toContain('name="question_or_goal"');
+    expect(document).toContain('name="budget_mode"');
+    expect(document).toContain("创建 TaskCard");
+    expect(document).toContain("data-dashboard-create-script");
+  });
+
+  test("create flow posts exact payload keys and refreshes from the backend list", async () => {
+    const createdTask = taskCardFixture("TASK-dashboard-created", {
+      title: "Dashboard 建卡验收",
+      status: "created"
+    });
+    const fake = createFakeFetch([
+      { body: { tasks: [] } },
+      { status: 201, body: createdTask },
+      { body: { tasks: [createdTask] } }
+    ]);
+    const controller = createDashboardController(fake.fetchClient);
+
+    const initialDocument = await controller.load();
+    expect(initialDocument).toContain("当前没有 TaskCard。");
+
+    const createdDocument = await controller.createTask({
+      type: "engineering",
+      title: "Dashboard 建卡验收",
+      question_or_goal: "验证 POST 后重新读取 GET /api/tasks。",
+      inference_budget: { mode: "normal" }
+    });
+
+    expect(fake.requests).toHaveLength(3);
+    expect(fake.requests.map((request) => [request.method, request.url])).toEqual([
+      ["GET", DASHBOARD_TASKS_ENDPOINT],
+      ["POST", DASHBOARD_TASKS_ENDPOINT],
+      ["GET", DASHBOARD_TASKS_ENDPOINT]
+    ]);
+
+    const postBody = fake.requests[1]?.jsonBody as Record<string, unknown>;
+    expect(Object.keys(postBody)).toEqual([
+      "type",
+      "title",
+      "question_or_goal",
+      "inference_budget"
+    ]);
+    expect(postBody).toEqual({
+      type: "engineering",
+      title: "Dashboard 建卡验收",
+      question_or_goal: "验证 POST 后重新读取 GET /api/tasks。",
+      inference_budget: { mode: "normal" }
+    });
+    expect(Object.keys(postBody.inference_budget as Record<string, unknown>)).toEqual(["mode"]);
+
+    expect(countOccurrences(createdDocument, "<tr data-task-row>")).toBe(1);
+    expect(countOccurrences(createdDocument, "TASK-dashboard-created")).toBe(1);
+    expect(countOccurrences(createdDocument, "Dashboard 建卡验收")).toBe(1);
+    expect(countOccurrences(createdDocument, ">created<")).toBe(1);
+  });
+
+  test("rendered form submit script posts exact JSON payload and refreshes task rows", async () => {
+    const createdTask = taskCardFixture("TASK-dashboard-script", {
+      title: "脚本建卡验收",
+      status: "created"
+    });
+    const harness = createDashboardScriptHarness(
+      {
+        type: "engineering",
+        title: "脚本建卡验收",
+        question_or_goal: "验证可见表单提交路径。",
+        budget_mode: "normal"
+      },
+      [{ status: 201, body: createdTask }, { body: { tasks: [createdTask] } }]
+    );
+
+    await harness.submit();
+
+    expect(harness.prevented).toBe(true);
+    expect(harness.fake.requests.map((request) => [request.method, request.url])).toEqual([
+      ["POST", DASHBOARD_TASKS_ENDPOINT],
+      ["GET", DASHBOARD_TASKS_ENDPOINT]
+    ]);
+
+    const postBody = harness.fake.requests[0]?.jsonBody as Record<string, unknown>;
+    expect(Object.keys(postBody)).toEqual([
+      "type",
+      "title",
+      "question_or_goal",
+      "inference_budget"
+    ]);
+    expect(postBody).toEqual({
+      type: "engineering",
+      title: "脚本建卡验收",
+      question_or_goal: "验证可见表单提交路径。",
+      inference_budget: { mode: "normal" }
+    });
+    expect(Object.keys(postBody.inference_budget as Record<string, unknown>)).toEqual(["mode"]);
+    expect(harness.listRegion.innerHTML).toContain("TASK-dashboard-script");
+    expect(harness.listRegion.innerHTML).toContain("脚本建卡验收");
+    expect(harness.listRegion.innerHTML).toContain(">created<");
+    expect(harness.errorRegion.hidden).toBe(true);
+    expect(harness.resetCalled).toBe(true);
+  });
+
+  test("rendered form submit script rejects malformed create responses without phantom rows", async () => {
+    const harness = createDashboardScriptHarness(
+      {
+        type: "engineering",
+        title: "脚本畸形创建",
+        question_or_goal: "POST 响应缺少 TaskCard 字段。",
+        budget_mode: "normal"
+      },
+      [{ status: 201, body: { task_id: "TASK-script-incomplete" } }]
+    );
+
+    await harness.submit();
+
+    expect(harness.fake.requests).toHaveLength(1);
+    expect(harness.errorRegion.hidden).toBe(false);
+    expect(harness.errorRegion.innerHTML).toContain("任务创建失败。");
+    expect(harness.errorRegion.innerHTML).toContain("任务创建响应格式不符合 TaskCard 契约。");
+    expect(harness.listRegion.innerHTML).not.toContain("<tr data-task-row>");
+    expect(harness.listRegion.innerHTML).not.toContain("TASK-script-incomplete");
+    expect(harness.resetCalled).toBe(false);
+  });
+
+  test("rendered form submit script rejects invalid create status enum", async () => {
+    const harness = createDashboardScriptHarness(
+      {
+        type: "engineering",
+        title: "脚本非法状态创建",
+        question_or_goal: "POST 响应 status 非法。",
+        budget_mode: "normal"
+      },
+      [
+        {
+          status: 201,
+          body: taskCardFixture("TASK-script-invalid-create-status", {
+            status: "not_a_status" as TaskCard["status"]
+          })
+        }
+      ]
+    );
+
+    await harness.submit();
+
+    expect(harness.errorRegion.hidden).toBe(false);
+    expect(harness.errorRegion.innerHTML).toContain("任务创建失败。");
+    expect(harness.errorRegion.innerHTML).toContain("任务创建响应格式不符合 TaskCard 契约。");
+    expect(harness.listRegion.innerHTML).not.toContain("<tr data-task-row>");
+    expect(harness.listRegion.innerHTML).not.toContain("TASK-script-invalid-create-status");
+    expect(harness.resetCalled).toBe(false);
+  });
+
+  test("rendered form submit script rejects malformed refreshed task rows", async () => {
+    const createdTask = taskCardFixture("TASK-script-refresh", {
+      title: "脚本创建后刷新畸形",
+      status: "created"
+    });
+    const harness = createDashboardScriptHarness(
+      {
+        type: "engineering",
+        title: "脚本创建后刷新畸形",
+        question_or_goal: "GET tasks 元素缺少字段。",
+        budget_mode: "normal"
+      },
+      [
+        { status: 201, body: createdTask },
+        { body: { tasks: [{ task_id: "TASK-script-malformed" }] } }
+      ]
+    );
+
+    await harness.submit();
+
+    expect(harness.fake.requests.map((request) => request.method)).toEqual(["POST", "GET"]);
+    expect(harness.errorRegion.hidden).toBe(false);
+    expect(harness.errorRegion.innerHTML).toContain("任务已提交，但列表刷新失败。");
+    expect(harness.errorRegion.innerHTML).toContain("任务列表响应格式不符合 TaskCard 契约。");
+    expect(harness.listRegion.innerHTML).not.toContain("<tr data-task-row>");
+    expect(harness.listRegion.innerHTML).not.toContain("TASK-script-malformed");
+    expect(harness.resetCalled).toBe(false);
+  });
+
+  test("rendered form submit script rejects invalid refreshed task status enum", async () => {
+    const createdTask = taskCardFixture("TASK-script-valid-create", {
+      title: "脚本创建成功",
+      status: "created"
+    });
+    const harness = createDashboardScriptHarness(
+      {
+        type: "engineering",
+        title: "脚本非法状态刷新",
+        question_or_goal: "GET tasks status 非法。",
+        budget_mode: "normal"
+      },
+      [
+        { status: 201, body: createdTask },
+        {
+          body: {
+            tasks: [
+              taskCardFixture("TASK-script-invalid-list-status", {
+                title: "非法状态行",
+                status: "not_a_status" as TaskCard["status"]
+              })
+            ]
+          }
+        }
+      ]
+    );
+
+    await harness.submit();
+
+    expect(harness.fake.requests.map((request) => request.method)).toEqual(["POST", "GET"]);
+    expect(harness.errorRegion.hidden).toBe(false);
+    expect(harness.errorRegion.innerHTML).toContain("任务已提交，但列表刷新失败。");
+    expect(harness.errorRegion.innerHTML).toContain("任务列表响应格式不符合 TaskCard 契约。");
+    expect(harness.listRegion.innerHTML).not.toContain("<tr data-task-row>");
+    expect(harness.listRegion.innerHTML).not.toContain("TASK-script-invalid-list-status");
+    expect(harness.resetCalled).toBe(false);
+  });
+
+  test("fresh render recovers a previously created task from GET /api/tasks", async () => {
+    const previouslyCreated = taskCardFixture("TASK-dashboard-recovered", {
+      title: "刷新恢复任务",
+      status: "created"
+    });
+    const fake = createFakeFetch([{ body: { tasks: [previouslyCreated] } }]);
+
+    const document = await renderDashboardFromServer(fake.fetchClient);
+
+    expect(fake.requests).toHaveLength(1);
+    expect(fake.requests[0]?.method).toBe("GET");
+    expect(countOccurrences(document, "<tr data-task-row>")).toBe(1);
+    expect(countOccurrences(document, "TASK-dashboard-recovered")).toBe(1);
+    expect(countOccurrences(document, "刷新恢复任务")).toBe(1);
+    expect(countOccurrences(document, ">created<")).toBe(1);
+  });
+
+  test("list failure renders Chinese-first error copy and no phantom task row", async () => {
+    const fake = createFakeFetch([{ status: 500, body: { error: "boom" } }]);
+    const controller = createDashboardController(fake.fetchClient);
+
+    const document = await controller.load();
+
+    expect(document).toContain("任务列表加载失败。");
+    expect(document).toContain("任务列表请求失败");
+    expect(document).toContain("任务列表暂不可用。");
+    expect(document).not.toContain("<tr data-task-row>");
+    expect(document).not.toContain("TASK-phantom");
+  });
+
+  test("malformed list response renders an error state without phantom rows", async () => {
+    const fake = createFakeFetch([{ body: { items: [taskCardFixture("TASK-wrong-shape")] } }]);
+    const controller = createDashboardController(fake.fetchClient);
+
+    const document = await controller.load();
+
+    expect(document).toContain("任务列表加载失败。");
+    expect(document).toContain("任务列表响应格式不符合 TaskCard 契约。");
+    expect(document).toContain("任务列表暂不可用。");
+    expect(document).not.toContain("<tr data-task-row>");
+    expect(document).not.toContain("TASK-wrong-shape");
+  });
+
+  test("create failure renders Chinese-first error copy and no phantom task row", async () => {
+    const fake = createFakeFetch([
+      { body: { tasks: [] } },
+      { status: 500, body: { error: "boom" } }
+    ]);
+    const controller = createDashboardController(fake.fetchClient);
+
+    await controller.load();
+    const document = await controller.createTask({
+      type: "engineering",
+      title: "不会出现的任务",
+      question_or_goal: "失败时不能乐观插入列表。",
+      inference_budget: { mode: "normal" }
+    });
+
+    expect(fake.requests).toHaveLength(2);
+    expect(document).toContain("任务创建失败。");
+    expect(document).toContain("任务创建请求失败");
+    expect(document).not.toContain("<tr data-task-row>");
+    expect(document).not.toContain("不会出现的任务");
+  });
+
+  test("post-create refresh failure is not reported as create failure", async () => {
+    const createdTask = taskCardFixture("TASK-refresh-failed", {
+      title: "已创建但刷新失败",
+      status: "created"
+    });
+    const fake = createFakeFetch([
+      { body: { tasks: [] } },
+      { status: 201, body: createdTask },
+      { status: 500, body: { error: "list failed" } }
+    ]);
+    const controller = createDashboardController(fake.fetchClient);
+
+    await controller.load();
+    const document = await controller.createTask({
+      type: "engineering",
+      title: "已创建但刷新失败",
+      question_or_goal: "POST 成功后 GET 失败。",
+      inference_budget: { mode: "normal" }
+    });
+
+    expect(document).toContain("任务已提交，但列表刷新失败。");
+    expect(document).toContain("任务列表请求失败");
+    expect(document).not.toContain("任务创建失败。");
+    expect(document).not.toContain("<tr data-task-row>");
+    expect(document).not.toContain("TASK-refresh-failed");
+  });
+
+  test("post-create malformed refresh is not reported as create failure", async () => {
+    const createdTask = taskCardFixture("TASK-refresh-malformed", {
+      title: "已创建但刷新畸形",
+      status: "created"
+    });
+    const fake = createFakeFetch([
+      { body: { tasks: [] } },
+      { status: 201, body: createdTask },
+      { status: 200, body: { items: [createdTask] } }
+    ]);
+    const controller = createDashboardController(fake.fetchClient);
+
+    await controller.load();
+    const document = await controller.createTask({
+      type: "engineering",
+      title: "已创建但刷新畸形",
+      question_or_goal: "POST 成功后 GET shape 错误。",
+      inference_budget: { mode: "normal" }
+    });
+
+    expect(document).toContain("任务已提交，但列表刷新失败。");
+    expect(document).toContain("任务列表响应格式不符合 TaskCard 契约。");
+    expect(document).not.toContain("任务创建失败。");
+    expect(document).not.toContain("<tr data-task-row>");
+    expect(document).not.toContain("TASK-refresh-malformed");
+  });
+
+  test("malformed create response renders an error state without phantom rows", async () => {
+    const fake = createFakeFetch([
+      { body: { tasks: [] } },
+      { status: 201, body: { task_id: "TASK-incomplete" } }
+    ]);
+    const controller = createDashboardController(fake.fetchClient);
+
+    await controller.load();
+    const document = await controller.createTask({
+      type: "engineering",
+      title: "格式错误不应出现",
+      question_or_goal: "创建响应缺少 TaskCard 字段。",
+      inference_budget: { mode: "normal" }
+    });
+
+    expect(document).toContain("任务创建失败。");
+    expect(document).toContain("任务创建响应格式不符合 TaskCard 契约。");
+    expect(document).not.toContain("<tr data-task-row>");
+    expect(document).not.toContain("TASK-incomplete");
+    expect(document).not.toContain("格式错误不应出现");
+  });
+});
+
+interface FakeFetchResponse {
+  status?: number;
+  body: unknown;
+}
+
+interface RecordedFetchRequest {
+  url: string;
+  method: string;
+  jsonBody?: unknown;
+}
+
+function createFakeFetch(responses: FakeFetchResponse[]) {
+  const requests: RecordedFetchRequest[] = [];
+
+  const fetchClient = async (
+    input: RequestInfo | URL,
+    init?: RequestInit
+  ): Promise<Response> => {
+    const next = responses.shift();
+    if (!next) {
+      throw new Error("No fake fetch response queued.");
+    }
+
+    const method = init?.method ?? "GET";
+    const textBody = typeof init?.body === "string" ? init.body : undefined;
+    requests.push({
+      url: String(input),
+      method,
+      jsonBody: textBody ? JSON.parse(textBody) : undefined
+    });
+
+    return new Response(JSON.stringify(next.body), {
+      status: next.status ?? 200,
+      headers: {
+        "content-type": "application/json"
+      }
+    });
+  };
+
+  return { fetchClient, requests };
+}
+
+interface DashboardScriptHarness {
+  fake: ReturnType<typeof createFakeFetch>;
+  listRegion: { innerHTML: string };
+  errorRegion: { innerHTML: string; hidden: boolean };
+  prevented: boolean;
+  resetCalled: boolean;
+  submit: () => Promise<void>;
+}
+
+function createDashboardScriptHarness(
+  formValues: Record<string, string>,
+  responses: FakeFetchResponse[]
+): DashboardScriptHarness {
+  const fake = createFakeFetch(responses);
+  const listeners = new Map<string, (event: { preventDefault: () => void }) => void | Promise<void>>();
+  const listRegion = { innerHTML: "" };
+  const errorRegion = { innerHTML: "", hidden: true };
+  let prevented = false;
+  let resetCalled = false;
+  const form = {
+    addEventListener: (
+      type: string,
+      listener: (event: { preventDefault: () => void }) => void | Promise<void>
+    ) => {
+      listeners.set(type, listener);
+    },
+    reset: () => {
+      resetCalled = true;
+    }
+  };
+  const documentLike = {
+    querySelector: (selector: string) => {
+      if (selector === "[data-create-task-form]") return form;
+      if (selector === "[data-dashboard-task-list]") return listRegion;
+      if (selector === "[data-dashboard-errors]") return errorRegion;
+      return undefined;
+    }
+  };
+  class FakeFormData {
+    get(name: string): string | null {
+      return formValues[name] ?? null;
+    }
+  }
+
+  const runScript = new Function("document", "window", "FormData", DASHBOARD_CREATE_FORM_SCRIPT);
+  runScript(documentLike, { fetch: fake.fetchClient }, FakeFormData);
+
+  return {
+    fake,
+    listRegion,
+    errorRegion,
+    get prevented() {
+      return prevented;
+    },
+    get resetCalled() {
+      return resetCalled;
+    },
+    async submit() {
+      const listener = listeners.get("submit");
+      if (!listener) {
+        throw new Error("Dashboard submit listener was not registered.");
+      }
+      await listener({
+        preventDefault: () => {
+          prevented = true;
+        }
+      });
+    }
+  };
+}
+
+function taskCardFixture(taskId: string, overrides: Partial<TaskCard> = {}): TaskCard {
+  return {
+    task_id: taskId,
+    type: "engineering",
+    status: "created",
+    title: "Dashboard 任务",
+    question_or_goal: "验证 Dashboard 页面。",
+    created_by: "pi",
+    current_owner: "coordinator",
+    reviewer: "reviewer",
+    inference_budget: { mode: "normal" },
+    linked_jobs: [],
+    linked_reports: [],
+    created_at: "2026-07-08T05:00:00.000Z",
+    updated_at: "2026-07-08T05:00:00.000Z",
+    ...overrides
+  };
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}

--- a/packages/frontend/src/pages/index.ts
+++ b/packages/frontend/src/pages/index.ts
@@ -2,4 +2,5 @@ export const FRONTEND_PAGES_NAMESPACE = "frontend/pages" as const;
 
 export type FrontendPagesNamespace = typeof FRONTEND_PAGES_NAMESPACE;
 
+export * from "./Dashboard";
 export * from "./Workbench";


### PR DESCRIPTION
Part of #11
Closes #35

## Summary
- Add a dependency-light Dashboard page under `packages/frontend/src/pages/**` with task list, create form, Chinese-first empty/error states, and `/` plus `/dashboard` route renderer.
- Add page-local task helpers for existing backend contracts: `GET /api/tasks -> { tasks }` and `POST /api/tasks -> TaskCard`, typed against shared core `TaskCard` / `CreateTaskInput`.
- Wire the visible form path with a page-local submit script: exact JSON body, `POST /api/tasks`, then server-sourced `GET /api/tasks` refresh.
- Add frontend smoke tests for exact create payload keys, visible form submit, create/refresh error separation, malformed/invalid response guards, refresh recovery, and existing Workbench compatibility.
- Add #35 OpenSpec fixture/evidence rows and `docs/review-loop-log.jsonl` accountability row while preserving the issue boundary.

## Verification
- `npx --yes bun@1.2.19 run test:frontend` (18 pass, 121 expects)
- `npx --yes bun@1.2.19 run typecheck`
- `npx --yes bun@1.2.19 run check`
- `openspec validate m1-foundation --strict --no-interactive`
- `git diff --check`
- Dashboard document smoke via `npx --yes bun@1.2.19 -e ...renderDashboardDocument...`
- `git -C zero diff --quiet && test -z "$(git ls-files workspace)"`
- `docs/review-loop-log.jsonl` JSONL parse check
- GitHub CI at final head `0e77346bf9a4e29f4cfe6fc478c079019efee092`: `docs-links`, `linux-base`, `macos-seatbelt`, `check` all pass

## Agent Review
- Fixture reviewer: requested scope narrowing to `packages/frontend/src/pages/**` and exact create-payload evidence; fixture was revised and then passed.
- Implementer subagent: implemented Dashboard page-local helpers, renderer, flow controller, and tests.
- Reviewer agents used: Chandrasekhar, Hooke, Kant.
- Reviewed head SHA: `0e77346bf9a4e29f4cfe6fc478c079019efee092`
- Verified findings addressed: native form did not submit JSON; post-create refresh failure was misclassified as create failure; visible script lacked malformed TaskCard guards; visible script accepted invalid `TaskStatus` enum values.
- Latest comprehensive cross-review: PASS at `f8c502a400191d20d26744fa8f5e5cf2dbb07a66`.
- Final review: PASS at `f8c502a400191d20d26744fa8f5e5cf2dbb07a66`; final-head alignment PASS at `0e77346bf9a4e29f4cfe6fc478c079019efee092` because the only later delta is the review-loop log row.

## Known Limits
- No Dashboard→Workbench task context navigation, no SideNav task-list wiring, no idempotency header UI, no backend static serving, no WebSocket live updates, no auth/permission UI, and no full React runtime/router setup in #35.
