### PR TITLE
fix(core): pin temporary cleanup identity

### DIFF
--- a/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
+++ b/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
@@ -2298,6 +2298,7 @@ describe("idempotency, lock, and artifact services", () => {
       permit: WorkspaceRecordCleanupPermit;
     }> = [];
     let pinnedHandleClosures = 0;
+    const allPinnedHandlesClosed = createSignal();
 
     try {
       for (let index = 0; index < 1024; index += 1) {
@@ -2308,6 +2309,7 @@ describe("idempotency, lock, and artifact services", () => {
           {
             afterCleanupPermitPinnedHandleClosed: () => {
               pinnedHandleClosures += 1;
+              if (pinnedHandleClosures === 1024) allPinnedHandlesClosed.resolve();
             }
           },
           () =>
@@ -2361,7 +2363,10 @@ describe("idempotency, lock, and artifact services", () => {
           )
         )
       );
-      await delay(0);
+      await Promise.race([
+        allPinnedHandlesClosed.promise,
+        timeoutAfter(5_000, "cleanup permit pinned handles did not all close")
+      ]);
       expect(pinnedHandleClosures).toBe(created.length);
     }
   }, 20_000);
@@ -3502,6 +3507,7 @@ describe("idempotency, lock, and artifact services", () => {
       let expectedIdentity: { dev: bigint; ino: bigint } | undefined;
       let isolatedPath: string | undefined;
       let replacementIdentity: { dev: bigint; ino: bigint } | undefined;
+      let pinnedDescriptor: number | undefined;
 
       const failure = await captureTaskServiceError(() =>
         runWithWorkspaceRecordCompensationTestHooks(
@@ -3509,6 +3515,7 @@ describe("idempotency, lock, and artifact services", () => {
             beforeOwnedTemporaryRecordWrite: async (input) => {
               temporaryPath = input.path;
               expectedIdentity = input.identity;
+              pinnedDescriptor = input.fd;
               await writeFile(input.path, partialBytes);
               throw primaryError;
             },
@@ -3520,6 +3527,10 @@ describe("idempotency, lock, and artifact services", () => {
                 await writeFile(input.isolatedPath, replacementBytes, { flag: "wx" });
                 replacementIdentity = await stat(input.isolatedPath, { bigint: true });
               }
+              const pinnedIdentity = await readFileDescriptorIdentity(pinnedDescriptor!);
+              expect(workspaceRecordPhysicalIdentityMatches(pinnedIdentity, expectedIdentity!)).toBe(
+                true
+              );
               throw isolationError;
             },
             beforeOwnedPathCompensationStateInspection: ({ site }) => {
@@ -3548,6 +3559,8 @@ describe("idempotency, lock, and artifact services", () => {
       expect(temporaryPath).toBeDefined();
       expect(expectedIdentity).toBeDefined();
       expect(isolatedPath).toBeDefined();
+      expect(pinnedDescriptor).toBeDefined();
+      await expectFileDescriptorClosed(pinnedDescriptor!);
 
       if (outcome === "restore_exact") {
         await expectPrivateAuthorityDirectory(dirname(temporaryPath!));
@@ -8116,6 +8129,20 @@ async function expectFileDescriptorClosed(fd: number): Promise<void> {
       })
   );
   expect(error).toMatchObject({ code: "EBADF" });
+}
+
+async function readFileDescriptorIdentity(
+  fd: number
+): Promise<{ dev: bigint; ino: bigint }> {
+  const entry = await new Promise<Awaited<ReturnType<typeof stat>>>(
+    (resolvePromise, rejectPromise) => {
+      fstat(fd, (statError, descriptorStat) => {
+        if (statError) rejectPromise(statError);
+        else resolvePromise(descriptorStat);
+      });
+    }
+  );
+  return { dev: BigInt(entry.dev), ino: BigInt(entry.ino) };
 }
 
 function aggregateErrorMessages(value: unknown, ancestors = new Set<unknown>()): string[] {

--- a/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
+++ b/packages/core/src/domain/services/idempotency-lock-artifact-services.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { fstat } from "node:fs";
+import { fstat, fstatSync, type BigIntStats } from "node:fs";
 import {
   access,
   chmod,
@@ -2297,8 +2297,9 @@ describe("idempotency, lock, and artifact services", () => {
       record: { id: string };
       permit: WorkspaceRecordCleanupPermit;
     }> = [];
+    const closedPinnedFileDescriptors = new Set<number>();
+    const pinnedHandleClosedByPath = new Map<string, ReturnType<typeof createSignal>>();
     let pinnedHandleClosures = 0;
-    const allPinnedHandlesClosed = createSignal();
 
     try {
       for (let index = 0; index < 1024; index += 1) {
@@ -2307,9 +2308,22 @@ describe("idempotency, lock, and artifact services", () => {
         const evidenceRef = `permit.capacity.${index}`;
         const result = await runWithWorkspaceRecordPublicationHooks(
           {
-            afterCleanupPermitPinnedHandleClosed: () => {
+            afterCleanupPermitPinnedHandleClosed: (input) => {
+              let descriptorError: unknown;
+              try {
+                fstatSync(input.fd);
+              } catch (error) {
+                descriptorError = error;
+              }
+              expect(descriptorError).toMatchObject({ code: "EBADF" });
+              expect(closedPinnedFileDescriptors.has(input.fd)).toBe(false);
+              const pinnedHandleClosed = pinnedHandleClosedByPath.get(input.path);
+              if (!pinnedHandleClosed) {
+                throw new Error(`Unexpected cleanup permit pinned handle path: ${input.path}`);
+              }
+              closedPinnedFileDescriptors.add(input.fd);
               pinnedHandleClosures += 1;
-              if (pinnedHandleClosures === 1024) allPinnedHandlesClosed.resolve();
+              pinnedHandleClosed.resolve();
             }
           },
           () =>
@@ -2323,8 +2337,14 @@ describe("idempotency, lock, and artifact services", () => {
             )
         );
         if (result.status !== "created") throw new Error("Expected cleanup permit capacity fixture.");
+        const path = workspaceRecordPath(
+          workspaceRoot,
+          ["permit-capacity", fileName],
+          evidenceRef
+        );
+        pinnedHandleClosedByPath.set(path, createSignal());
         created.push({
-          path: workspaceRecordPath(workspaceRoot, ["permit-capacity", fileName], evidenceRef),
+          path,
           evidenceRef,
           record,
           permit: result.cleanupPermit
@@ -2348,26 +2368,62 @@ describe("idempotency, lock, and artifact services", () => {
       expect(overflow.evidenceRefs).toEqual([overflowEvidenceRef]);
       expect(overflow.message).toBe("Workspace record authority coordination is at capacity.");
     } finally {
-      await Promise.all(
-        created.map(({ path, evidenceRef, record, permit }) =>
-          conditionalDeleteJsonRecordWithCleanupPermit(
-            permit,
-            path,
-            evidenceRef,
+      await Promise.race([
+        (async () => {
+          for (const { path, evidenceRef, record, permit } of created) {
+            await conditionalDeleteJsonRecordWithCleanupPermit(
+              permit,
+              path,
+              evidenceRef,
+              schema,
+              {
+                kind: "record",
+                expected: record,
+                matches: (current, expected) => current.id === expected.id
+              }
+            );
+            const pinnedHandleClosed = pinnedHandleClosedByPath.get(path);
+            if (!pinnedHandleClosed) throw new Error(`Missing pinned handle signal: ${path}`);
+            await pinnedHandleClosed.promise;
+          }
+        })(),
+        timeoutAfter(10_000, "cleanup permit pinned handles did not all close")
+      ]);
+      expect(pinnedHandleClosures).toBe(1024);
+      expect(closedPinnedFileDescriptors.size).toBe(1024);
+      expect(closedPinnedFileDescriptors.size).toBe(created.length);
+
+      const recoveryEvidenceRef = "permit.capacity.recovered";
+      const recoveryPath = workspaceRecordPath(
+        workspaceRoot,
+        ["permit-capacity", "permit-capacity-recovered.json"],
+        recoveryEvidenceRef
+      );
+      const recoveryRecord = { id: "permit-capacity-recovered" };
+      const recovery = await createJsonRecordIfAbsentWithCleanupPermit(
+        workspaceRoot,
+        ["permit-capacity"],
+        "permit-capacity-recovered.json",
+        recoveryRecord,
+        recoveryEvidenceRef,
+        schema
+      );
+      expect(recovery.status).toBe("created");
+      if (recovery.status === "created") {
+        expect(
+          await conditionalDeleteJsonRecordWithCleanupPermit(
+            recovery.cleanupPermit,
+            recoveryPath,
+            recoveryEvidenceRef,
             schema,
             {
               kind: "record",
-              expected: record,
+              expected: recoveryRecord,
               matches: (current, expected) => current.id === expected.id
             }
           )
-        )
-      );
-      await Promise.race([
-        allPinnedHandlesClosed.promise,
-        timeoutAfter(5_000, "cleanup permit pinned handles did not all close")
-      ]);
-      expect(pinnedHandleClosures).toBe(created.length);
+        ).toEqual({ status: "deleted" });
+      }
     }
   }, 20_000);
 
@@ -8134,15 +8190,15 @@ async function expectFileDescriptorClosed(fd: number): Promise<void> {
 async function readFileDescriptorIdentity(
   fd: number
 ): Promise<{ dev: bigint; ino: bigint }> {
-  const entry = await new Promise<Awaited<ReturnType<typeof stat>>>(
+  const entry = await new Promise<BigIntStats>(
     (resolvePromise, rejectPromise) => {
-      fstat(fd, (statError, descriptorStat) => {
+      fstat(fd, { bigint: true }, (statError, descriptorStat) => {
         if (statError) rejectPromise(statError);
         else resolvePromise(descriptorStat);
       });
     }
   );
-  return { dev: BigInt(entry.dev), ino: BigInt(entry.ino) };
+  return { dev: entry.dev, ino: entry.ino };
 }
 
 function aggregateErrorMessages(value: unknown, ancestors = new Set<unknown>()): string[] {

--- a/packages/core/src/domain/services/workspace-record-store.ts
+++ b/packages/core/src/domain/services/workspace-record-store.ts
@@ -229,6 +229,7 @@ export interface WorkspaceRecordCompensationTestHooks {
     input: Readonly<{
       path: string;
       identity: WorkspaceRecordPhysicalIdentity;
+      fd: number;
     }>
   ) => Promise<void> | void;
   beforeOwnedPathIsolation?: (
@@ -1310,7 +1311,7 @@ async function writeOwnedTemporaryRecordFile(
     }
     temporaryIdentity = { dev: entry.dev, ino: entry.ino };
     await compensationTestHookStorage.getStore()?.beforeOwnedTemporaryRecordWrite?.(
-      Object.freeze({ path: temporaryPath, identity: temporaryIdentity })
+      Object.freeze({ path: temporaryPath, identity: temporaryIdentity, fd: temporaryFile.fd })
     );
     await temporaryFile.writeFile(recordText, "utf8");
     return { identity: temporaryIdentity, file: temporaryFile, handleClosed: false };
@@ -1333,11 +1334,6 @@ async function writeOwnedTemporaryRecordFile(
       } catch (error) {
         cleanupErrors.push(error);
       }
-      try {
-        await temporaryFile.close();
-      } catch (error) {
-        cleanupErrors.push(error);
-      }
     }
     if (temporaryIdentity && observedBytes) {
       try {
@@ -1347,6 +1343,13 @@ async function writeOwnedTemporaryRecordFile(
           observedBytes,
           evidenceRef
         );
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+    }
+    if (temporaryFile) {
+      try {
+        await temporaryFile.close();
       } catch (error) {
         cleanupErrors.push(error);
       }


### PR DESCRIPTION
## 关联

Part of #74
CI repair stacked on #75

## 改动

- partial temporary write 的 ownership-sensitive cleanup 在隔离与补偿终态前持续持有原 generation fd，阻止 Linux unlink/recreate 复用同一 inode 后被误判为自有代。
- cleanup 终态后精确关闭 fd；关闭失败继续作为 compensation 聚合，不覆盖原始写入错误。
- 1024 cleanup permits 全部终态后，逐 fd 以 OS `fstat` 证明 `EBADF`，验证 1024 个 fd 全部不同、1025th 结构化拒绝，并实际证明容量恢复。
- descriptor identity 使用原生 bigint `fstat`，不再经过可能丢精度的 JavaScript `number`。

## 验证

- focused tests 连续两次：每次 3 pass / 0 fail
- `npx --yes bun@1.2.19 run test:core-services`：124 pass / 5 platform skip / 0 fail
- `npx --yes bun@1.2.19 run typecheck`：通过
- `git diff --check`、Zero diff、tracked workspace 检查：通过
- [SHA-matched CI run 29167258621](https://github.com/DankerMu/SHUD-Harness/actions/runs/29167258621)：Linux、macOS、docs-links、聚合 check 全绿

## 边界

- 仅修复 #76 合入后暴露的 Linux authority/timing 缺口；不含 mutable publication、idempotency caller、backend、OpenSpec、文档或 Zero 改动。
- 既有 M1 单进程、协作式 workspace 非目标不变。

## 计划偏离

- 无偏离。

## Agent Review

- Reviewer agents used: correctness, integration, security/performance, test evidence, spec compliance, invariant/state; independent Phase 7 reviewer
- Reviewed head SHA: `d725749650562b53c34f5cea6145660d8374a4e0`
- Review evidence: [cross-review + verifier bundle](https://github.com/DankerMu/SHUD-Harness/pull/78#issuecomment-4948698005) | [Phase 7 Gap Sweep](https://github.com/DankerMu/SHUD-Harness/pull/78#issuecomment-4948698016) | [中文工作说明](https://github.com/DankerMu/SHUD-Harness/pull/78#issuecomment-4948698017)
- OpenSpec change: `m1-foundation`; fixture level: high; selected risk packs: workspace/path safety, rollback/partial outputs, resource lifecycle, oracle integrity
- Key findings addressed: per-fd closure proof replacing callback-count proxy; exact bigint descriptor identity; SHA-matched Linux execution
- Latest comprehensive round: six reviewers clean; Phase 7 clean
