### PR TITLE
feat(frontend): add task context header components (#36)

### DIFF
--- a/openspec/changes/m1-foundation/tasks.md
+++ b/openspec/changes/m1-foundation/tasks.md
@@ -252,6 +252,25 @@
       - Error tests cover list failure and create failure with Chinese-first error copy and no phantom task row.
       - `bun run test:frontend`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 - [ ] 7.3 ExperimentHeader + StatusBar 占位组件（task 上下文 props）
+  - Fixture (#36): expanded / medium
+    - Expanded trigger: shared schema/field binding. The new component props intentionally bind to shared core `TaskCard` / `TaskStatus` fields, so schema/field-name drift and downstream component import compatibility are review-relevant even though the runtime behavior is placeholder-depth.
+    - Change surface: `packages/frontend/src/components/**`, component exports, and focused frontend smoke tests.
+    - Must preserve: #34 Workbench four-panel layout contract and CSS grid, #35 Dashboard routes/list/create behavior, no backend/static-serving/API changes, no soft-monitoring data wiring, no Dashboard→Workbench task-context navigation, no `zero/` source diff, and no tracked runtime `workspace/` assets.
+    - Must add/change: `ExperimentHeader` placeholder component, `StatusBar` placeholder component, task-context props typed from shared core `TaskCard`/`TaskStatus`, and tests proving selected TaskCard id/status are rendered.
+    - Risk packs considered:
+      - Public page/component entry: selected - components become exported frontend building blocks.
+      - Schema / field names: selected - props must use shared `TaskCard`/`TaskStatus` fields and render canonical `task_id`/`status`.
+      - Legacy compatibility / examples: selected - existing Workbench and Dashboard renderer/tests are unchanged sibling consumers that must keep passing.
+      - Release / packaging / dependency compatibility: selected - no unresolved runtime/bundler dependency may break frontend package checks.
+      - Error handling / empty state: selected - placeholders must render stable Chinese-first empty copy when no task context is provided.
+      - Config, File IO/path safety, Auth/secrets, Concurrency/shared state, Resource limits/discovery, Documentation/migration, Scientific governance, Hydrology runtime, and Zero governance: not selected - no config, file IO, secret, shared mutable state, external discovery, docs migration, scientific runtime, or Zero/tool behavior changes.
+    - Evidence floor (#36):
+      - Frontend test imports `ExperimentHeader` and `StatusBar` from the intended `packages/frontend/src/components` export boundary.
+      - Frontend test renders `ExperimentHeader` with a TaskCard fixture whose `task_id` is exactly `TASK-M1-36-HEADER` and `status` is exactly `running`, then observes both exact values.
+      - Frontend test renders `StatusBar` with the same TaskCard fixture and observes exact `TASK-M1-36-HEADER` plus canonical `running`.
+      - Frontend test renders `ExperimentHeader` without task context and observes exact empty copy `未选择任务`; renders `StatusBar` without task context and observes exact empty copy `等待任务上下文`; neither output contains `undefined` or `[object Object]`.
+      - Existing Workbench and Dashboard frontend tests remain compatible, proving #34/#35 sibling surfaces did not drift.
+      - `bun run test:frontend`; `bun run typecheck`; `bun run check`; `openspec validate m1-foundation --strict --no-interactive`; `git diff --check`; `git -C zero diff --quiet`; `test -z "$(git ls-files workspace)"`.
 
 ## 8. GLM provider（glm-provider）
 

--- a/packages/frontend/src/components/ExperimentHeader.ts
+++ b/packages/frontend/src/components/ExperimentHeader.ts
@@ -1,0 +1,31 @@
+import type { TaskCard, TaskStatus } from "@shud-harness/core";
+import { escapeHtml } from "./rendering";
+
+export type ExperimentHeaderTaskContext = Pick<TaskCard, "task_id"> & {
+  status: TaskStatus;
+};
+
+export interface ExperimentHeaderProps {
+  task?: ExperimentHeaderTaskContext;
+}
+
+export function ExperimentHeader(props: ExperimentHeaderProps = {}): string {
+  if (!props.task) {
+    return [
+      '<header class="experiment-header" data-experiment-header>',
+      '<p class="experiment-header__empty">未选择任务</p>',
+      "</header>"
+    ].join("");
+  }
+
+  const taskId = escapeHtml(props.task.task_id);
+  const status = escapeHtml(props.task.status);
+
+  return [
+    '<header class="experiment-header" data-experiment-header>',
+    '<span class="experiment-header__eyebrow">TaskCard</span>',
+    `<h2 class="experiment-header__task-id">${taskId}</h2>`,
+    `<p class="experiment-header__status"><span>status</span><strong>${status}</strong></p>`,
+    "</header>"
+  ].join("");
+}

--- a/packages/frontend/src/components/StatusBar.ts
+++ b/packages/frontend/src/components/StatusBar.ts
@@ -1,0 +1,27 @@
+import type { TaskCard, TaskStatus } from "@shud-harness/core";
+import { escapeHtml } from "./rendering";
+
+export type StatusBarTaskContext = Pick<TaskCard, "task_id"> & {
+  status: TaskStatus;
+};
+
+export interface StatusBarProps {
+  task?: StatusBarTaskContext;
+}
+
+export function StatusBar(props: StatusBarProps = {}): string {
+  if (!props.task) {
+    return [
+      '<footer class="status-bar" data-status-bar>',
+      '<span class="status-bar__empty">等待任务上下文</span>',
+      "</footer>"
+    ].join("");
+  }
+
+  return [
+    '<footer class="status-bar" data-status-bar>',
+    `<span class="status-bar__task-id">${escapeHtml(props.task.task_id)}</span>`,
+    `<span class="status-bar__status">${escapeHtml(props.task.status)}</span>`,
+    "</footer>"
+  ].join("");
+}

--- a/packages/frontend/src/components/index.ts
+++ b/packages/frontend/src/components/index.ts
@@ -3,7 +3,9 @@ export const FRONTEND_COMPONENTS_NAMESPACE = "frontend/components" as const;
 export type FrontendComponentsNamespace = typeof FRONTEND_COMPONENTS_NAMESPACE;
 
 export * from "./AgentActivityFeed";
+export * from "./ExperimentHeader";
 export * from "./ExperimentPanel";
 export * from "./ResultsPanel";
 export * from "./SideNav";
+export * from "./StatusBar";
 export * from "./rendering";

--- a/packages/frontend/src/components/task-context-components.test.ts
+++ b/packages/frontend/src/components/task-context-components.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import type { TaskCard } from "@shud-harness/core";
+import { ExperimentHeader, StatusBar } from "./index";
+
+describe("ExperimentHeader and StatusBar placeholders", () => {
+  test("render selected TaskCard id and status from shared task context", () => {
+    const task = taskCardFixture();
+
+    const header = ExperimentHeader({ task });
+    const statusBar = StatusBar({ task });
+
+    expect(header).toContain('<h2 class="experiment-header__task-id">TASK-M1-36-HEADER</h2>');
+    expect(header).toContain("<strong>running</strong>");
+    expect(statusBar).toContain('<span class="status-bar__task-id">TASK-M1-36-HEADER</span>');
+    expect(statusBar).toContain('<span class="status-bar__status">running</span>');
+  });
+
+  test("render stable empty task-context states", () => {
+    const header = ExperimentHeader();
+    const statusBar = StatusBar();
+    const combined = `${header}${statusBar}`;
+
+    expect(header).toContain('<p class="experiment-header__empty">未选择任务</p>');
+    expect(statusBar).toContain('<span class="status-bar__empty">等待任务上下文</span>');
+
+    for (const output of [header, statusBar, combined]) {
+      expect(output).not.toContain("undefined");
+      expect(output).not.toContain("[object Object]");
+    }
+  });
+});
+
+function taskCardFixture(): TaskCard {
+  return {
+    task_id: "TASK-M1-36-HEADER",
+    type: "engineering",
+    status: "running",
+    title: "Header and status bar fixture",
+    question_or_goal: "验证 ExperimentHeader 和 StatusBar 的任务上下文字段绑定。",
+    created_by: "pi",
+    current_owner: "coordinator",
+    reviewer: "reviewer",
+    inference_budget: { mode: "normal" },
+    linked_jobs: [],
+    linked_reports: [],
+    created_at: "2026-07-08T05:00:00.000Z",
+    updated_at: "2026-07-08T05:00:00.000Z"
+  };
+}


### PR DESCRIPTION
Part of #11
Closes #36

## Summary
- Add dependency-light `ExperimentHeader` and `StatusBar` placeholder renderers under `packages/frontend/src/components/**`.
- Type task-context props against shared core `TaskCard` / `TaskStatus` fields and render canonical `task_id` plus `status`.
- Export both components from the frontend component boundary.
- Add frontend smoke tests for selected TaskCard rendering, exact empty-state copy, and existing Workbench/Dashboard compatibility.
- Expand the #36 OpenSpec fixture to cover shared field binding, component export evidence, and sibling compatibility.

## Verification
- `npx --yes bun@1.2.19 run test:frontend` (20 pass, 133 expects)
- `npx --yes bun@1.2.19 run typecheck`
- `npx --yes bun@1.2.19 run check`
- `openspec validate m1-foundation --strict --no-interactive`
- `git diff --check`
- `git -C zero diff --quiet && test -z "$(git ls-files workspace)"`

## Agent Review
- Fixture reviewer: first pass requested expanded fixture classification and exact evidence; second pass returned PASS.
- Reviewer agents used: Sagan (correctness), Bacon (integration), Bernoulli (security/perf), Helmholtz (test/evidence), Noether (final).
- Reviewed head SHA: `81cb0bfb7ad36361f20a41b17e6f6dbd5e65a806`
- OpenSpec change: `m1-foundation`; fixture level: expanded; selected risk packs: public component entry, schema/field names, legacy compatibility/examples, release/packaging compatibility, empty-state handling.
- Round 1 comprehensive cross-review: PASS, no actionable findings.
- Phase 4.5 verifier verdict table: no candidates; confirmed=0, plausible=0, refuted=0.
- Final review: PASS at `81cb0bfb7ad36361f20a41b17e6f6dbd5e65a806`.

## Known Limits
- No soft-monitoring metrics wiring, no Dashboard-to-Workbench task-context navigation, no backend/static serving changes, and no runtime React router setup in #36.
